### PR TITLE
Fix fatal error when GraphiQL tries to run introspection query

### DIFF
--- a/src/Type/Introspection.php
+++ b/src/Type/Introspection.php
@@ -282,25 +282,25 @@ EOD;
                         'deprecationReason' => 'Use `locations`.',
                         'type' => Type::nonNull(Type::boolean()),
                         'resolve' => function($d) {
-                            return in_array(Directive::$directiveLocations['QUERY'], $d['locations']) ||
-                                in_array(Directive::$directiveLocations['MUTATION'], $d['locations']) ||
-                                in_array(Directive::$directiveLocations['SUBSCRIPTION'], $d['locations']);
+                            return in_array(Directive::$directiveLocations['QUERY'], $d->locations) ||
+                                in_array(Directive::$directiveLocations['MUTATION'], $d->locations) ||
+                                in_array(Directive::$directiveLocations['SUBSCRIPTION'], $d->locations);
                         }
                     ],
                     'onFragment' => [
                         'deprecationReason' => 'Use `locations`.',
                         'type' => Type::nonNull(Type::boolean()),
                         'resolve' => function($d) {
-                            return in_array(Directive::$directiveLocations['FRAGMENT_SPREAD'], $d['locations']) ||
-                            in_array(Directive::$directiveLocations['INLINE_FRAGMENT'], $d['locations']) ||
-                            in_array(Directive::$directiveLocations['FRAGMENT_DEFINITION'], $d['locations']);
+                            return in_array(Directive::$directiveLocations['FRAGMENT_SPREAD'], $d->locations) ||
+                            in_array(Directive::$directiveLocations['INLINE_FRAGMENT'], $d->locations) ||
+                            in_array(Directive::$directiveLocations['FRAGMENT_DEFINITION'], $d->locations);
                         }
                     ],
                     'onField' => [
                         'deprecationReason' => 'Use `locations`.',
                         'type' => Type::nonNull(Type::boolean()),
                         'resolve' => function($d) {
-                            return in_array(Directive::$directiveLocations['FIELD'], $d['locations']);
+                            return in_array(Directive::$directiveLocations['FIELD'], $d->locations);
                         }
                     ]
                 ]


### PR DESCRIPTION
Solves fatal error:

PHP Fatal error:  Cannot use object of type GraphQL\\Type\\Definition\\Directive as array in /var/www/html/sites/all/modules/med_stdlib/lib/vendor/webonyx/graphql-php/src/Type/Introspection.php on line 295