### PR TITLE
Added compatibility with php7 error handling

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -89,6 +89,9 @@ class Error extends \Exception implements \JsonSerializable
         } else if ($error instanceof \Exception) {
             $message = $error->getMessage();
             $originalError = $error;
+        } else if ($error instanceof \Error) {
+            $message = $error->getMessage();
+            $originalError = $error;
         } else {
             $message = (string) $error;
         }
@@ -119,9 +122,9 @@ class Error extends \Exception implements \JsonSerializable
      * @param Source $source
      * @param array|null $positions
      * @param array|null $path
-     * @param \Exception $previous
+     * @param \Exception|\Error $previous
      */
-    public function __construct($message, $nodes = null, Source $source = null, $positions = null, $path = null, \Exception $previous = null)
+    public function __construct($message, $nodes = null, Source $source = null, $positions = null, $path = null, $previous = null)
     {
         parent::__construct($message, 0, $previous);
 

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -680,6 +680,8 @@ class Executor
             return $resolveFn($source, $args, $context, $info);
         } catch (\Exception $error) {
             return $error;
+        } catch (\Error $error) {
+            return $error;
         }
     }
 
@@ -778,6 +780,8 @@ class Executor
             return $completed;
         } catch (\Exception $error) {
             throw Error::createLocatedError($error, $fieldNodes, $path);
+        } catch (\Error $error) {
+            throw Error::createLocatedError($error, $fieldNodes, $path);
         }
     }
 
@@ -810,6 +814,7 @@ class Executor
      * @return array|null|Promise
      * @throws Error
      * @throws \Exception
+     * @throws \Error
      */
     private function completeValue(
         Type $returnType,
@@ -832,6 +837,10 @@ class Executor
         }
 
         if ($result instanceof \Exception) {
+            throw $result;
+        }
+
+        if ($result instanceof \Error) {
             throw $result;
         }
 


### PR DESCRIPTION
Hello !

I recently stumbled upon an issue with php7 and error handling. In php7 a `\Error` class was introduced (to convert warning and fatal errors to exceptions). The problem is that `\Error` is not inheriting `\Exception` and, as a consequence, is not catched correctly.

Here is a fix for that, I checked on older php versions, it should not breaking anything (as catching on an unknown class will not generate any error : https://3v4l.org/Hb5HH ).