### PR TITLE
Optimized travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,23 @@ php:
     - 7.0
     - 7.1
     - hhvm
+    - nightly
+
+allow_failures:
+    - php: nightly
+
+cache:
+    directories:
+        - $HOME/.composer/cache
+
+before_install:
+    - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
+    - composer selfupdate
 
 install:
     - composer install --dev --prefer-dist
 
-script:
-    - mkdir -p build/logs
-    - bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+script: if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then phpunit --coverage-clover build/logs/clover.xml; else phpunit; fi
 
 after_success:
-    - composer require "satooshi/php-coveralls:^1.0"
-    - travis_retry php bin/coveralls -v
+    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then composer require "satooshi/php-coveralls:^1.0" && travis_retry php bin/coveralls -v; fi


### PR DESCRIPTION
* Speed up tests by testing coverage only on php 5.6
* Add php nightly because composer accept it
* Add composer cache dir to travis cache