### PR TITLE
Fix Standard Server PSR request parsing

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -482,9 +482,9 @@ class Helper
                 throw new RequestError('Missing "Content-Type" header');
             }
 
-            if (stripos('application/graphql', $contentType[0]) !== false) {
+            if (stripos($contentType[0], 'application/graphql') !== false) {
                 $bodyParams = ['query' => $request->getBody()->getContents()];
-            } else if (stripos('application/json', $contentType[0]) !== false) {
+            } else if (stripos($contentType[0], 'application/json') !== false) {
                 $bodyParams = $request->getParsedBody();
 
                 if (null === $bodyParams) {


### PR DESCRIPTION
Sending PSR request to GraphQL Standard server doesn't work.

```php
/** @var ExecutionResult|ExecutionResult[] $result */
$result = $server->executePsrRequest($psrRequest);
```

This ends with following error.

> GraphQL Request must include at least one of those two parameters: "query" or "queryId".

Caused by bug in request's content-type matching.