### PR TITLE
[WIP] Support for file uploads

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -482,34 +482,22 @@ class Helper
                 throw new RequestError('Missing "Content-Type" header');
             }
 
-            if (stripos('application/graphql', $contentType[0]) !== false) {
+            $contentType = $contentType[0];
+            if (stripos($contentType, 'application/graphql') !== false) {
                 $bodyParams = ['query' => $request->getBody()->getContents()];
-            } else if (stripos('application/json', $contentType[0]) !== false) {
+            } elseif (stripos($contentType, 'application/json') !== false) {
                 $bodyParams = $request->getParsedBody();
 
-                if (null === $bodyParams) {
-                    throw new InvariantViolation(
-                        "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got null"
-                    );
-                }
-
-                if (!is_array($bodyParams)) {
-                    throw new RequestError(
-                        "GraphQL Server expects JSON object or array, but got " .
-                        Utils::printSafeJson($bodyParams)
-                    );
-                }
-
-                if (empty($bodyParams)) {
-                    throw new InvariantViolation(
-                        "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got empty array"
-                    );
-                }
+                $this->validateParsedBody($bodyParams);
+            } elseif (stripos($contentType, 'multipart/form-data') !== false) {
+                $bodyParams = $request->getParsedBody();
+                $this->validateParsedBody($bodyParams);
+                $bodyParams = $this->parseUploadedFiles($request, $bodyParams);
             } else {
                 $bodyParams = $request->getParsedBody();
 
                 if (!is_array($bodyParams)) {
-                    throw new RequestError("Unexpected content type: " . Utils::printSafeJson($contentType[0]));
+                    throw new RequestError("Unexpected content type: " . Utils::printSafeJson($contentType));
                 }
             }
         }
@@ -552,5 +540,66 @@ class Helper
             ->withStatus($httpStatus)
             ->withHeader('Content-Type', 'application/json')
             ->withBody($writableBodyStream);
+    }
+
+    /**
+     * Inject uploaded files defined in the 'map' key into the 'variables' key
+     *
+     * @param ServerRequestInterface $request
+     * @param array $bodyParams
+     *
+     * @return array
+     */
+    private function parseUploadedFiles(ServerRequestInterface $request, array $bodyParams)
+    {
+        if (!isset($bodyParams['map'])) {
+            return $bodyParams;
+        }
+
+        $map = json_decode($bodyParams['map'], true);
+        $result = json_decode($bodyParams['operations'], true);
+        $result['operation'] = $result['operationName'];
+        unset($result['operationName']);
+
+        foreach ($map as $fileKey => $locations) {
+            foreach ($locations as $location) {
+                $items = &$result;
+                foreach (explode('.', $location) as $key) {
+                    if (!isset($items[$key]) || !is_array($items[$key])) {
+                        $items[$key] = [];
+                    }
+                    $items = &$items[$key];
+                }
+
+                $items = $request->getUploadedFiles()[$fileKey];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $bodyParams
+     */
+    private function validateParsedBody($bodyParams)
+    {
+        if (null === $bodyParams) {
+            throw new InvariantViolation(
+                "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got null"
+            );
+        }
+
+        if (!is_array($bodyParams)) {
+            throw new RequestError(
+                "GraphQL Server expects JSON object or array, but got " .
+                Utils::printSafeJson($bodyParams)
+            );
+        }
+
+        if (empty($bodyParams)) {
+            throw new InvariantViolation(
+                "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got empty array"
+            );
+        }
     }
 }

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -493,19 +493,16 @@ class Helper
                     );
                 }
 
-                // Try parsing ourselves if PSR-7 implementation doesn't parse JSON automatically
-                if (is_array($bodyParams) && empty($bodyParams)) {
-                    $bodyParams = json_decode($request->getBody(), true);
-
-                    if (json_last_error()) {
-                        throw new RequestError("Could not parse JSON: " . json_last_error_msg());
-                    }
-                }
-
                 if (!is_array($bodyParams)) {
                     throw new RequestError(
                         "GraphQL Server expects JSON object or array, but got " .
                         Utils::printSafeJson($bodyParams)
+                    );
+                }
+
+                if (empty($bodyParams)) {
+                    throw new InvariantViolation(
+                        "PSR-7 request is expected to provide parsed body for \"application/json\" requests but got empty array"
                     );
                 }
             } else {

--- a/src/Type/Definition/FileType.php
+++ b/src/Type/Definition/FileType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace GraphQL\Type\Definition;
+
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Utils\Utils;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Class FileType
+ *
+ * @package GraphQL\Type\Definition
+ */
+class FileType extends ScalarType
+{
+    /**
+     * @var string
+     */
+    public $name = Type::FILE;
+
+    /**
+     * @var string
+     */
+    public $description =
+        'The `File` special type represents a file to be uploaded in the same HTTP query as specified by
+ [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec).';
+
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function serialize($value)
+    {
+        throw new InvariantViolation('FileType cannot be represented as string');
+    }
+
+    /**
+     * Parses an externally provided value (query variable) to use as an input
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function parseValue($value)
+    {
+        if (!$value instanceof UploadedFileInterface) {
+            throw new \UnexpectedValueException("Could not get uploaded file, be sure to conform to GraphQL multipart request specification. Instead got: " . Utils::printSafe($value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input
+     *
+     * @param \GraphQL\Language\AST\Node $valueNode
+     *
+     * @return mixed
+     */
+    public function parseLiteral($valueNode)
+    {
+        throw new Error('File cannot be hardcoded in query, be sure to conform to GraphQL multipart request specification. Instead got: ' . $valueNode->kind, [$valueNode]);
+    }
+}

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -17,6 +17,7 @@ abstract class Type implements \JsonSerializable
     const BOOLEAN = 'Boolean';
     const FLOAT = 'Float';
     const ID = 'ID';
+    const FILE = 'File';
 
     /**
      * @var array
@@ -70,6 +71,15 @@ abstract class Type implements \JsonSerializable
 
     /**
      * @api
+     * @return FileType
+     */
+    public static function file()
+    {
+        return self::getInternalType(self::FILE);
+    }
+
+    /**
+     * @api
      * @param ObjectType|InterfaceType|UnionType|ScalarType|InputObjectType|EnumType|ListOfType|NonNull $wrappedType
      * @return ListOfType
      */
@@ -90,7 +100,7 @@ abstract class Type implements \JsonSerializable
 
     /**
      * @param $name
-     * @return array|IDType|StringType|FloatType|IntType|BooleanType
+     * @return array|IDType|StringType|FloatType|IntType|BooleanType|FileType
      */
     private static function getInternalType($name = null)
     {
@@ -100,7 +110,8 @@ abstract class Type implements \JsonSerializable
                 self::STRING => new StringType(),
                 self::FLOAT => new FloatType(),
                 self::INT => new IntType(),
-                self::BOOLEAN => new BooleanType()
+                self::BOOLEAN => new BooleanType(),
+                self::FILE => new FileType()
             ];
         }
         return $name ? self::$internalTypes[$name] : self::$internalTypes;

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -41,7 +41,7 @@ class BuildSchema
     /**
      * @param Type $innerType
      * @param TypeNode $inputTypeNode
-     * @return Type 
+     * @return Type
      */
     private function buildWrappedType(Type $innerType, TypeNode $inputTypeNode)
     {
@@ -99,7 +99,7 @@ class BuildSchema
         $this->typeConfigDecorator = $typeConfigDecorator;
         $this->loadedTypeDefs = [];
     }
-    
+
     public function buildSchema()
     {
         $schemaDef = null;
@@ -194,6 +194,7 @@ class BuildSchema
             'Int' => Type::int(),
             'Float' => Type::float(),
             'Boolean' => Type::boolean(),
+            'File' => Type::file(),
             'ID' => Type::id(),
             '__Schema' => Introspection::_schema(),
             '__Directive' => Introspection::_directive(),
@@ -619,7 +620,7 @@ class BuildSchema
     /**
      * A helper function to build a GraphQLSchema directly from a source
      * document.
-     * 
+     *
      * @api
      * @param DocumentNode|Source|string $source
      * @param callable $typeConfigDecorator

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -66,7 +66,8 @@ class SchemaPrinter
             $typename === Type::BOOLEAN ||
             $typename === Type::INT ||
             $typename === Type::FLOAT ||
-            $typename === Type::ID
+            $typename === Type::ID ||
+            $typename === Type::FILE
         );
     }
 
@@ -112,7 +113,7 @@ class SchemaPrinter
 
         return "schema {\n" . implode("\n", $operationTypes) . "\n}";
     }
-    
+
     /**
      * GraphQL schema define root types for each type of operation. These types are
      * the same as any other type and can be named in any manner, however there is
@@ -182,7 +183,7 @@ class SchemaPrinter
 
     private static function printInterface(InterfaceType $type)
     {
-        return self::printDescription($type) . 
+        return self::printDescription($type) .
             "interface {$type->name} {\n" .
                 self::printFields($type) . "\n" .
             "}";
@@ -213,7 +214,7 @@ class SchemaPrinter
     private static function printInputObject(InputObjectType $type)
     {
         $fields = array_values($type->getFields());
-        return self::printDescription($type) . 
+        return self::printDescription($type) .
             "input {$type->name} {\n" .
                 implode("\n", array_map(function($f, $i) {
                     return self::printDescription($f, '  ', !$i) . '  ' . self::printInputValue($f);

--- a/tests/Executor/UploadTest.php
+++ b/tests/Executor/UploadTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace GraphQL\Tests\Executor;
+
+use GraphQL\Server\StandardServer;
+use GraphQL\Tests\Server\Psr7\PsrRequestStub;
+use GraphQL\Tests\Server\Psr7\PsrUploadedFileStub;
+use GraphQL\Type\Schema;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+class UploadTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanUploadFileWithPsrRequest()
+    {
+        $request = $this->getRequest();
+
+        $server = new StandardServer([
+            'schema' => $this->getSchema(),
+            'debug' => true,
+        ]);
+
+        $response = $server->executePsrRequest($request);
+
+        $expected = ['testUpload' => 'Uploaded file was image.jpg (image/jpeg) with description: foo bar'];
+        $this->assertSame($expected, $response->data);
+    }
+
+    /**
+     * @return Schema
+     */
+    private function getSchema()
+    {
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+            ]),
+            'mutation' => new ObjectType([
+                'name' => 'Mutation',
+                'fields' => [
+                    'testUpload' => [
+                        'type' => Type::string(),
+                        'args' => [
+                            'text' => Type::string(),
+                            'file' => Type::file(),
+                        ],
+                        'resolve' => function ($root, array $args) {
+
+                            /** @var UploadedFileInterface $file */
+                            $file = $args['file'];
+                            $this->assertInstanceOf(UploadedFileInterface::class, $file);
+
+                            // Do something more interesting with the file
+                            // $file->moveTo('some/folder/in/my/project');
+
+                            return 'Uploaded file was ' . $file->getClientFilename() . ' (' . $file->getClientMediaType() . ') with description: ' . $args['text'];
+                        },
+                    ],
+
+                ],
+            ]),
+        ]);
+
+        return $schema;
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    private function getRequest()
+    {
+        $request = new PsrRequestStub();
+        $request->headers['content-type'] = ['multipart/form-data'];
+        $request->method = 'POST';
+
+        $request->uploadedFiles = [
+            1 => new PsrUploadedFileStub('image.jpg', 'image/jpeg'),
+        ];
+
+        $request->parsedBody = [
+            'operations' => json_encode([
+                'query' => 'mutation TestUpload($text: String, $file: File) {
+    testUpload(text: $text, file: $file)
+}',
+                'variables' => [
+                    'text' => 'foo bar',
+                    'file' => null,
+                ],
+                'operationName' => 'TestUpload',
+            ]),
+            'map' => json_encode([
+                1 => ['variables.file'],
+            ]),
+        ];
+
+        return $request;
+    }
+}
+

--- a/tests/Server/Psr7/PsrRequestStub.php
+++ b/tests/Server/Psr7/PsrRequestStub.php
@@ -24,6 +24,11 @@ class PsrRequestStub implements ServerRequestInterface
     public $parsedBody;
 
     /**
+     * @var array
+     */
+    public  $uploadedFiles = [];
+
+    /**
      * Retrieves the HTTP protocol version as a string.
      *
      * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
@@ -457,7 +462,7 @@ class PsrRequestStub implements ServerRequestInterface
      */
     public function getUploadedFiles()
     {
-        throw new \Exception("Not implemented");
+        return $this->uploadedFiles;
     }
 
     /**

--- a/tests/Server/Psr7/PsrUploadedFileStub.php
+++ b/tests/Server/Psr7/PsrUploadedFileStub.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace GraphQL\Tests\Server\Psr7;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+class PsrUploadedFileStub implements UploadedFileInterface
+{
+    public $clientFilename;
+
+    public $clientMediaType;
+
+    public function __construct($clientFilename, $clientMediaType)
+    {
+        $this->clientFilename = $clientFilename;
+        $this->clientMediaType = $clientMediaType;
+    }
+
+    /**
+     * Retrieve a stream representing the uploaded file.
+     *
+     * This method MUST return a StreamInterface instance, representing the
+     * uploaded file. The purpose of this method is to allow utilizing native PHP
+     * stream functionality to manipulate the file upload, such as
+     * stream_copy_to_stream() (though the result will need to be decorated in a
+     * native PHP stream wrapper to work with such functions).
+     *
+     * If the moveTo() method has been called previously, this method MUST raise
+     * an exception.
+     *
+     * @return StreamInterface Stream representation of the uploaded file.
+     * @throws \RuntimeException in cases when no stream is available or can be
+     *     created.
+     */
+    public function getStream()
+    {
+        throw new \Exception("Not implemented");
+    }
+
+    /**
+     * Move the uploaded file to a new location.
+     *
+     * Use this method as an alternative to move_uploaded_file(). This method is
+     * guaranteed to work in both SAPI and non-SAPI environments.
+     * Implementations must determine which environment they are in, and use the
+     * appropriate method (move_uploaded_file(), rename(), or a stream
+     * operation) to perform the operation.
+     *
+     * $targetPath may be an absolute path, or a relative path. If it is a
+     * relative path, resolution should be the same as used by PHP's rename()
+     * function.
+     *
+     * The original file or stream MUST be removed on completion.
+     *
+     * If this method is called more than once, any subsequent calls MUST raise
+     * an exception.
+     *
+     * When used in an SAPI environment where $_FILES is populated, when writing
+     * files via moveTo(), is_uploaded_file() and move_uploaded_file() SHOULD be
+     * used to ensure permissions and upload status are verified correctly.
+     *
+     * If you wish to move to a stream, use getStream(), as SAPI operations
+     * cannot guarantee writing to stream destinations.
+     *
+     * @see http://php.net/is_uploaded_file
+     * @see http://php.net/move_uploaded_file
+     *
+     * @param string $targetPath Path to which to move the uploaded file.
+     *
+     * @throws \InvalidArgumentException if the $targetPath specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
+     *     the second or subsequent call to the method.
+     */
+    public function moveTo($targetPath)
+    {
+        throw new \Exception("Not implemented");
+    }
+
+    /**
+     * Retrieve the file size.
+     *
+     * Implementations SHOULD return the value stored in the "size" key of
+     * the file in the $_FILES array if available, as PHP calculates this based
+     * on the actual size transmitted.
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize()
+    {
+        throw new \Exception("Not implemented");
+    }
+
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * The return value MUST be one of PHP's UPLOAD_ERR_XXX constants.
+     *
+     * If the file was uploaded successfully, this method MUST return
+     * UPLOAD_ERR_OK.
+     *
+     * Implementations SHOULD return the value stored in the "error" key of
+     * the file in the $_FILES array.
+     *
+     * @see http://php.net/manual/en/features.file-upload.errors.php
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
+     */
+    public function getError()
+    {
+        throw new \Exception("Not implemented");
+    }
+
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious filename with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "name" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename()
+    {
+        return $this->clientFilename;
+    }
+
+    /**
+     * Retrieve the media type sent by the client.
+     *
+     * Do not trust the value returned by this method. A client could send
+     * a malicious media type with the intention to corrupt or hack your
+     * application.
+     *
+     * Implementations SHOULD return the value stored in the "type" key of
+     * the file in the $_FILES array.
+     *
+     * @return string|null The media type sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientMediaType()
+    {
+        return $this->clientMediaType;
+    }
+}

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -360,7 +360,6 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
             $psrRequest->body = $psrRequestBody;
         } else {
             $psrRequest->parsedBody = $content;
-
         }
 
         $helper = new Helper();

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GraphQL\Tests\Server;
 
 use GraphQL\Error\Error;
@@ -8,9 +9,53 @@ use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
 use GraphQL\Tests\Server\Psr7\PsrRequestStub;
 use GraphQL\Tests\Server\Psr7\PsrStreamStub;
+use GraphQL\Tests\Server\Psr7\PsrUploadedFileStub;
 
 class RequestParsingTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function testParsesMultipartRequest()
+    {
+        $query = '{my query}';
+        $variables = [
+            'test' => 1,
+            'test2' => 2,
+            'uploads' => [
+                0 => null,
+                1 => null,
+            ],
+        ];
+        $operation = 'op';
+
+        $body = [
+            'operations' => json_encode([
+                'query' => $query,
+                'variables' => $variables,
+                'operationName' => $operation,
+            ]),
+            'map' => json_encode([
+                1 => ['variables.uploads.0'],
+                2 => ['variables.uploads.1'],
+            ]),
+        ];
+
+        $file1 = new PsrUploadedFileStub('image.jpg', 'image/jpeg');
+        $file2 = new PsrUploadedFileStub('foo.txt', 'text/plain');
+        $files = [
+            1 => $file1,
+            2 => $file2,
+        ];
+
+        $parsedBody = $this->parsePsrRequest('multipart/form-data; boundary=----WebKitFormBoundarySl4GaqVa1r8GtAbn', $body, 'POST', $files);
+
+        $variables['uploads'] = [
+            0 => $file1,
+            1 => $file2,
+        ];
+        $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, 'uploaded files should get injected into variables');
+        $this->assertFalse($parsedBody->isReadOnly());
+    }
+
     public function testParsesGraphqlRequest()
     {
         $query = '{my query}';
@@ -82,7 +127,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
-            'psr' => $this->parsePsrRequest('application/json', json_encode($body))
+            'psr' => $this->parsePsrRequest('application/json', $body)
         ];
         foreach ($parsed as $method => $parsedBody) {
             $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
@@ -103,7 +148,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
-            'psr' => $this->parsePsrRequest('application/json', json_encode($body))
+            'psr' => $this->parsePsrRequest('application/json', $body)
         ];
         foreach ($parsed as $method => $parsedBody) {
             $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
@@ -124,7 +169,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
-            'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
+            'psr' => $this->parsePsrRequest('application/json', $body)
         ];
         foreach ($parsed as $method => $parsedBody) {
             $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
@@ -148,7 +193,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
-            'psr' => $this->parsePsrRequest('application/json', json_encode($body))
+            'psr' => $this->parsePsrRequest('application/json', $body)
         ];
         foreach ($parsed as $method => $parsedBody) {
             $this->assertInternalType('array', $parsedBody, $method);
@@ -170,7 +215,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         }
 
         try {
-            $this->parsePsrRequest('application/json', $body);
+            $this->parsePsrRequest('application/json', null);
             $this->fail('Expected exception not thrown');
         } catch (InvariantViolation $e) {
             // Expecting parsing exception to be thrown somewhere else:
@@ -184,7 +229,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
     public function testFailsParsingNonPreParsedPsrRequest()
     {
         try {
-            $this->parsePsrRequest('application/json', json_encode([]));
+            $this->parsePsrRequest('application/json', []);
             $this->fail('Expected exception not thrown');
         } catch (InvariantViolation $e) {
             // Expecting parsing exception to be thrown somewhere else:
@@ -199,10 +244,10 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
 
     public function testFailsParsingNonArrayOrObjectJsonRequest()
     {
-        $body = '"str"';
+        $body = 'str';
 
         try {
-            $this->parseRawRequest('application/json', $body);
+            $this->parseRawRequest('application/json', json_encode($body));
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('GraphQL Server expects JSON object or array, but got "str"', $e->getMessage());
@@ -268,7 +313,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         }
 
         try {
-            $this->parsePsrRequest('application/json', json_encode($body), "PUT");
+            $this->parsePsrRequest('application/json', $body, "PUT");
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('HTTP Method "PUT" is not supported', $e->getMessage());
@@ -288,36 +333,35 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REQUEST_METHOD'] = $method;
 
         $helper = new Helper();
-        return $helper->parseHttpRequest(function() use ($content) {
+
+        return $helper->parseHttpRequest(function () use ($content) {
             return $content;
         });
     }
 
     /**
      * @param string $contentType
-     * @param string $content
-     * @param $method
+     * @param array|string $content
+     * @param string $method
+     * @param array $files
      *
      * @return OperationParams|OperationParams[]
      */
-    private function parsePsrRequest($contentType, $content, $method = 'POST')
+    private function parsePsrRequest($contentType, $content, $method = 'POST', array $files = [])
     {
-        $psrRequestBody = new PsrStreamStub();
-        $psrRequestBody->content = $content;
-
         $psrRequest = new PsrRequestStub();
         $psrRequest->headers['content-type'] = [$contentType];
         $psrRequest->method = $method;
-        $psrRequest->body = $psrRequestBody;
+        $psrRequest->uploadedFiles = $files;
 
-        if ($contentType === 'application/json') {
-            $parsedBody = json_decode($content, true);
-            $parsedBody = $parsedBody === false ? null : $parsedBody;
+        if ($contentType === 'application/graphql') {
+            $psrRequestBody = new PsrStreamStub();
+            $psrRequestBody->content = $content;
+            $psrRequest->body = $psrRequestBody;
         } else {
-            $parsedBody = null;
-        }
+            $psrRequest->parsedBody = $content;
 
-        $psrRequest->parsedBody = $parsedBody;
+        }
 
         $helper = new Helper();
         return $helper->parsePsrRequest($psrRequest);

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -181,6 +181,20 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFailsParsingNonPreParsedPsrRequest()
+    {
+        try {
+            $this->parsePsrRequest('application/json', json_encode([]));
+            $this->fail('Expected exception not thrown');
+        } catch (InvariantViolation $e) {
+            // Expecting parsing exception to be thrown somewhere else:
+            $this->assertEquals(
+                'PSR-7 request is expected to provide parsed body for "application/json" requests but got empty array',
+                $e->getMessage()
+            );
+        }
+    }
+
     // There is no equivalent for psr request, because it should throw
 
     public function testFailsParsingNonArrayOrObjectJsonRequest()
@@ -242,15 +256,19 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
 
     public function testFailsOnMethodsOtherThanPostOrGet()
     {
+        $body = [
+            'query' => '{my query}',
+        ];
+
         try {
-            $this->parseRawRequest('application/json', json_encode([]), "PUT");
+            $this->parseRawRequest('application/json', json_encode($body), "PUT");
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('HTTP Method "PUT" is not supported', $e->getMessage());
         }
 
         try {
-            $this->parsePsrRequest('application/json', json_encode([]), "PUT");
+            $this->parsePsrRequest('application/json', json_encode($body), "PUT");
             $this->fail('Expected exception not thrown');
         } catch (RequestError $e) {
             $this->assertEquals('HTTP Method "PUT" is not supported', $e->getMessage());

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -43,9 +43,9 @@ class StandardServerTest extends TestCase
 
     public function testSimplePsrRequestExecution()
     {
-        $body = json_encode([
+        $body = [
             'query' => '{f1}'
-        ]);
+        ];
 
         $expected = [
             'data' => [
@@ -53,11 +53,8 @@ class StandardServerTest extends TestCase
             ]
         ];
 
-        $preParsedRequest = $this->preparePsrRequest('application/json', $body, true);
-        $this->assertPsrRequestEquals($expected, $preParsedRequest);
-
-        $notPreParsedRequest = $this->preparePsrRequest('application/json', $body, false);
-        $this->assertPsrRequestEquals($expected, $notPreParsedRequest);
+        $request = $this->preparePsrRequest('application/json', $body);
+        $this->assertPsrRequestEquals($expected, $request);
     }
 
     private function executePsrRequest($psrRequest)
@@ -75,22 +72,11 @@ class StandardServerTest extends TestCase
         return $result;
     }
 
-    private function preparePsrRequest($contentType, $content, $preParseBody)
+    private function preparePsrRequest($contentType, $parsedBody)
     {
-        $psrRequestBody = new PsrStreamStub();
-        $psrRequestBody->content = $content;
-
         $psrRequest = new PsrRequestStub();
         $psrRequest->headers['content-type'] = [$contentType];
         $psrRequest->method = 'POST';
-        $psrRequest->body = $psrRequestBody;
-
-        if ($preParseBody && $contentType === 'application/json') {
-            $parsedBody = json_decode($content, true);
-        } else {
-            $parsedBody = [];
-        }
-
         $psrRequest->parsedBody = $parsedBody;
         return $psrRequest;
     }

--- a/tests/StarWarsIntrospectionTest.php
+++ b/tests/StarWarsIntrospectionTest.php
@@ -36,6 +36,7 @@ class StarWarsIntrospectionTest extends \PHPUnit_Framework_TestCase
                     ['name' => 'Float'],
                     ['name' => 'Int'],
                     ['name' => 'Boolean'],
+                    ['name' => 'File'],
                     ['name' => '__Schema'],
                     ['name' => '__Type'],
                     ['name' => '__TypeKind'],

--- a/tests/Type/IntrospectionTest.php
+++ b/tests/Type/IntrospectionTest.php
@@ -111,6 +111,15 @@ class IntrospectionTest extends \PHPUnit_Framework_TestCase
                                         'possibleTypes' => NULL,
                                     ),
                                     array (
+                                        'kind' => 'SCALAR',
+                                        'name' => 'File',
+                                        'fields' => NULL,
+                                        'inputFields' => NULL,
+                                        'interfaces' => NULL,
+                                        'enumValues' => NULL,
+                                        'possibleTypes' => NULL,
+                                    ),
+                                    array (
                                         'kind' => 'OBJECT',
                                         'name' => '__Schema',
                                         'fields' =>
@@ -994,6 +1003,72 @@ class IntrospectionTest extends \PHPUnit_Framework_TestCase
                                                         'name' => 'INLINE_FRAGMENT',
                                                         'isDeprecated' => false,
                                                         'deprecationReason' => null
+                                                    ),
+                                                7 =>
+                                                    array (
+                                                        'name' => 'SCHEMA',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                8 =>
+                                                    array (
+                                                        'name' => 'SCALAR',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                9 =>
+                                                    array (
+                                                        'name' => 'OBJECT',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                10 =>
+                                                    array (
+                                                        'name' => 'FIELD_DEFINITION',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                11 =>
+                                                    array (
+                                                        'name' => 'ARGUMENT_DEFINITION',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                12 =>
+                                                    array (
+                                                        'name' => 'INTERFACE',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                13 =>
+                                                    array (
+                                                        'name' => 'UNION',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                14 =>
+                                                    array (
+                                                        'name' => 'ENUM',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                15 =>
+                                                    array (
+                                                        'name' => 'ENUM_VALUE',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                16 =>
+                                                    array (
+                                                        'name' => 'INPUT_OBJECT',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
+                                                    ),
+                                                17 =>
+                                                    array (
+                                                        'name' => 'INPUT_FIELD_DEFINITION',
+                                                        'isDeprecated' => false,
+                                                        'deprecationReason' => NULL,
                                                     ),
                                             ),
                                         'possibleTypes' => NULL,

--- a/tests/Type/ResolutionTest.php
+++ b/tests/Type/ResolutionTest.php
@@ -283,7 +283,8 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
             'String' => Type::string(),
             'Float' => Type::float(),
             'Int' => Type::int(),
-            'Boolean' => Type::boolean()
+            'Boolean' => Type::boolean(),
+            'File' => Type::file(),
         ];
         $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
 
@@ -295,6 +296,7 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
                 'Float' => 1,
                 'Int' => 1,
                 'Boolean' => 1,
+                'File' => 1,
             ],
             'possibleTypeMap' => []
         ];
@@ -344,7 +346,8 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
             'PostCommentMutation' => $this->postCommentMutation,
             'Float' => Type::float(),
             'Int' => Type::int(),
-            'Boolean' => Type::boolean()
+            'Boolean' => Type::boolean(),
+            'File' => Type::file()
         ];
 
         $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
@@ -369,7 +372,8 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
                 'PostCommentMutation' => 1,
                 'Float' => 1,
                 'Int' => 1,
-                'Boolean' => 1
+                'Boolean' => 1,
+                'File' => 1
             ],
             'possibleTypeMap' => [
                 'Node' => [
@@ -424,7 +428,8 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
             'Float' => Type::float(),
             'ID' => Type::id(),
             'Int' => Type::int(),
-            'Boolean' => Type::boolean()
+            'Boolean' => Type::boolean(),
+            'File' => Type::file()
         ];
         $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
 
@@ -442,7 +447,8 @@ class ResolutionTest extends \PHPUnit_Framework_TestCase
                 'Float' => 1,
                 'ID' => 1,
                 'Int' => 1,
-                'Boolean' => 1
+                'Boolean' => 1,
+                'File' => 1,
             ],
             'possibleTypeMap' => [
                 'Node' => [

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -35,7 +35,7 @@ class BuildSchemaTest extends \PHPUnit_Framework_TestCase
                 str: String
             }
         '));
-        
+
         $result = GraphQL::execute($schema, '{ str }', ['str' => 123]);
         $this->assertEquals($result['data'], ['str' => 123]);
     }
@@ -80,6 +80,7 @@ type HelloScalars {
   float: Float
   id: ID
   bool: Boolean
+  file: File
 }
 ';
         $output = $this->cycleOutput($body);


### PR DESCRIPTION
This is a work in progress to implement [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec) to support file uploads. 

The `StandardServer` now supports file uploads for request with `multipart/form-data` content type, but only for PSR-7 requests (IMHO it would be out of scope to parse raw request for uploaded files). A new type `File` was introduced to represent uploaded file in the schema.

Usage should look like:

```php

$request = getPsr7RequestFromAnotherLibrary();

$schema = new Schema([
    'query' => new ObjectType([
        'name' => 'Query',
    ]),
    'mutation' => new ObjectType([
        'name' => 'Mutation',
        'fields' => [
            'testUpload' => [
                'type' => Type::string(),
                'args' => [
                    'text' => Type::string(),
                    'file' => Type::file(),
                ],
                'resolve' => function ($root, array $args) {

                    /** @var UploadedFileInterface $file */
                    $file = $args['file'];
                    $this->assertInstanceOf(UploadedFileInterface::class, $file);

                    // Do something more interesting with the file
                    // $file->moveTo('some/folder/in/my/project');

                    return 'Uploaded file was ' . $file->getClientFilename() . ' (' . $file->getClientMediaType() . ') with description: ' . $args['text'];
                },
            ],

        ],
    ]),
]);

$server = new StandardServer([
    'schema' => $schema,
]);

$response = $server->executePsrRequest($request);

```

On the implementation side of things, I would need advice on how to properly test `\GraphQL\Type\Definition\FileType`. For now we have `\GraphQL\Tests\Executor\UploadTest` which is more or less a functionnal tests for the entire stack. It's nice and working, but it only test a single case. It might be best to have unit tests covering only `FileType`, with more different cases, but I could not find anything similar. Would you have any recommendations about that ? where and how it should be done ?
 
Like I mentionned it includes PR #218, because at this point it would probably not be wise to parse uploaded file ourselves. But I suppose I could rebase without #218 if that's a problem for you.
 
It should be a solution for #178 (and https://github.com/Folkloreatelier/laravel-graphql/issues/125)

I'll write some docs, once we agree on the code.




