### PR TITLE
inherit resolve and args from the field type

### DIFF
--- a/tests/LazyLoadingTest.php
+++ b/tests/LazyLoadingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace GraphQL\Tests;
+
+use GraphQL\GraphQL;
+use GraphQL\Type\Schema;
+
+/**
+ * Class LazyLoadingTest
+ * @package GraphQL\Tests
+ *
+ */
+class LazyLoadingTest extends \PHPUnit_Framework_TestCase{
+	private $schema;
+
+	public function setUp() {
+		$typeRegistry = new LazySchema();
+
+		$this->schema = new Schema([
+			'query' => $typeRegistry->get('Query'),
+			'typeLoader' => function ($name) use ($typeRegistry) {
+				return $typeRegistry->get($name);
+			}
+		]);
+	}
+
+	public function testResolve() {
+		$query = '{
+			inPlaceResolved
+			selfResolved {
+				field1
+			}
+		}';
+
+		$result = GraphQL::executeQuery($this->schema, $query)->jsonSerialize();
+		$data = $result['data'];
+
+		$this->assertEquals(LazySchema::IN_PLACE_RESOLVED_EXAMPLE, $data['inPlaceResolved']);
+		$this->assertEquals(LazySchema::SELF_RESOLVED_EXAMPLE, $data['selfResolved']['field1']);
+	}
+}

--- a/tests/LazySchema.php
+++ b/tests/LazySchema.php
@@ -1,0 +1,69 @@
+<?php
+namespace GraphQL\Tests;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class LazySchema
+ * @package GraphQL\Tests
+ */
+class LazySchema {
+	private $types = [];
+
+	const SELF_RESOLVED_EXAMPLE = 5;
+	const IN_PLACE_RESOLVED_EXAMPLE = 10;
+
+	/**
+	 * @param $name
+	 *
+	 * @return ObjectType
+	 */
+	public function get($name) {
+		if (!isset($this->types[$name])) {
+			$this->types[$name] = $this->{$name}();
+		}
+		return $this->types[$name];
+	}
+
+	private function Query() {
+		return new ObjectType([
+			'name' => 'QueryType',
+			'fields' => function() {
+				return [
+					'inPlaceResolved' => [
+						'type' => Type::int(),
+						'resolve' => function() {
+							return self::IN_PLACE_RESOLVED_EXAMPLE;
+						}
+					],
+					'selfResolved' => ['type' => $this->get('SelfResolvedObject')]
+				];
+			}
+		]);
+	}
+
+	/**
+	 * this type defines it's own resolve function
+	 * we will test, whether it is used, when 'resolve' is not defined in the parent type, that is using given type
+	 *
+	 * @return \GraphQL\Type\Definition\ObjectType
+	 */
+	private function SelfResolvedObject() {
+		return new ObjectType([
+				'name' => 'SelfResolvedObject',
+				'description' => 'This object has a resolve function and we want it to be used when resolve is not defined in the parent object',
+				'fields' => function() {
+					return [
+						'field1' => Type::int()
+					];
+				},
+				'resolve' => function() {
+					return [
+						'field1' => self::SELF_RESOLVED_EXAMPLE
+					];
+				}
+			]
+		);
+	}
+}


### PR DESCRIPTION
When I want lazy loading and define fields as a callback like it's done in documentation:
```
private function MyTypeA()
    {
        return new ObjectType([
            'name' => 'MyTypeA',
            'fields' => function() {
                return [
                    'b' => ['type' => $this->get('MyTypeB')]
                ];
            }
        ]);
    }
```

The field b in MyTypeA looses information about args and resolver. So if you want to resolve, you have to repeate resolve definition.

Suggested commit solves this problem. The field, defined as a callback inherits resolve and args from the type if they are not explicitly overwritten by this callback function.