### PR TITLE
[WIP][0.13] Separate multiple inherited interfaces with `&`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -696,6 +696,14 @@ Parses string containing GraphQL query or [type definition](type-system/type-lan
  * (By default, the parser creates AST nodes that know the location
  * in the source that they correspond to. This configuration flag
  * disables that behavior for performance or testing.)
+ * 
+ * allowLegacySDLImplementsInterfaces: boolean,
+ * (If enabled, the parser will parse implemented interfaces with no `&`
+ * character between each interface. Otherwise, the parser will follow the
+ * current specification.
+ * 
+ * This option is provided to ease adoption of the final SDL specification
+ * and will be removed in a future major release.)
  *
  * @api
  * @param Source|string $source

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -150,6 +150,8 @@ class Lexer
                 return $this->readComment($line, $col, $prev);
             case 36: // $
                 return new Token(Token::DOLLAR, $position, $position + 1, $line, $col, $prev);
+            case 38: // &
+                return new Token(Token::AMP, $position, $position + 1, $line, $col, $prev);
             case 40: // (
                 return new Token(Token::PAREN_L, $position, $position + 1, $line, $col, $prev);
             case 41: // )

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -58,6 +58,14 @@ class Parser
      * (By default, the parser creates AST nodes that know the location
      * in the source that they correspond to. This configuration flag
      * disables that behavior for performance or testing.)
+     * 
+     * allowLegacySDLImplementsInterfaces: boolean,
+     * (If enabled, the parser will parse implemented interfaces with no `&`
+     * character between each interface. Otherwise, the parser will follow the
+     * current specification.
+     * 
+     * This option is provided to ease adoption of the final SDL specification
+     * and will be removed in a future major release.)
      *
      * @api
      * @param Source|string $source
@@ -966,9 +974,19 @@ class Parser
         $types = [];
         if ($this->lexer->token->value === 'implements') {
             $this->lexer->advance();
+            // Optional leading ampersand
+            $this->skip(Token::AMP);
             do {
                 $types[] = $this->parseNamedType();
-            } while ($this->peek(Token::NAME));
+            } while (
+                $this->skip(Token::AMP) ||
+                // Legacy support for the SDL?
+                (
+                    isset($this->lexer->options['allowLegacySDLImplementsInterfaces']) &&
+                    $this->peek(Token::NAME)
+                )
+                
+            );
         }
         return $types;
     }

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -195,7 +195,7 @@ class Printer
                     return $this->join([
                         'type',
                         $def->name,
-                        $this->wrap('implements ', $this->join($def->interfaces, ', ')),
+                        $this->wrap('implements ', $this->join($def->interfaces, ' & ')),
                         $this->join($def->directives, ' '),
                         $this->block($def->fields)
                     ], ' ');

--- a/src/Language/Token.php
+++ b/src/Language/Token.php
@@ -12,6 +12,7 @@ class Token
     const EOF = '<EOF>';
     const BANG = '!';
     const DOLLAR = '$';
+    const AMP = '&';
     const PAREN_L = '(';
     const PAREN_R = ')';
     const SPREAD = '...';
@@ -42,6 +43,7 @@ class Token
         $description[self::EOF] = '<EOF>';
         $description[self::BANG] = '!';
         $description[self::DOLLAR] = '$';
+        $description[self::AMP] = '&';
         $description[self::PAREN_L] = '(';
         $description[self::PAREN_R] = ')';
         $description[self::SPREAD] = '...';

--- a/tests/Language/SchemaPrinterTest.php
+++ b/tests/Language/SchemaPrinterTest.php
@@ -56,7 +56,7 @@ class SchemaPrinterTest extends \PHPUnit_Framework_TestCase
   mutation: MutationType
 }
 
-type Foo implements Bar {
+type Foo implements Bar & Baz {
   one: Type
   two(argument: InputType!): Type
   three(argument: InputType, other: String): Int

--- a/tests/Language/schema-kitchen-sink.graphql
+++ b/tests/Language/schema-kitchen-sink.graphql
@@ -10,7 +10,7 @@ schema {
   mutation: MutationType
 }
 
-type Foo implements Bar {
+type Foo implements Bar & Baz {
   one: Type
   two(argument: InputType!): Type
   three(argument: InputType, other: String): Int


### PR DESCRIPTION
> This replaces:
> 
> ```graphql
> type Foo implements Bar, Baz { field: Type }
> ```
> 
> With:
> 
> ```graphql
> type Foo implements Bar & Baz { field: Type }
> ```
> 
> With no changes to the common case of implementing a single interface.
> 
> This is a breaking change for existing uses of multiple inheritence. To allow for an adaptive migration, this adds a parse option to continue to support the existing experimental SDL: `parse(source, {allowLegacySDLImplementsInterfaces: true})`

Ref: graphql/graphql-js#1169