### PR TITLE
Rework Lexer.php to avoid use of mb_substring.

### DIFF
--- a/benchmarks/HugeSchemaBench.php
+++ b/benchmarks/HugeSchemaBench.php
@@ -46,9 +46,13 @@ class HugeSchemaBench
 
         $this->schema = $this->schemaBuilder->buildSchema();
 
-        $queryBuilder = new QueryGenerator($this->schema, 0.05);
+        $smallQueryBuilder = new QueryGenerator($this->schema, 0.05);
         $this->descriptor = $this->schema->getDescriptor();
-        $this->smallQuery = $queryBuilder->buildQuery();
+        $this->smallQuery = $smallQueryBuilder->buildQuery();
+
+        $largeQueryBuilder = new QueryGenerator($this->schema,.5);
+        $this->largeQuery = $largeQueryBuilder->buildQuery();
+
     }
 
     public function benchSchema()
@@ -71,6 +75,17 @@ class HugeSchemaBench
     {
         $schema = $this->createLazySchema();
         $result = GraphQL::execute($schema, $this->smallQuery);
+    }
+
+    public function benchLargeQuery()
+    {
+        $result = GraphQL::execute($this->schema, $this->largeQuery);
+    }
+
+    public function benchLargeQueryLazy()
+    {
+        $schema = $this->createLazySchema();
+        $result = GraphQL::execute($schema, $this->largeQuery);
     }
 
     private function createLazySchema()

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -1234,7 +1234,7 @@ class Parser
         while ($previousToken->kind == Token::COMMENT
             && ($previousToken->line + 1) == $currentToken->line
         ) {
-            $description = $previousToken->value . $description;
+            $description = $previousToken->value . PHP_EOL . $description;
 
             // walk the tokens backwards until no longer adjacent comments
             $currentToken = $previousToken;

--- a/src/Language/Source.php
+++ b/src/Language/Source.php
@@ -11,6 +11,11 @@ class Source
     public $body;
 
     /**
+     * @var array
+     */
+    public $buf;
+
+    /**
      * @var int
      */
     public $length;
@@ -28,7 +33,8 @@ class Source
         );
 
         $this->body = $body;
-        $this->length = mb_strlen($body, 'UTF-8');
+        $this->buf =  array_map('GraphQL\Utils::ord', preg_split('//u', $body, -1, PREG_SPLIT_NO_EMPTY));
+        $this->length = count($this->buf);
         $this->name = $name ?: 'GraphQL';
     }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -272,7 +272,7 @@ class Utils
     public static function chr($ord, $encoding = 'UTF-8')
     {
         if ($ord <= 255) {
-            return chr($ord);
+            return chr(is_int($ord) ? $ord : ord($ord));
         }
         if ($encoding === 'UCS-4BE') {
             return pack("N", $ord);

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -460,6 +460,60 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @it Records the correct stream location for tokens
+     */
+    public function testTokensHaveCorrectLocationInfo()
+    {
+        $lexer = new Lexer(new Source('{
+      #comment
+      field
+      object (name: "string") {
+        anotherField
+      }
+    }'));
+
+        $expectedTokens = [
+            ['kind' => Token::BRACE_L, 'start' => 0, 'end' => 1, 'line' => 1, 'value' => null],
+            // Comments are explicitly skipped as part of advance.
+            //['kind' => Token::COMMENT, 'start' => 8, 'end' => 17, line => 1, 'value' => 'field'],
+            ['kind' => Token::NAME, 'start' => 23, 'end' => 28, 'line' => 3, 'value' => 'field'],
+            ['kind' => Token::NAME, 'start' => 35, 'end' => 41, 'line' => 4, 'value' => 'object'],
+            ['kind' => Token::PAREN_L, 'start' => 42, 'end' => 43, 'line' => 4, 'value' => null],
+            ['kind' => Token::NAME, 'start' => 43, 'end' => 47, 'line' => 4, 'value' => 'name'],
+            ['kind' => Token::COLON, 'start' => 47, 'end' => 48, 'line' => 4, 'value' => null],
+            ['kind' => Token::STRING, 'start' => 49, 'end' => 57, 'line' => 4, 'value' => 'string'],
+            ['kind' => Token::PAREN_R, 'start' => 57, 'end' => 58, 'line' => 4, 'value' => null],
+            ['kind' => Token::BRACE_L, 'start' => 59, 'end' => 60, 'line' => 4, 'value' => null],
+            ['kind' => Token::NAME, 'start' => 69, 'end' => 81, 'line' => 5, 'value' => 'anotherField'],
+            ['kind' => Token::BRACE_R, 'start' => 88, 'end' => 89, 'line' => 6, 'value' => null],
+            ['kind' => Token::BRACE_R, 'start' => 94, 'end' => 95, 'line' => 7, 'value' => null],
+            ['kind' => Token::EOF, 'start' => 95, 'end' => 95, 'line' => 7, 'value' => null]
+        ];
+
+        foreach ($expectedTokens as $expectedToken) {
+            $token = $lexer->advance();
+            $this->assertArraySubset($expectedToken, (array) $token);
+        }
+    }
+
+    /**
+     * @it Correctly provides value of comment tokens.
+     */
+    public function testCommentsHaveCorrectValues() {
+        $eofToken = $this->lexOne('#comment');
+
+        $this->assertArraySubset(
+            ['kind' => Token::EOF, 'start' => 8, 'end' => 8, 'value' => null],
+            (array) $eofToken
+        );
+
+        $this->assertArraySubset(
+            ['kind' => Token::COMMENT, 'start' => 0, 'end' => 8, 'value' => 'comment'],
+            (array) $eofToken->prev
+        );
+    }
+
+    /**
      * @param string $body
      * @return Token
      */


### PR DESCRIPTION
This resolves issues lexing large queries by implementing an internal array buffer and using an internal position to manage reading the query "stream". As of this commit, all unit tests pass.

As a bit of background, we found when we switched to this library for GraphQL processing that we experienced PHP timeouts on large requests, typically this was triggered by mutations which had input lists of nontrivial size. I ran a profiler over the requests, and identified mb_substring as the culprit.

Benchmark comparisons:

|Benchmark | Old Code | New Code |
| -------------- | ------------- | ------------ |
| Small Query | 993.013 (ms) | 275.589 (ms) |
| Large Query | 87,769.078 (ms) | 2,772.053 (ms) |