### PR TITLE
Layz loading reduced test case [DO NOT MERGE]

### DIFF
--- a/examples/01-blog/.gitignore
+++ b/examples/01-blog/.gitignore
@@ -1,0 +1,1 @@
+schema.descriptor

--- a/examples/01-blog/Blog/Type/QueryType.php
+++ b/examples/01-blog/Blog/Type/QueryType.php
@@ -55,7 +55,14 @@ class QueryType extends ObjectType
                         throw new \Exception("Exception message thrown in field resolver");
                     }
                 ],
-                'hello' => Type::string()
+                'hello' => Type::string(),
+                'node' => [
+                    'type' => Types::node(),
+                    'description' => 'Get any node. Will require type spread.',
+                    'args' => [
+                        'id' => Types::nonNull(Types::id())
+                    ]
+                ]
             ],
             'resolveField' => function($val, $args, $context, ResolveInfo $info) {
                 return $this->{$info->fieldName}($val, $args, $context, $info);
@@ -93,5 +100,10 @@ class QueryType extends ObjectType
     public function deprecatedField()
     {
         return 'You can request deprecated field, but it is not displayed in auto-generated documentation by default.';
+    }
+
+    public function node($rootValue, $args)
+    {
+        return DataSource::findUser($args['id']);
     }
 }


### PR DESCRIPTION
Here is a reduced test case attempting to show the issues with type spreads when using lazy type resolution.

Test query:

```curl 'http://localhost:8080/' -H 'content-type: application/json' -H 'Connection: keep-alive' --data-binary '{"query":"{ node(id: 2) { id, ... on User { email } } }","variables":null}'```

Checking out 383ca58 and running the test query results in:

```
{"data":{"node":{"id":"ID","email":"jane@example.com"}}}
```

Checking out 	c20a1e7 and running the test query results in:

```
{"data":{"node":{"id":"ID"}}}
```

Ignoring the fact that something is obviously very strange with the `"id":"ID"` as it should be `"id":"2"` you will see that the second version using the LazyTypeResolution does not correctly handle the type spread in the query.