### PR TITLE
Support PHP7 error exceptions everywhere

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -54,6 +54,8 @@ class Deferred
             $this->promise->resolve($cb());
         } catch (\Exception $e) {
             $this->promise->reject($e);
+        } catch (\Throwable $e) {
+            $this->promise->reject($e);
         }
     }
 }

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -86,10 +86,7 @@ class Error extends \Exception implements \JsonSerializable
             $nodes = $error->nodes ?: $nodes;
             $source = $error->source;
             $positions = $error->positions;
-        } else if ($error instanceof \Exception) {
-            $message = $error->getMessage();
-            $originalError = $error;
-        } else if ($error instanceof \Error) {
+        } else if ($error instanceof \Exception || $error instanceof \Throwable) {
             $message = $error->getMessage();
             $originalError = $error;
         } else {
@@ -122,7 +119,7 @@ class Error extends \Exception implements \JsonSerializable
      * @param Source $source
      * @param array|null $positions
      * @param array|null $path
-     * @param \Exception|\Error $previous
+     * @param \Throwable $previous
      */
     public function __construct($message, $nodes = null, Source $source = null, $positions = null, $path = null, $previous = null)
     {

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -46,10 +46,10 @@ class FormattedError
     }
 
     /**
-     * @param \Exception $e
+     * @param \Throwable $e
      * @return array
      */
-    public static function createFromException(\Exception $e)
+    public static function createFromException($e)
     {
         return [
             'message' => $e->getMessage(),

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -664,7 +664,7 @@ class Executor
      * @param mixed $source
      * @param mixed $context
      * @param ResolveInfo $info
-     * @return \Exception|Promise|mixed
+     * @return \Throwable|Promise|mixed
      */
     private function resolveOrError($fieldDef, $fieldNode, $resolveFn, $source, $context, $info)
     {
@@ -680,7 +680,7 @@ class Executor
             return $resolveFn($source, $args, $context, $info);
         } catch (\Exception $error) {
             return $error;
-        } catch (\Error $error) {
+        } catch (\Throwable $error) {
             return $error;
         }
     }
@@ -780,7 +780,7 @@ class Executor
             return $completed;
         } catch (\Exception $error) {
             throw Error::createLocatedError($error, $fieldNodes, $path);
-        } catch (\Error $error) {
+        } catch (\Throwable $error) {
             throw Error::createLocatedError($error, $fieldNodes, $path);
         }
     }
@@ -813,8 +813,7 @@ class Executor
      * @param $result
      * @return array|null|Promise
      * @throws Error
-     * @throws \Exception
-     * @throws \Error
+     * @throws \Throwable
      */
     private function completeValue(
         Type $returnType,
@@ -836,11 +835,7 @@ class Executor
             });
         }
 
-        if ($result instanceof \Exception) {
-            throw $result;
-        }
-
-        if ($result instanceof \Error) {
+        if ($result instanceof \Exception || $result instanceof \Throwable) {
             throw $result;
         }
 

--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -56,7 +56,7 @@ class ReactPromiseAdapter implements PromiseAdapter
     /**
      * @inheritdoc
      */
-    public function createRejected(\Exception $reason)
+    public function createRejected($reason)
     {
         $promise = \React\Promise\reject($reason);
         return new Promise($promise, $this);

--- a/src/Executor/Promise/Adapter/SyncPromise.php
+++ b/src/Executor/Promise/Adapter/SyncPromise.php
@@ -46,8 +46,12 @@ class SyncPromise
      */
     private $waiting = [];
 
-    public function reject(\Exception $reason)
+    public function reject($reason)
     {
+        if (!$reason instanceof \Exception && !$reason instanceof \Throwable) {
+            throw new \Exception('SyncPromise::reject() has to be called with an instance of \Throwable');
+        }
+
         switch ($this->state) {
             case self::PENDING:
                 $this->state = self::REJECTED;
@@ -131,6 +135,8 @@ class SyncPromise
                         $promise->resolve($onFulfilled ? $onFulfilled($this->result) : $this->result);
                     } catch (\Exception $e) {
                         $promise->reject($e);
+                    } catch (\Throwable $e) {
+                        $promise->reject($e);
                     }
                 } else if ($this->state === self::REJECTED) {
                     try {
@@ -140,6 +146,8 @@ class SyncPromise
                             $promise->reject($this->result);
                         }
                     } catch (\Exception $e) {
+                        $promise->reject($e);
+                    } catch (\Throwable $e) {
                         $promise->reject($e);
                     }
                 }

--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -60,6 +60,8 @@ class SyncPromiseAdapter implements PromiseAdapter
             );
         } catch (\Exception $e) {
             $promise->reject($e);
+        } catch (\Throwable $e) {
+            $promise->reject($e);
         }
 
         return new Promise($promise, $this);
@@ -77,7 +79,7 @@ class SyncPromiseAdapter implements PromiseAdapter
     /**
      * @inheritdoc
      */
-    public function createRejected(\Exception $reason)
+    public function createRejected($reason)
     {
         $promise = new SyncPromise();
         return new Promise($promise->reject($reason), $this);

--- a/src/Executor/Promise/PromiseAdapter.php
+++ b/src/Executor/Promise/PromiseAdapter.php
@@ -53,11 +53,11 @@ interface PromiseAdapter
      * Creates a rejected promise for a reason if the reason is not a promise. If
      * the provided reason is a promise, then it is returned as-is.
      *
-     * @param mixed $reason
+     * @param \Throwable $reason
      *
      * @return Promise
      */
-    public function createRejected(\Exception $reason);
+    public function createRejected($reason);
 
     /**
      * Given an array of promises (or values), returns a promise that is fulfilled when all the

--- a/src/Server.php
+++ b/src/Server.php
@@ -552,7 +552,7 @@ class Server
             $httpStatus = $this->unexpectedErrorStatus;
             $error = new Error($this->unexpectedErrorMessage, null, null, null, null, $e);
             $result = ['errors' => [$this->formatError($error)]];
-        } catch (\Error $e) {
+        } catch (\Throwable $e) {
             $httpStatus = $this->unexpectedErrorStatus;
             $error = new Error($this->unexpectedErrorMessage, null, null, null, null, $e);
             $result = ['errors' => [$this->formatError($error)]];
@@ -561,7 +561,10 @@ class Server
         $this->produceOutput($result, $httpStatus);
     }
 
-    private function formatException(\Exception $e)
+    /**
+    * @param \Throwable $e
+    */
+    private function formatException($e)
     {
         $formatter = $this->exceptionFormatter;
         return $formatter($e);

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -263,6 +263,8 @@ abstract class Type implements \JsonSerializable
             return $this->toString();
         } catch (\Exception $e) {
             echo $e;
+        } catch (\Throwable $e) {
+            echo $e;
         }
     }
 }

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -130,8 +130,8 @@ class DocumentValidator
     public static function isError($value)
     {
         return is_array($value)
-            ? count(array_filter($value, function($item) { return $item instanceof \Exception;})) === count($value)
-            : $value instanceof \Exception;
+            ? count(array_filter($value, function($item) { return $item instanceof \Exception || $item instanceof \Throwable;})) === count($value)
+            : ($value instanceof \Exception || $value instanceof \Throwable);
     }
 
     public static function append(&$arr, $items)

--- a/tests/Executor/Promise/SyncPromiseTest.php
+++ b/tests/Executor/Promise/SyncPromiseTest.php
@@ -218,6 +218,8 @@ class SyncPromiseTest extends \PHPUnit_Framework_TestCase
         try {
             $promise->reject('a');
             $this->fail('Expected exception not thrown');
+        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+            throw $e;
         } catch (\Throwable $e) {
             $this->assertEquals(SyncPromise::PENDING, $promise->state);
         } catch (\Exception $e) {


### PR DESCRIPTION
This handles error exceptions in all places and also replace \Error with \Throwable.

This is a breaking change as the API for the interface PromiseAdapter changes, but otherwise there is now way in catching php7 errors that might happen in the Promise.