### PR TITLE
Add ext-mbstring missing requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "API"
   ],
   "require": {
-    "php": ">=5.4,<8.0-DEV"
+    "php": ">=5.4,<8.0-DEV",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
This fix "PHP Fatal error:  Uncaught Error: Call to undefined function GraphQL\Language\mb_strlen()"