### PR TITLE
fix for duplicate usage of "id"

### DIFF
--- a/examples/01-blog/Blog/Type/UserType.php
+++ b/examples/01-blog/Blog/Type/UserType.php
@@ -45,10 +45,12 @@ class UserType extends ObjectType
                 Types::node()
             ],
             'resolveField' => function($value, $args, $context, ResolveInfo $info) {
-                if (method_exists($this, $info->fieldName)) {
-                    return $this->{$info->fieldName}($value, $args, $context, $info);
-                } else {
-                    return $value->{$info->fieldName};
+                $resolvers = array_diff(get_class_methods(static::class), get_class_methods(get_parent_class()));
+                if (in_array($resolvers, $info->fieldName)) {
+                  return $this->{$info->fieldName}($value, $args, $context, $info);
+                }
+                else {
+                  return $value->{$info->fieldName};
                 }
             }
         ];


### PR DESCRIPTION
only uses current class to check for methods instead of all its parents.