### PR TITLE
make Schema serializable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   ],
   "require": {
     "php": ">=5.4,<8.0-DEV",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "opis/closure": "^2.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -133,6 +133,11 @@ class Schema
         $this->typeResolutionStrategy = $config['typeResolution'] ?: $this->getEagerTypeResolutionStrategy();
     }
 
+    public function __wakeup()
+    {
+        $this->eagerTypeResolutionStrategy->addType(Introspection::_schema());
+    }
+
     /**
      * @return ObjectType
      */

--- a/src/Type/EagerResolution.php
+++ b/src/Type/EagerResolution.php
@@ -53,6 +53,15 @@ class EagerResolution implements Resolution
     }
 
     /**
+     * @param Type $type
+     */
+    public function addType($type)
+    {
+        $typeMap = Utils\TypeInfo::extractTypes($type);
+        $this->typeMap = array_merge($this->typeMap, $typeMap);
+    }
+
+    /**
      * @inheritdoc
      */
     public function resolveType($name)

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -29,6 +29,7 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Introspection;
 use GraphQL\Utils;
+use Opis\Closure\SerializableClosure;
 
 /**
  * Class BuildSchema
@@ -338,8 +339,8 @@ class BuildSchema
         return new ObjectType([
             'name' => $typeName,
             'description' => $this->getDescription($def),
-            'fields' => function() use ($def) { return $this->makeFieldDefMap($def); },
-            'interfaces' => function() use ($def) { return $this->makeImplementedInterfaces($def); }
+            'fields' => new SerializableClosure(function() use ($def) { return $this->makeFieldDefMap($def); }),
+            'interfaces' => new SerializableClosure(function() use ($def) { return $this->makeImplementedInterfaces($def); })
         ]);
     }
 
@@ -394,7 +395,7 @@ class BuildSchema
         return new InterfaceType([
             'name' => $typeName,
             'description' => $this->getDescription($def),
-            'fields' => function() use ($def) { return $this->makeFieldDefMap($def); },
+            'fields' => new SerializableClosure(function() use ($def) { return $this->makeFieldDefMap($def); }),
             'resolveType' => [$this, 'cannotExecuteSchema']
         ]);
     }
@@ -434,13 +435,13 @@ class BuildSchema
         return new CustomScalarType([
             'name' => $def->name->value,
             'description' => $this->getDescription($def),
-            'serialize' => function() { return false; },
+            'serialize' => new SerializableClosure(function() { return false; }),
             // Note: validation calls the parse functions to determine if a
             // literal value is correct. Returning null would cause use of custom
             // scalars to always fail validation. Returning false causes them to
             // always pass validation.
-            'parseValue' => function() { return false; },
-            'parseLiteral' => function() { return false; }
+            'parseValue' => new SerializableClosure(function() { return false; }),
+            'parseLiteral' => new SerializableClosure(function() { return false; })
         ]);
     }
 
@@ -449,7 +450,7 @@ class BuildSchema
         return new InputObjectType([
             'name' => $def->name->value,
             'description' => $this->getDescription($def),
-            'fields' => function() use ($def) { return $this->makeInputValues($def->fields); }
+            'fields' => new SerializableClosure(function() use ($def) { return $this->makeInputValues($def->fields); })
         ]);
     }
 

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -62,7 +62,7 @@ class TypeInfo
     static function isTypeSubTypeOf(Schema $schema, Type $maybeSubType, Type $superType)
     {
         // Equivalent type is a valid subtype
-        if ($maybeSubType === $superType) {
+        if ($maybeSubType == $superType) {
             return true;
         }
 


### PR DESCRIPTION
When using BuildSchema it becomes important to cache the output schema.

This can be achieved trivially with something like APC but only if you don’t have closures in your objects and/or you wrap them in SerializableClosures.

I’ve transformed everything so that it’s now serializable and will fit into APC if users are writing their resolvers without closures.

# TODO
- [ ] Fix test