### PR TITLE
Fix `ResolveInfo::getFieldSelection()` when using multiple fragments

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -95,9 +95,14 @@ class ResolveInfo
      */
     public function getFieldSelection($depth = 0)
     {
+        $fields = [];
+
         /** @var Field $fieldAST */
-        $fieldAST = $this->fieldASTs[0];
-        return $this->foldSelectionSet($fieldAST->selectionSet, $depth);
+        foreach ($this->fieldASTs as $fieldAST) {
+            $fields = array_merge_recursive($fields, $this->foldSelectionSet($fieldAST->selectionSet, $depth));
+        }
+
+        return $fields;
     }
 
     private function foldSelectionSet(SelectionSet $selectionSet, $descend)

--- a/tests/StarWarsQueryTest.php
+++ b/tests/StarWarsQueryTest.php
@@ -302,6 +302,57 @@ class StarWarsQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertValidQuery($query, $expected);
     }
 
+    function testFragmentWithProjection()
+    {
+        $query = '
+        query UseFragment {
+          human(id: "1003") {
+            name
+            ...fa
+            ...fb
+          }
+        }
+
+        fragment fa on Character {
+          friends {
+            id
+          }
+        }
+        fragment fb on Character {
+          friends {
+            name
+          }
+        }
+        ';
+
+        $expected = [
+            'human' => [
+                'name' => 'Leia Organa',
+                'friends' => [
+                    [
+                        'name' => 'Luke Skywalker',
+                        'id' => '1000'
+
+                    ],
+                    [
+                        'name' => 'Han Solo',
+                        'id' => '1002'
+                    ],
+                    [
+                        'name' => 'C-3PO',
+                        'id' => '2000'
+                    ],
+                    [
+                        'name' => 'R2-D2',
+                        'id' => '2001'
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertValidQuery($query, $expected);
+    }
+
     // Using __typename to find the type of an object
     public function testVerifyThatR2D2IsADroid()
     {

--- a/tests/StarWarsSchema.php
+++ b/tests/StarWarsSchema.php
@@ -16,6 +16,7 @@ use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 
 /**
@@ -161,8 +162,18 @@ class StarWarsSchema
                 'friends' => [
                     'type' => Type::listOf($characterInterface),
                     'description' => 'The friends of the human, or an empty list if they have none.',
-                    'resolve' => function ($human) {
-                        return StarWarsData::getFriends($human);
+                    'resolve' => function ($human, $args, ResolveInfo $info) {
+                        $fieldSelection = $info->getFieldSelection();
+                        $fieldSelection['id'] = true;
+
+                        $friends = array_map(
+                            function($friend) use ($fieldSelection) {
+                                return array_intersect_key($friend, $fieldSelection);
+                            },
+                            StarWarsData::getFriends($human)
+                        );
+
+                        return $friends;
                     },
                 ],
                 'appearsIn' => [


### PR DESCRIPTION
When using multiple fragments on the same field, `ResolveInfo::getFieldSelection()` was taking account only of the selection on the first fragment. Here is an example:

```graphql
query UseFragment {
  human(id: "1003") {
    name
    ...fa
    ...fb
  }
}

fragment fa on Character {
  friends {
    id
  }
}
fragment fb on Character {
  friends {
    name
  }
}
```

results with after applying select fields projection:

```json
{
    "data": {
        "human": {
            "name": "Leia Organa",
            "friends": [
                {
                    "id": "1000",
                    "name": null
                },
                {
                    "id": "1002",
                    "name": null
                },
                {
                    "id": "2000",
                    "name": null
                },
                {
                    "id": "2001",
                    "name": null
                }
            ]
        }
    }
}
```

While waiting for:

```json
{
    "data": {
        "human": {
            "name": "Leia Organa",
            "friends": [
                {
                    "id": "1000",
                    "name": "Luke Skywalker"
                },
                {
                    "id": "1002",
                    "name": "Han Solo"
                },
                {
                    "id": "2000",
                    "name": "C-3PO"
                },
                {
                    "id": "2001",
                    "name": "R2-D2"
                }
            ]
        }
    }
}
```