### PR TITLE
Support PHP7 error exceptions everywhere

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -52,7 +52,7 @@ class Deferred
         try {
             $cb = $this->callback;
             $this->promise->resolve($cb());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->promise->reject($e);
         }
     }

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -86,10 +86,7 @@ class Error extends \Exception implements \JsonSerializable
             $nodes = $error->nodes ?: $nodes;
             $source = $error->source;
             $positions = $error->positions;
-        } else if ($error instanceof \Exception) {
-            $message = $error->getMessage();
-            $originalError = $error;
-        } else if ($error instanceof \Error) {
+        } else if ($error instanceof \Throwable) {
             $message = $error->getMessage();
             $originalError = $error;
         } else {
@@ -122,7 +119,7 @@ class Error extends \Exception implements \JsonSerializable
      * @param Source $source
      * @param array|null $positions
      * @param array|null $path
-     * @param \Exception|\Error $previous
+     * @param \Throwable $previous
      */
     public function __construct($message, $nodes = null, Source $source = null, $positions = null, $path = null, $previous = null)
     {

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -46,10 +46,10 @@ class FormattedError
     }
 
     /**
-     * @param \Exception $e
+     * @param \Throwable $e
      * @return array
      */
-    public static function createFromException(\Exception $e)
+    public static function createFromException(\Throwable $e)
     {
         return [
             'message' => $e->getMessage(),

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -664,7 +664,7 @@ class Executor
      * @param mixed $source
      * @param mixed $context
      * @param ResolveInfo $info
-     * @return \Exception|Promise|mixed
+     * @return \Throwable|Promise|mixed
      */
     private function resolveOrError($fieldDef, $fieldNode, $resolveFn, $source, $context, $info)
     {
@@ -678,9 +678,7 @@ class Executor
             );
 
             return $resolveFn($source, $args, $context, $info);
-        } catch (\Exception $error) {
-            return $error;
-        } catch (\Error $error) {
+        } catch (\Throwable $error) {
             return $error;
         }
     }
@@ -778,9 +776,7 @@ class Executor
                 });
             }
             return $completed;
-        } catch (\Exception $error) {
-            throw Error::createLocatedError($error, $fieldNodes, $path);
-        } catch (\Error $error) {
+        } catch (\Throwable $error) {
             throw Error::createLocatedError($error, $fieldNodes, $path);
         }
     }
@@ -813,8 +809,7 @@ class Executor
      * @param $result
      * @return array|null|Promise
      * @throws Error
-     * @throws \Exception
-     * @throws \Error
+     * @throws \Throwable
      */
     private function completeValue(
         Type $returnType,
@@ -836,11 +831,7 @@ class Executor
             });
         }
 
-        if ($result instanceof \Exception) {
-            throw $result;
-        }
-
-        if ($result instanceof \Error) {
+        if ($result instanceof \Throwable) {
             throw $result;
         }
 

--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -56,7 +56,7 @@ class ReactPromiseAdapter implements PromiseAdapter
     /**
      * @inheritdoc
      */
-    public function createRejected(\Exception $reason)
+    public function createRejected(\Throwable $reason)
     {
         $promise = \React\Promise\reject($reason);
         return new Promise($promise, $this);

--- a/src/Executor/Promise/Adapter/SyncPromise.php
+++ b/src/Executor/Promise/Adapter/SyncPromise.php
@@ -46,7 +46,7 @@ class SyncPromise
      */
     private $waiting = [];
 
-    public function reject(\Exception $reason)
+    public function reject(\Throwable $reason)
     {
         switch ($this->state) {
             case self::PENDING:
@@ -129,7 +129,7 @@ class SyncPromise
                 if ($this->state === self::FULFILLED) {
                     try {
                         $promise->resolve($onFulfilled ? $onFulfilled($this->result) : $this->result);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $promise->reject($e);
                     }
                 } else if ($this->state === self::REJECTED) {
@@ -139,7 +139,7 @@ class SyncPromise
                         } else {
                             $promise->reject($this->result);
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $promise->reject($e);
                     }
                 }

--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -58,7 +58,7 @@ class SyncPromiseAdapter implements PromiseAdapter
                 [$promise, 'resolve'],
                 [$promise, 'reject']
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $promise->reject($e);
         }
 
@@ -77,7 +77,7 @@ class SyncPromiseAdapter implements PromiseAdapter
     /**
      * @inheritdoc
      */
-    public function createRejected(\Exception $reason)
+    public function createRejected(\Throwable $reason)
     {
         $promise = new SyncPromise();
         return new Promise($promise->reject($reason), $this);

--- a/src/Executor/Promise/PromiseAdapter.php
+++ b/src/Executor/Promise/PromiseAdapter.php
@@ -57,7 +57,7 @@ interface PromiseAdapter
      *
      * @return Promise
      */
-    public function createRejected(\Exception $reason);
+    public function createRejected(\Throwable $reason);
 
     /**
      * Given an array of promises (or values), returns a promise that is fulfilled when all the

--- a/src/Server.php
+++ b/src/Server.php
@@ -546,13 +546,9 @@ class Server
             }
             $data += ['query' => null, 'variables' => null];
             $result = $this->executeQuery($data['query'], (array) $data['variables'])->toArray();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // This is only possible for schema creation errors and some very unpredictable errors,
             // (all errors which occur during query execution are caught and included in final response)
-            $httpStatus = $this->unexpectedErrorStatus;
-            $error = new Error($this->unexpectedErrorMessage, null, null, null, null, $e);
-            $result = ['errors' => [$this->formatError($error)]];
-        } catch (\Error $e) {
             $httpStatus = $this->unexpectedErrorStatus;
             $error = new Error($this->unexpectedErrorMessage, null, null, null, null, $e);
             $result = ['errors' => [$this->formatError($error)]];
@@ -561,7 +557,7 @@ class Server
         $this->produceOutput($result, $httpStatus);
     }
 
-    private function formatException(\Exception $e)
+    private function formatException(\Throwable $e)
     {
         $formatter = $this->exceptionFormatter;
         return $formatter($e);

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -261,7 +261,7 @@ abstract class Type implements \JsonSerializable
     {
         try {
             return $this->toString();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             echo $e;
         }
     }

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -130,8 +130,8 @@ class DocumentValidator
     public static function isError($value)
     {
         return is_array($value)
-            ? count(array_filter($value, function($item) { return $item instanceof \Exception;})) === count($value)
-            : $value instanceof \Exception;
+            ? count(array_filter($value, function($item) { return $item instanceof \Throwable;})) === count($value)
+            : $value instanceof \Throwable;
     }
 
     public static function append(&$arr, $items)


### PR DESCRIPTION
Instead of duplicating code and check for `\Exception` and `\Error` separate use the base interface
`\Throwable`
