### PR TITLE
Change Lexer::readString to decode escaped characters to their litera…

### DIFF
--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -229,13 +229,13 @@ class Lexer
                 $code = Utils::charCodeAt($body, $position);
                 switch ($code) {
                     case 34: $value .= '"'; break;
-                    case 47: $value .= '\/'; break;
+                    case 47: $value .= '/'; break;
                     case 92: $value .= '\\'; break;
-                    case 98: $value .= '\b'; break;
-                    case 102: $value .= '\f'; break;
-                    case 110: $value .= '\n'; break;
-                    case 114: $value .= '\r'; break;
-                    case 116: $value .= '\t'; break;
+                    case 98: $value .= chr(8); break; // \b (backspace)
+                    case 102: $value .= "\f"; break;
+                    case 110: $value .= "\n"; break;
+                    case 114: $value .= "\r"; break;
+                    case 116: $value .= "\t"; break;
                     case 117:
                         $hex = mb_substr($body, $position + 1, 4);
                         if (!preg_match('/[0-9a-fA-F]{4}/', $hex)) {

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -58,8 +58,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Token(Token::STRING, 0, 8, 'simple'), $this->lexOne('"simple"'));
         $this->assertEquals(new Token(Token::STRING, 0, 15, ' white space '), $this->lexOne('" white space "'));
         $this->assertEquals(new Token(Token::STRING, 0, 10, 'quote "'), $this->lexOne('"quote \\""'));
-        $this->assertEquals(new Token(Token::STRING, 0, 20, 'escaped \n\r\b\t\f'), $this->lexOne('"escaped \\n\\r\\b\\t\\f"'));
-        $this->assertEquals(new Token(Token::STRING, 0, 15, 'slashes \\ \/'), $this->lexOne('"slashes \\\\ \\/"'));
+        $this->assertEquals(new Token(Token::STRING, 0, 25, 'escaped \n\r\b\t\f'), $this->lexOne('"escaped \\\\n\\\\r\\\\b\\\\t\\\\f"'));
+        $this->assertEquals(new Token(Token::STRING, 0, 16, 'slashes \\ \/'), $this->lexOne('"slashes \\\\ \\\\/"'));
 
         $this->assertEquals(new Token(Token::STRING, 0, 13, 'unicode яуц'), $this->lexOne('"unicode яуц"'));
 


### PR DESCRIPTION
Given the partial query `foo(message: "new\nline")`, I would expect the following literal if I were to print `$args['message']`:

> new
> line

Instead, I get:

> new\nline

because the Lexer fails to decode the literal, and instead repeats it as-is.

Furthermore, the partial query `foo(message: "new\\nline")`, also results in `new\nline` creating an ambiguous situation where it's impossible to know what the source argument was.

However, `\"` and `\\` do correctly get transformed into `"` and `\` respectively.

This pull request corrects that behavior for `\/ \b \f \n \r \t` to make it work as `\"` and `\\` already are working. (PHP does not support `"\b"`, hence the `chr(8)`.) Related tests are updated.