### PR TITLE
Use directives when calculating query complexity

### DIFF
--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -86,6 +86,54 @@ class QueryComplexityTest extends AbstractQuerySecurityTest
         $this->assertDocumentValidators($query, 3, 4);
     }
 
+    public function testQueryWithEnabledIncludeDirectives()
+    {
+        $query = 'query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        $this->getRule()->setRawVariableValues(['withDogs' => true]);
+
+        $this->assertDocumentValidators($query, 3, 4);
+    }
+
+    public function testQueryWithDisabledIncludeDirectives()
+    {
+        $query = 'query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        $this->getRule()->setRawVariableValues(['withDogs' => false]);
+
+        $this->assertDocumentValidators($query, 1, 2);
+    }
+
+    public function testQueryWithEnabledSkipDirectives()
+    {
+        $query = 'query MyQuery($withoutDogs: Boolean!) { human { dogs(name: "Root") @skip(if:$withoutDogs) { name } } }';
+
+        $this->getRule()->setRawVariableValues(['withoutDogs' => true]);
+
+        $this->assertDocumentValidators($query, 1, 2);
+    }
+
+    public function testQueryWithDisabledSkipDirectives()
+    {
+        $query = 'query MyQuery($withoutDogs: Boolean!) { human { dogs(name: "Root") @skip(if:$withoutDogs) { name } } }';
+
+        $this->getRule()->setRawVariableValues(['withoutDogs' => false]);
+
+        $this->assertDocumentValidators($query, 3, 4);
+    }
+
+    public function testQueryWithMultipleDirectives()
+    {
+        $query = 'query MyQuery($withDogs: Boolean!, $withoutDogName: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name @skip(if:$withoutDogName) } } }';
+
+        $this->getRule()->setRawVariableValues([
+            'withDogs' => true,
+            'withoutDogName' => true
+        ]);
+
+        $this->assertDocumentValidators($query, 2, 3);
+    }
+
     public function testComplexityIntrospectionQuery()
     {
         $this->assertIntrospectionQuery(181);


### PR DESCRIPTION
While using query complexity to make sure certain fields would never be used in conjunction with other fields (in my case, a `search` field, which should have no side-effects), I found out that directives are ignored when calculating query complexity.
This makes it harder to combine queries, specially with an Apollo frontend.

By actively checking the directives for a field and ignoring the complexity for that field (and subsequent fields), the calculation is much more correct and as expected.

I don't have too much experience with this library directly (I'm using it in conjunction with https://github.com/overblog/GraphQLBundle), so any help, tips, tricks and/or pointers are welcome.