### PR TITLE
Fixed SyncPromiseAdapter::all() to not change the order of arrays

### DIFF
--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -96,6 +96,7 @@ class SyncPromiseAdapter implements PromiseAdapter
 
         foreach ($promisesOrValues as $index => $promiseOrValue) {
             if ($promiseOrValue instanceof Promise) {
+                $result[$index] = null;
                 $promiseOrValue->then(
                     function($value) use ($index, &$count, $total, &$result, $all) {
                         $result[$index] = $value;

--- a/tests/Executor/Promise/SyncPromiseAdapterTest.php
+++ b/tests/Executor/Promise/SyncPromiseAdapterTest.php
@@ -186,18 +186,18 @@ class SyncPromiseAdapterTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $this->assertEquals($onFulfilledCalled, false);
-        $this->assertEquals($onRejectedCalled, false);
+        $this->assertSame($onFulfilledCalled, false);
+        $this->assertSame($onRejectedCalled, false);
 
         SyncPromise::runQueue();
 
         if ($expectedNextState !== SyncPromise::PENDING) {
-            $this->assertEquals(!$expectedNextReason, $onFulfilledCalled);
-            $this->assertEquals(!!$expectedNextReason, $onRejectedCalled);
+            $this->assertSame(!$expectedNextReason, $onFulfilledCalled);
+            $this->assertSame(!!$expectedNextReason, $onRejectedCalled);
         }
 
-        $this->assertEquals($expectedNextValue, $actualNextValue);
-        $this->assertEquals($expectedNextReason, $actualNextReason);
-        $this->assertEquals($expectedNextState, $promise->adoptedPromise->state);
+        $this->assertSame($expectedNextValue, $actualNextValue);
+        $this->assertSame($expectedNextReason, $actualNextReason);
+        $this->assertSame($expectedNextState, $promise->adoptedPromise->state);
     }
 }


### PR DESCRIPTION
Right now, `SyncPromiseAdapter::all()` changes the order of arrays when resolving promises. For example, an array that should be

```
Array &0 (
    0 => '1'
    1 => 'value1'
    2 => 'value2'
    3 => 3
    4 => 'value2-value3'
    5 => Array &1 ()
)
```

is instead

```
Array &0 (
    0 => '1'
    3 => 3
    5 => Array &1 ()
    1 => 'value1'
    2 => 'value2'
    4 => 'value2-value3'
)
```

As a consequence, the array will be converted to a JSON object with numeric keys when encoding as JSON. `json_encode()` only converts arrays with incremental integer indices to JSON arrays.

This problem is actually detected simply by changing `assertEquals()` to `assertSame()` in the tests. I recommend to generally use `assertSame()` much more often than is done in this project (169 uses of `assertSame()` vs. 562 use of `assertEquals()`) to more easily discover similar flaws.