### PR TITLE
Resolve callables by default

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -918,7 +918,7 @@ class Executor
             }
         }
 
-        return $property instanceof \Closure ? $property($source, $args, $context) : $property;
+        return is_callable($property) ? $property($source, $args, $context) : $property;
     }
 
     /**

--- a/tests/Executor/ResolveTest.php
+++ b/tests/Executor/ResolveTest.php
@@ -61,6 +61,30 @@ class ResolveTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @it default function calls callables
+     */
+    public function testDefaultFunctionCallsCallables()
+    {
+        $schema = $this->buildSchema(['type' => Type::string()]);
+        $_secret = 'secretValue' . uniqid();
+
+        $source = [
+            'test' => new class($_secret) {
+                public function __construct($_secret) {
+                    $this->_secret = $_secret;
+                }
+                public function __invoke() {
+                    return $this->_secret;
+                }
+            }
+        ];
+        $this->assertEquals(
+            ['data' => ['test' => $_secret]],
+            GraphQL::execute($schema, '{ test }', $source)
+        );
+    }
+
+    /**
      * @it default function passes args and context
      */
     public function testDefaultFunctionPassesArgsAndContext()

--- a/tests/Executor/ResolveTest.php
+++ b/tests/Executor/ResolveTest.php
@@ -69,14 +69,7 @@ class ResolveTest extends \PHPUnit_Framework_TestCase
         $_secret = 'secretValue' . uniqid();
 
         $source = [
-            'test' => new class($_secret) {
-                public function __construct($_secret) {
-                    $this->_secret = $_secret;
-                }
-                public function __invoke() {
-                    return $this->_secret;
-                }
-            }
+            'test' => new ResolveTestCallableFixture($_secret)
         ];
         $this->assertEquals(
             ['data' => ['test' => $_secret]],
@@ -137,5 +130,20 @@ class ResolveTest extends \PHPUnit_Framework_TestCase
             ['data' => ['test' => '["Source!",{"aStr":"String!","aInt":-123}]']],
             GraphQL::execute($schema, '{ test(aInt: -123, aStr: "String!") }', 'Source!')
         );
+    }
+}
+
+class ResolveTestCallableFixture
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __invoke($root, $args, $context)
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
Enables any `callable`s to be resolved by default. Then you can build a schema with the Builder (lefting resolver functions to the default field resolver) and create invokable classes as resolvers.

```graphql
type Query {
  message: String
}
```

```php
class MessageResolver
{
    public function __construct(string $greet)
    {
        $this->greet = $greet;
    }

    public function __invoke($root, $args, $context)
    {
        return $this->greet;
    }
}

$rootValue = [
    'message' => new MessageResolver('Hello')
];

GraphQL::execute(BuildSchema::build('schema.graphql'), $rootValue);
```