### PR TITLE
Check ListOfType results is an instance of ArrayAccess instead of ArrayObject

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -285,7 +285,7 @@ class Executor
     }
 
     /**
-     * Implements the logic to compute the key of a given field�s entry
+     * Implements the logic to compute the key of a given fields entry
      */
     private static function getFieldEntryKey(Field $node)
     {

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -285,7 +285,7 @@ class Executor
     }
 
     /**
-     * Implements the logic to compute the key of a given field’s entry
+     * Implements the logic to compute the key of a given fieldï¿½s entry
      */
     private static function getFieldEntryKey(Field $node)
     {
@@ -430,7 +430,7 @@ class Executor
         if ($fieldType instanceof ListOfType) {
             $itemType = $fieldType->getWrappedType();
             Utils::invariant(
-                is_array($result) || $result instanceof \ArrayObject,
+                is_array($result) || $result instanceof \ArrayAccess,
                 'User Error: expected iterable, but did not find one.'
             );
 

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -430,7 +430,7 @@ class Executor
         if ($fieldType instanceof ListOfType) {
             $itemType = $fieldType->getWrappedType();
             Utils::invariant(
-                is_array($result) || $result instanceof \ArrayAccess,
+                is_array($result) || $result instanceof \Traversable,
                 'User Error: expected iterable, but did not find one.'
             );
 


### PR DESCRIPTION
To allow the use of a class implementing the ArrayAccess interface.