### PR TITLE
Drop support non pre-parsed PSR-7 request body

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -493,19 +493,16 @@ class Helper
                     );
                 }
 
-                // Try parsing ourselves if PSR-7 implementation doesn't parse JSON automatically
-                if (is_array($bodyParams) && empty($bodyParams)) {
-                    $bodyParams = json_decode($request->getBody(), true);
-
-                    if (json_last_error()) {
-                        throw new RequestError("Could not parse JSON: " . json_last_error_msg());
-                    }
-                }
-
                 if (!is_array($bodyParams)) {
                     throw new RequestError(
                         "GraphQL Server expects JSON object or array, but got " .
                         Utils::printSafeJson($bodyParams)
+                    );
+                }
+
+                if (empty($bodyParams)) {
+                    throw new InvariantViolation(
+                        "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got empty array"
                     );
                 }
             } else {

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -181,6 +181,20 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFailsParsingNonPreParsedPsrRequest()
+    {
+        try {
+            $this->parsePsrRequest('application/json', json_encode([]));
+            $this->fail('Expected exception not thrown');
+        } catch (InvariantViolation $e) {
+            // Expecting parsing exception to be thrown somewhere else:
+            $this->assertEquals(
+                'PSR-7 request is expected to provide parsed body for "application/json" requests but got empty array',
+                $e->getMessage()
+            );
+        }
+    }
+
     // There is no equivalent for psr request, because it should throw
 
     public function testFailsParsingNonArrayOrObjectJsonRequest()
@@ -242,15 +256,19 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
 
     public function testFailsOnMethodsOtherThanPostOrGet()
     {
+        $body = [
+            'query' => '{my query}',
+        ];
+
         try {
-            $this->parseRawRequest('application/json', json_encode([]), "PUT");
+            $this->parseRawRequest('application/json', json_encode($body), "PUT");
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('HTTP Method "PUT" is not supported', $e->getMessage());
         }
 
         try {
-            $this->parsePsrRequest('application/json', json_encode([]), "PUT");
+            $this->parsePsrRequest('application/json', json_encode($body), "PUT");
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('HTTP Method "PUT" is not supported', $e->getMessage());

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -43,9 +43,9 @@ class StandardServerTest extends TestCase
 
     public function testSimplePsrRequestExecution()
     {
-        $body = json_encode([
+        $body = [
             'query' => '{f1}'
-        ]);
+        ];
 
         $expected = [
             'data' => [
@@ -53,11 +53,8 @@ class StandardServerTest extends TestCase
             ]
         ];
 
-        $preParsedRequest = $this->preparePsrRequest('application/json', $body, true);
-        $this->assertPsrRequestEquals($expected, $preParsedRequest);
-
-        $notPreParsedRequest = $this->preparePsrRequest('application/json', $body, false);
-        $this->assertPsrRequestEquals($expected, $notPreParsedRequest);
+        $request = $this->preparePsrRequest('application/json', $body);
+        $this->assertPsrRequestEquals($expected, $request);
     }
 
     private function executePsrRequest($psrRequest)
@@ -75,22 +72,11 @@ class StandardServerTest extends TestCase
         return $result;
     }
 
-    private function preparePsrRequest($contentType, $content, $preParseBody)
+    private function preparePsrRequest($contentType, $parsedBody)
     {
-        $psrRequestBody = new PsrStreamStub();
-        $psrRequestBody->content = $content;
-
         $psrRequest = new PsrRequestStub();
         $psrRequest->headers['content-type'] = [$contentType];
         $psrRequest->method = 'POST';
-        $psrRequest->body = $psrRequestBody;
-
-        if ($preParseBody && $contentType === 'application/json') {
-            $parsedBody = json_decode($content, true);
-        } else {
-            $parsedBody = [];
-        }
-
         $psrRequest->parsedBody = $parsedBody;
         return $psrRequest;
     }


### PR DESCRIPTION
I've realized that PR #202 was probably a mistake and should be reversed. The fact that `$request->getParsedBody()` might be empty was due to an incorrect use of Zend Expressive. And I now think that it is not, and should not be, the responsibility of `graphql-php` to parse a PSR-7 request.

I've since [updated my code](https://github.com/Ecodev/dilps/commit/83b7b8c55d1c2d1b604eeb842e48cc8b581aa5f4) to properly configure Zend Expressive to parse the request with [BodyParamsMiddleware](https://docs.zendframework.com/zend-expressive/features/helpers/body-parse/) before reaching `graphql-php`.

If we don't merge this PR, then suddenly `graphql-php` will have to re-implement all kind of request parsing method (i'm thinking `multipart/form-data`) just in case the request was not parsed beforehand. And that would probably not be something we would like to have in that project. Instead it should live in a different project specialized in request parsing.