### PR TITLE
php merge for associative array non-integer intexed

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -136,10 +136,10 @@ class ResolveInfo
                 if (isset($this->fragments[$spreadName])) {
                     /** @var FragmentDefinitionNode $fragment */
                     $fragment = $this->fragments[$spreadName];
-                    $fields += $this->foldSelectionSet($fragment->selectionSet, $descend);
+                    $fields = array_merge_recursive($this->foldSelectionSet($fragment->selectionSet, $descend), $fields);
                 }
             } else if ($selectionNode instanceof InlineFragmentNode) {
-                $fields += $this->foldSelectionSet($selectionNode->selectionSet, $descend);
+                $fields = array_merge_recursive($this->foldSelectionSet($selectionNode->selectionSet, $descend), $fields);
             }
         }
 

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -261,11 +261,7 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
         }
        }
 ';
-        $expectedDefaultSelection = [
-            'author' => true,
-            'image' => true,
-            'replies' => true
-        ];
+
         $expectedDeepSelection = [
             'author' => [
                 'name' => true,
@@ -279,7 +275,7 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
                 'height' => true,
                 'url' => true
             ],
-            '_replies02' => [
+            'replies' => [
                 'body' => true, //this would be missing if not for the fix https://github.com/webonyx/graphql-php/pull/98
                 'author' => [
                     'id' => true,
@@ -307,9 +303,8 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
             'fields' => [
                 'article' => [
                     'type' => $article,
-                    'resolve' => function($value, $args, $context, ResolveInfo $info) use (&$hasCalled, &$actualDefaultSelection, &$actualDeepSelection) {
+                    'resolve' => function($value, $args, $context, ResolveInfo $info) use (&$hasCalled, &$actualDeepSelection) {
                         $hasCalled = true;
-                        $actualDefaultSelection = $info->getFieldSelection();
                         $actualDeepSelection = $info->getFieldSelection(5);
                         return null;
                     }
@@ -322,7 +317,6 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($hasCalled);
         $this->assertEquals(['data' => ['article' => null]], $result);
-        $this->assertEquals($expectedDefaultSelection, $actualDefaultSelection);
         $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
 

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -236,12 +236,12 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
       }
       
       fragment Replies01 on article {
-        replies {
+        _replies01: replies {
             body
         }
       }
       fragment Replies02 on article {
-        replies {            
+        _replies02: replies {            
             author {
                 id
                 name

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -236,12 +236,12 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
       }
       
       fragment Replies01 on article {
-        _replies01: replies {
+        _replies012: replies {
             body
         }
       }
       fragment Replies02 on article {
-        _replies02: replies {            
+        _replies012: replies {            
             author {
                 id
                 name
@@ -279,7 +279,7 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
                 'height' => true,
                 'url' => true
             ],
-            'replies' => [
+            '_replies02' => [
                 'body' => true, //this would be missing if not for the fix https://github.com/webonyx/graphql-php/pull/98
                 'author' => [
                     'id' => true,
@@ -325,4 +325,6 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedDefaultSelection, $actualDefaultSelection);
         $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
+
+
 }

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -235,12 +235,12 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
         url
       }
       
-      fragment Replies01 on article {
+      fragment Replies01 on Article {
         _replies012: replies {
             body
         }
       }
-      fragment Replies02 on article {
+      fragment Replies02 on Article {
         _replies012: replies {            
             author {
                 id

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -162,4 +162,167 @@ class ResolveInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedDefaultSelection, $actualDefaultSelection);
         $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
+
+    public function testMergedFragmentsFieldSelection()
+    {
+        $image = new ObjectType([
+            'name' => 'Image',
+            'fields' => [
+                'url' => ['type' => Type::string()],
+                'width' => ['type' => Type::int()],
+                'height' => ['type' => Type::int()]
+            ]
+        ]);
+
+        $article = null;
+
+        $author = new ObjectType([
+            'name' => 'Author',
+            'fields' => function() use ($image, &$article) {
+                return [
+                    'id' => ['type' => Type::string()],
+                    'name' => ['type' => Type::string()],
+                    'pic' => [ 'type' => $image, 'args' => [
+                        'width' => ['type' => Type::int()],
+                        'height' => ['type' => Type::int()]
+                    ]],
+                    'recentArticle' => ['type' => $article],
+                ];
+            },
+        ]);
+
+        $reply = new ObjectType([
+            'name' => 'Reply',
+            'fields' => [
+                'author' => ['type' => $author],
+                'body' => ['type' => Type::string()]
+            ]
+        ]);
+
+        $article = new ObjectType([
+            'name' => 'Article',
+            'fields' => [
+                'id' => ['type' => Type::string()],
+                'isPublished' => ['type' => Type::boolean()],
+                'author' => ['type' => $author],
+                'title' => ['type' => Type::string()],
+                'body' => ['type' => Type::string()],
+                'image' => ['type' => $image],
+                'replies' => ['type' => Type::listOf($reply)]
+            ]
+        ]);
+
+        $doc = '
+      query Test {
+        article {
+            author {
+                name
+                pic {
+                    url
+                    width
+                }
+            }
+            image {
+                width
+                height
+                ...MyImage
+            }
+            ...Replies01
+            ...Replies02
+        }
+      }
+      fragment MyImage on Image {
+        url
+      }
+      
+      fragment Replies01 on article {
+        replies {
+            body
+        }
+      }
+      fragment Replies02 on article {
+        replies {            
+            author {
+                id
+                name
+                pic {
+                    url
+                    width
+                    ... on Image {
+                        height
+                    }
+                }
+                recentArticle {
+                    id
+                    title
+                    body
+                }
+            }
+        }
+       }
+';
+        $expectedDefaultSelection = [
+            'author' => true,
+            'image' => true,
+            'replies' => true
+        ];
+        $expectedDeepSelection = [
+            'author' => [
+                'name' => true,
+                'pic' => [
+                    'url' => true,
+                    'width' => true
+                ]
+            ],
+            'image' => [
+                'width' => true,
+                'height' => true,
+                'url' => true
+            ],
+            'replies' => [
+                'body' => true, //this would be missing if not for the fix https://github.com/webonyx/graphql-php/pull/98
+                'author' => [
+                    'id' => true,
+                    'name' => true,
+                    'pic' => [
+                        'url' => true,
+                        'width' => true,
+                        'height' => true
+                    ],
+                    'recentArticle' => [
+                        'id' => true,
+                        'title' => true,
+                        'body' => true
+                    ]
+                ]
+            ]
+        ];
+
+        $hasCalled = false;
+        $actualDefaultSelection = null;
+        $actualDeepSelection = null;
+
+        $blogQuery = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'article' => [
+                    'type' => $article,
+                    'resolve' => function($value, $args, $context, ResolveInfo $info) use (&$hasCalled, &$actualDefaultSelection, &$actualDeepSelection) {
+                        $hasCalled = true;
+                        $actualDefaultSelection = $info->getFieldSelection();
+                        $actualDeepSelection = $info->getFieldSelection(5);
+                        return null;
+                    }
+                ]
+            ]
+        ]);
+
+        $schema = new Schema(['query' => $blogQuery]);
+        $result = GraphQL::execute($schema, $doc);
+
+        $this->assertTrue($hasCalled);
+        $this->assertEquals(['data' => ['article' => null]], $result);
+        $this->assertEquals($expectedDefaultSelection, $actualDefaultSelection);
+        $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
+    }
 }


### PR DESCRIPTION
`+=` is useful as an array merge just in case the array is numerically indexed, which is not the case here at all.

Problems solved by this:
```
fragment Fb on User {
  id
  _posts2R94ZT: posts(first: $first_1) {
    totalCount
  }
}

fragment Fc on User {
  _posts2R94ZT: posts(first: $first_1) {
    edges {
      node {
        id
        ...F5
      }
      cursor
    }
    pageInfo {
      hasNextPage
      hasPreviousPage
    }
  }
  id
  ...Fb
}
```

fragment selection would be merged as opposed to first fragment selection being ignored before.
