### PR TITLE
Added possibility to throw a custom error from the resolver

### DIFF
--- a/src/Error.php
+++ b/src/Error.php
@@ -51,7 +51,7 @@ class Error extends \Exception
             $previous = null;
         }
         
-        $errorClass = $error instanceof Error ? get_class($error):'Error';
+        $errorClass = $error instanceof Error ? get_class($error):'\GraphQL\Error';
 
         return new $errorClass($message, $nodes, $previous);
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -50,8 +50,10 @@ class Error extends \Exception
             $message = (string) $error;
             $previous = null;
         }
+        
+        $errorClass = $error instanceof Error ? get_class($error):'Error';
 
-        return new Error($message, $nodes, $previous);
+        return new $errorClass($message, $nodes, $previous);
     }
 
     /**

--- a/src/Executor/ExecutionResult.php
+++ b/src/Executor/ExecutionResult.php
@@ -30,7 +30,11 @@ class ExecutionResult
         $result = ['data' => $this->data];
 
         if (!empty($this->errors)) {
-            $result['errors'] = array_map(['GraphQL\Error', 'formatError'], $this->errors);
+            $result['errors'] = array_map(function($e)
+            {
+                $errorClass = $e instanceof Error ? get_class($e):'\GraphQL\Error';
+                return $errorClass::formatError($e);
+            }, $this->errors);
         }
 
         return $result;

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -24,12 +24,17 @@ class GraphQL
             $validationErrors = DocumentValidator::validate($schema, $documentAST);
 
             if (!empty($validationErrors)) {
-                return ['errors' => array_map(['GraphQL\Error', 'formatError'], $validationErrors)];
+                return ['errors' => array_map(function($e)
+                {
+                    $errorClass = $e instanceof Error ? get_class($e):'\GraphQL\Error';
+                    return $errorClass::formatError($e);
+                }, $validationErrors)];
             } else {
                 return Executor::execute($schema, $documentAST, $rootValue, $variableValues, $operationName)->toArray();
             }
         } catch (Error $e) {
-            return ['errors' => [Error::formatError($e)]];
+            $errorClass = get_class($e);
+            return ['errors' => [$errorClass::formatError($e)]];
         }
     }
 }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -24,17 +24,12 @@ class GraphQL
             $validationErrors = DocumentValidator::validate($schema, $documentAST);
 
             if (!empty($validationErrors)) {
-                return ['errors' => array_map(function($e)
-                {
-                    $errorClass = $e instanceof Error ? get_class($e):'\GraphQL\Error';
-                    return $errorClass::formatError($e);
-                }, $validationErrors)];
+                return ['errors' => array_map(['GraphQL\Error', 'formatError'], $validationErrors)];
             } else {
                 return Executor::execute($schema, $documentAST, $rootValue, $variableValues, $operationName)->toArray();
             }
         } catch (Error $e) {
-            $errorClass = get_class($e);
-            return ['errors' => [$errorClass::formatError($e)]];
+            return ['errors' => [Error::formatError($e)]];
         }
     }
 }


### PR DESCRIPTION
Currently it is not possible to use custom error class that extends `GraphQL\Error` to control the format of errors. The GraphQL specifications allow errors to have extra fields has stated here https://facebook.github.io/graphql/#sec-Errors

> GraphQL servers may provide additional entries to error as they choose to produce more helpful or machine‐readable errors, however future versions of the spec may describe additional entries to errors.

This pull request is a proposition that allow custom error to be thrown from the resolve method and use custom format. By this, I mean throwing a class that extends `GraphQL\Error` and modify the `formatError` method so it returns extra fields.

There is 2 modifications to allow this.

If you throw a custom error from the resolve method, it will go through the `Error::createLocatedError` method and it will be converted to a `GraphQL\Error`. The first modification is to reuse the same error class as the original (instead of using only `GraphQL\Error`) when creating the located error.

The second modification is to allow ExecutionResult to use the `formatError` method of the current `$error` class instead of always using `GraphQL\Error::formatError`

This feature would be really helpful to implements custom validation and error reporting.