### PR TITLE
Support non pre-parsed PSR-7 request body

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -499,6 +499,10 @@ class Helper
                         Utils::printSafeJson($bodyParams)
                     );
                 }
+
+                if (empty($bodyParams)) {
+                    $bodyParams = json_decode($request->getBody(), true);
+                }
             } else {
                 $bodyParams = $request->getParsedBody();
 

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -47,15 +47,17 @@ class StandardServerTest extends TestCase
             'query' => '{f1}'
         ]);
 
-        $request = $this->preparePsrRequest('application/json', $body);
-
         $expected = [
             'data' => [
                 'f1' => 'f1'
             ]
         ];
 
-        $this->assertPsrRequestEquals($expected, $request);
+        $preParsedRequest = $this->preparePsrRequest('application/json', $body, true);
+        $this->assertPsrRequestEquals($expected, $preParsedRequest);
+
+        $notPreParsedRequest = $this->preparePsrRequest('application/json', $body, false);
+        $this->assertPsrRequestEquals($expected, $notPreParsedRequest);
     }
 
     private function executePsrRequest($psrRequest)
@@ -73,21 +75,20 @@ class StandardServerTest extends TestCase
         return $result;
     }
 
-    private function preparePsrRequest($contentType, $content, $method = 'POST')
+    private function preparePsrRequest($contentType, $content, $preParseBody)
     {
         $psrRequestBody = new PsrStreamStub();
         $psrRequestBody->content = $content;
 
         $psrRequest = new PsrRequestStub();
         $psrRequest->headers['content-type'] = [$contentType];
-        $psrRequest->method = $method;
+        $psrRequest->method = 'POST';
         $psrRequest->body = $psrRequestBody;
 
-        if ($contentType === 'application/json') {
+        if ($preParseBody && $contentType === 'application/json') {
             $parsedBody = json_decode($content, true);
-            $parsedBody = $parsedBody === false ? null : $parsedBody;
         } else {
-            $parsedBody = null;
+            $parsedBody = [];
         }
 
         $psrRequest->parsedBody = $parsedBody;


### PR DESCRIPTION
Because PSR-7 specification only specify that `getParsedBody()` **may**
return the parsed body for `application/json`, we cannot assume that it
is always the case. So if the value returned parsed body is an empty array,
it means we should try to parse it ourselves (`null` would mean no body at
all according to spec).

With this modification we try to used given parsed body, but fallback on
trying to parse the body if necessary. This leave the door open to custom
implementation of parsing if needed, while making it easier to use out of
the box.

This is in direct response to https://github.com/webonyx/graphql-php/issues/120#issuecomment-346949979