### PR TITLE
[0.12] Fix parsing of default values in build-schema

### DIFF
--- a/examples/01-blog/Blog/Type/Scalar/UrlType.php
+++ b/examples/01-blog/Blog/Type/Scalar/UrlType.php
@@ -42,20 +42,21 @@ class UrlType extends ScalarType
     /**
      * Parses an externally provided literal value to use as an input (e.g. in Query AST)
      *
-     * @param $ast Node
+     * @param Node $valueNode
+     * @param array|null $variables
      * @return null|string
      * @throws Error
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
         // Note: throwing GraphQL\Error\Error vs \UnexpectedValueException to benefit from GraphQL
         // error location in query:
-        if (!($ast instanceof StringValueNode)) {
-            throw new Error('Query error: Can only parse strings got: ' . $ast->kind, [$ast]);
+        if (!($valueNode instanceof StringValueNode)) {
+            throw new Error('Query error: Can only parse strings got: ' . $valueNode->kind, [$valueNode]);
         }
-        if (!is_string($ast->value) || !filter_var($ast->value, FILTER_VALIDATE_URL)) {
-            throw new Error('Query error: Not a valid URL', [$ast]);
+        if (!is_string($valueNode->value) || !filter_var($valueNode->value, FILTER_VALIDATE_URL)) {
+            throw new Error('Query error: Not a valid URL', [$valueNode]);
         }
-        return $ast->value;
+        return $valueNode->value;
     }
 }

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -1194,7 +1194,7 @@ class Executor
     {
         $serializedResult = $returnType->serialize($result);
 
-        if ($serializedResult === null) {
+        if (Utils::isInvalid($serializedResult)) {
             throw new InvariantViolation(
                 'Expected a value of type "'. Utils::printSafe($returnType) . '" but received: ' . Utils::printSafe($result)
             );

--- a/src/Language/AST/ListValueNode.php
+++ b/src/Language/AST/ListValueNode.php
@@ -7,7 +7,7 @@ class ListValueNode extends Node implements ValueNode
     public $kind = NodeKind::LST;
 
     /**
-     * @var ValueNode[]
+     * @var ValueNode[]|NodeList
      */
     public $values;
 }

--- a/src/Language/AST/ObjectValueNode.php
+++ b/src/Language/AST/ObjectValueNode.php
@@ -6,7 +6,7 @@ class ObjectValueNode extends Node implements ValueNode
     public $kind = NodeKind::OBJECT;
 
     /**
-     * @var ObjectFieldNode[]
+     * @var ObjectFieldNode[]|NodeList
      */
     public $fields;
 }

--- a/src/Type/Definition/BooleanType.php
+++ b/src/Type/Definition/BooleanType.php
@@ -2,6 +2,7 @@
 namespace GraphQL\Type\Definition;
 
 use GraphQL\Language\AST\BooleanValueNode;
+use GraphQL\Utils\Utils;
 
 /**
  * Class BooleanType
@@ -34,18 +35,19 @@ class BooleanType extends ScalarType
      */
     public function parseValue($value)
     {
-        return is_bool($value) ? $value : null;
+        return is_bool($value) ? $value : Utils::undefined();
     }
 
     /**
-     * @param $ast
+     * @param $valueNode
+     * @param array|null $variables
      * @return bool|null
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
-        if ($ast instanceof BooleanValueNode) {
-            return (bool) $ast->value;
+        if ($valueNode instanceof BooleanValueNode) {
+            return (bool) $valueNode->value;
         }
-        return null;
+        return Utils::undefined();
     }
 }

--- a/src/Type/Definition/CustomScalarType.php
+++ b/src/Type/Definition/CustomScalarType.php
@@ -1,6 +1,7 @@
 <?php
 namespace GraphQL\Type\Definition;
 
+use GraphQL\Utils\AST;
 use GraphQL\Utils\Utils;
 
 /**
@@ -24,23 +25,28 @@ class CustomScalarType extends ScalarType
      */
     public function parseValue($value)
     {
+        if (Utils::isInvalid($value)) {
+            return Utils::undefined();
+        }
+
         if (isset($this->config['parseValue'])) {
             return call_user_func($this->config['parseValue'], $value);
         } else {
-            return null;
+            return $value;
         }
     }
 
     /**
      * @param $valueNode
+     * @param array|null $variables
      * @return mixed
      */
-    public function parseLiteral(/* GraphQL\Language\AST\ValueNode */ $valueNode)
+    public function parseLiteral(/* GraphQL\Language\AST\ValueNode */ $valueNode, array $variables = null)
     {
         if (isset($this->config['parseLiteral'])) {
-            return call_user_func($this->config['parseLiteral'], $valueNode);
+            return call_user_func($this->config['parseLiteral'], $valueNode, $variables);
         } else {
-            return null;
+            return AST::valueFromASTUntyped($valueNode, $variables);
         }
     }
 

--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -122,9 +122,10 @@ class EnumType extends Type implements InputType, OutputType, LeafType
 
     /**
      * @param $valueNode
+     * @param array|null $variables
      * @return bool
      */
-    public function isValidLiteral($valueNode)
+    public function isValidLiteral($valueNode, array $variables = null)
     {
         return $valueNode instanceof EnumValueNode && $this->getNameLookup()->offsetExists($valueNode->value);
     }
@@ -136,14 +137,15 @@ class EnumType extends Type implements InputType, OutputType, LeafType
     public function parseValue($value)
     {
         $lookup = $this->getNameLookup();
-        return isset($lookup[$value]) ? $lookup[$value]->value : null;
+        return isset($lookup[$value]) ? $lookup[$value]->value : Utils::undefined();
     }
 
     /**
      * @param $value
+     * @param array|null $variables
      * @return null
      */
-    public function parseLiteral($value)
+    public function parseLiteral($value, array $variables = null)
     {
         if ($value instanceof EnumValueNode) {
             $lookup = $this->getNameLookup();

--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -108,7 +108,11 @@ class EnumType extends Type implements InputType, OutputType, LeafType
     public function serialize($value)
     {
         $lookup = $this->getValueLookup();
-        return isset($lookup[$value]) ? $lookup[$value]->name : null;
+        if (isset($lookup[$value])) {
+            return $lookup[$value]->name;
+        }
+
+        return Utils::undefined();
     }
 
     /**

--- a/src/Type/Definition/FloatType.php
+++ b/src/Type/Definition/FloatType.php
@@ -1,7 +1,6 @@
 <?php
 namespace GraphQL\Type\Definition;
 
-use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\FloatValueNode;
 use GraphQL\Language\AST\IntValueNode;
@@ -50,18 +49,19 @@ values as specified by
      */
     public function parseValue($value)
     {
-        return (is_numeric($value) && !is_string($value)) ? (float) $value : null;
+        return (is_numeric($value) && !is_string($value)) ? (float) $value : Utils::undefined();
     }
 
     /**
-     * @param $ast
+     * @param $valueNode
+     * @param array|null $variables
      * @return float|null
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
-        if ($ast instanceof FloatValueNode || $ast instanceof IntValueNode) {
-            return (float) $ast->value;
+        if ($valueNode instanceof FloatValueNode || $valueNode instanceof IntValueNode) {
+            return (float) $valueNode->value;
         }
-        return null;
+        return Utils::undefined();
     }
 }

--- a/src/Type/Definition/IDType.php
+++ b/src/Type/Definition/IDType.php
@@ -1,7 +1,6 @@
 <?php
 namespace GraphQL\Type\Definition;
 
-use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\IntValueNode;
 use GraphQL\Language\AST\StringValueNode;
@@ -55,18 +54,19 @@ When expected as an input type, any string (such as `"4"`) or integer
      */
     public function parseValue($value)
     {
-        return (is_string($value) || is_int($value)) ? (string) $value : null;
+        return (is_string($value) || is_int($value)) ? (string) $value : Utils::undefined();
     }
 
     /**
      * @param $ast
+     * @param array|null $variables
      * @return null|string
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
-        if ($ast instanceof StringValueNode || $ast instanceof IntValueNode) {
-            return $ast->value;
+        if ($valueNode instanceof StringValueNode || $valueNode instanceof IntValueNode) {
+            return $valueNode->value;
         }
-        return null;
+        return Utils::undefined();
     }
 }

--- a/src/Type/Definition/IntType.php
+++ b/src/Type/Definition/IntType.php
@@ -1,7 +1,6 @@
 <?php
 namespace GraphQL\Type\Definition;
 
-use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\IntValueNode;
 use GraphQL\Utils\Utils;
@@ -77,21 +76,22 @@ values. Int can represent values between -(2^31) and 2^31 - 1. ';
         // Below is a fix against PHP bug where (in some combinations of OSs and versions)
         // boundary values are treated as "double" vs "integer" and failing is_int() check
         $isInt = is_int($value) || $value === self::MIN_INT || $value === self::MAX_INT;
-        return $isInt && $value <= self::MAX_INT && $value >= self::MIN_INT ? $value : null;
+        return $isInt && $value <= self::MAX_INT && $value >= self::MIN_INT ? $value : Utils::undefined();
     }
 
     /**
-     * @param $ast
+     * @param $valueNode
+     * @param array|null $variables
      * @return int|null
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
-        if ($ast instanceof IntValueNode) {
-            $val = (int) $ast->value;
-            if ($ast->value === (string) $val && self::MIN_INT <= $val && $val <= self::MAX_INT) {
+        if ($valueNode instanceof IntValueNode) {
+            $val = (int) $valueNode->value;
+            if ($valueNode->value === (string) $val && self::MIN_INT <= $val && $val <= self::MAX_INT) {
                 return $val;
             }
         }
-        return null;
+        return Utils::undefined();
     }
 }

--- a/src/Type/Definition/LeafType.php
+++ b/src/Type/Definition/LeafType.php
@@ -1,6 +1,8 @@
 <?php
 namespace GraphQL\Type\Definition;
 
+use \GraphQL\Language\AST\Node;
+
 /*
 export type GraphQLLeafType =
 GraphQLScalarType |
@@ -19,6 +21,8 @@ interface LeafType
     /**
      * Parses an externally provided value (query variable) to use as an input
      *
+     * In the case of an invalid value this method must return Utils::undefined()
+     *
      * @param mixed $value
      * @return mixed
      */
@@ -27,10 +31,13 @@ interface LeafType
     /**
      * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input
      *
-     * @param \GraphQL\Language\AST\Node $valueNode
+     * In the case of an invalid value this method must return Utils::undefined()
+     *
+     * @param Node $valueNode
+     * @param array|null $variables
      * @return mixed
      */
-    public function parseLiteral($valueNode);
+    public function parseLiteral($valueNode, array $variables = null);
 
     /**
      * @param string $value
@@ -39,8 +46,9 @@ interface LeafType
     public function isValidValue($value);
 
     /**
-     * @param \GraphQL\Language\AST\Node $valueNode
-     * @return mixed
+     * @param Node $valueNode
+     * @param array|null $variables
+     * @return bool
      */
-    public function isValidLiteral($valueNode);
+    public function isValidLiteral($valueNode, array $variables = null);
 }

--- a/src/Type/Definition/ScalarType.php
+++ b/src/Type/Definition/ScalarType.php
@@ -41,14 +41,13 @@ abstract class ScalarType extends Type implements OutputType, InputType, LeafTyp
 
     /**
      * Determines if an internal value is valid for this type.
-     * Equivalent to checking for if the parsedValue is nullish.
      *
      * @param $value
      * @return bool
      */
     public function isValidValue($value)
     {
-        return null !== $this->parseValue($value);
+        return !Utils::isInvalid($this->parseValue($value));
     }
 
     /**
@@ -56,10 +55,11 @@ abstract class ScalarType extends Type implements OutputType, InputType, LeafTyp
      * Equivalent to checking for if the parsedLiteral is nullish.
      *
      * @param $valueNode
+     * @param array|null $variables
      * @return bool
      */
-    public function isValidLiteral($valueNode)
+    public function isValidLiteral($valueNode, array $variables = null)
     {
-        return null !== $this->parseLiteral($valueNode);
+        return !Utils::isInvalid($this->parseLiteral($valueNode, $variables));
     }
 }

--- a/src/Type/Definition/StringType.php
+++ b/src/Type/Definition/StringType.php
@@ -1,7 +1,6 @@
 <?php
 namespace GraphQL\Type\Definition;
 
-use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Utils\Utils;
@@ -52,18 +51,19 @@ represent free-form human-readable text.';
      */
     public function parseValue($value)
     {
-        return is_string($value) ? $value : null;
+        return is_string($value) ? $value : Utils::undefined();
     }
 
     /**
-     * @param $ast
+     * @param $valueNode
+     * @param array|null $variables
      * @return null|string
      */
-    public function parseLiteral($ast)
+    public function parseLiteral($valueNode, array $variables = null)
     {
-        if ($ast instanceof StringValueNode) {
-            return $ast->value;
+        if ($valueNode instanceof StringValueNode) {
+            return $valueNode->value;
         }
-        return null;
+        return Utils::undefined();
     }
 }

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -205,15 +205,15 @@ class AST
             return new ObjectValueNode(['fields' => $fieldNodes]);
         }
 
+        Utils::invariant(
+            $type instanceof ScalarType || $type instanceof EnumType,
+            "Must provide Input Type, cannot use: " . Utils::printSafe($type)
+        );
+
         // Since value is an internally represented value, it must be serialized
         // to an externally represented value before converting into an AST.
-        if ($type instanceof LeafType) {
-            $serialized = $type->serialize($value);
-        } else {
-            throw new InvariantViolation("Must provide Input Type, cannot use: " . Utils::printSafe($type));
-        }
-
-        if (null === $serialized) {
+        $serialized = $type->serialize($value);
+        if (null === $serialized || Utils::isInvalid($serialized)) {
             return null;
         }
 

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -30,9 +30,9 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\LeafType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
-use GraphQL\Utils\Utils;
 
 /**
  * Various utilities dealing with AST
@@ -383,19 +383,77 @@ class AST
             return $coercedObj;
         }
 
-        if ($type instanceof LeafType) {
-            $parsed = $type->parseLiteral($valueNode);
-
-            if (null === $parsed && !$type->isValidLiteral($valueNode)) {
-                // Invalid values represent a failure to parse correctly, in which case
-                // no value is returned.
-                return $undefined;
-            }
-
-            return $parsed;
+        if (!$type instanceof ScalarType && !$type instanceof EnumType) {
+            throw new InvariantViolation('Must be input type');
         }
 
-        throw new InvariantViolation('Must be input type');
+        if ($type->isValidLiteral($valueNode, $variables)) {
+            return $type->parseLiteral($valueNode, $variables);
+        }
+
+        return $undefined;
+    }
+
+    /**
+     * Produces a PHP value given a GraphQL Value AST.
+     *
+     * Unlike `valueFromAST()`, no type is provided. The resulting JavaScript value
+     * will reflect the provided GraphQL value AST.
+     *
+     * | GraphQL Value        | PHP Value     |
+     * | -------------------- | ------------- |
+     * | Input Object         | Assoc Array   |
+     * | List                 | Array         |
+     * | Boolean              | Boolean       |
+     * | String               | String        |
+     * | Int / Float          | Int / Float   |
+     * | Enum                 | Mixed         |
+     * | Null                 | null          |
+     *
+     * @api
+     * @param Node $valueNode
+     * @param array|null $variables
+     * @return mixed
+     * @throws \Exception
+     */
+    public static function valueFromASTUntyped($valueNode, array $variables = null) {
+        switch (true) {
+            case $valueNode instanceof NullValueNode:
+                return null;
+            case $valueNode instanceof IntValueNode:
+                return intval($valueNode->value, 10);
+            case $valueNode instanceof FloatValueNode:
+                return floatval($valueNode->value);
+            case $valueNode instanceof StringValueNode:
+            case $valueNode instanceof EnumValueNode:
+            case $valueNode instanceof BooleanValueNode:
+                return $valueNode->value;
+            case $valueNode instanceof ListValueNode:
+                return array_map(
+                    function($node) use ($variables) {
+                        return self::valueFromASTUntyped($node, $variables);
+                    },
+                    iterator_to_array($valueNode->values)
+                );
+            case $valueNode instanceof ObjectValueNode:
+              return array_combine(
+                array_map(
+                    function($field) { return $field->name->value; },
+                    iterator_to_array($valueNode->fields)
+                ),
+                array_map(
+                    function($field) use ($variables) { return self::valueFromASTUntyped($field->value, $variables); },
+                    iterator_to_array($valueNode->fields)
+                )
+              );
+            case $valueNode instanceof VariableNode:
+                $variableName = $valueNode->name->value;
+                return ($variables && isset($variables[$variableName]) && !Utils::isInvalid($variables[$variableName]))
+                    ? $variables[$variableName]
+                    : null;
+            default:
+                throw new InvariantViolation('Unexpected value kind: ' . $valueNode->kind);
+          }
     }
 
     /**

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -41,7 +41,7 @@ class BuildSchema
     /**
      * @param Type $innerType
      * @param TypeNode $inputTypeNode
-     * @return Type 
+     * @return Type
      */
     private function buildWrappedType(Type $innerType, TypeNode $inputTypeNode)
     {
@@ -99,7 +99,7 @@ class BuildSchema
         $this->typeConfigDecorator = $typeConfigDecorator;
         $this->loadedTypeDefs = [];
     }
-    
+
     public function buildSchema()
     {
         $schemaDef = null;
@@ -544,19 +544,9 @@ class BuildSchema
             'name' => $def->name->value,
             'description' => $this->getDescription($def),
             'astNode' => $def,
-            'serialize' => function() {
-                return false;
+            'serialize' => function($value) {
+                return $value;
             },
-            // Note: validation calls the parse functions to determine if a
-            // literal value is correct. Returning null would cause use of custom
-            // scalars to always fail validation. Returning false causes them to
-            // always pass validation.
-            'parseValue' => function() {
-                return false;
-            },
-            'parseLiteral' => function() {
-                return false;
-            }
         ];
     }
 
@@ -619,7 +609,7 @@ class BuildSchema
     /**
      * A helper function to build a GraphQLSchema directly from a source
      * document.
-     * 
+     *
      * @api
      * @param DocumentNode|Source|string $source
      * @param callable $typeConfigDecorator

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -16,11 +16,22 @@ class Utils
     }
 
     /**
+     * Check if the value is invalid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public static function isInvalid($value)
+    {
+        return self::undefined() === $value;
+    }
+
+    /**
      * @param object $obj
      * @param array  $vars
      * @param array  $requiredKeys
      *
-     * @return array
+     * @return object
      */
     public static function assign($obj, array $vars, array $requiredKeys = [])
     {

--- a/tests/Executor/TestClasses.php
+++ b/tests/Executor/TestClasses.php
@@ -2,6 +2,7 @@
 namespace GraphQL\Tests\Executor;
 
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
 
 class Dog
 {
@@ -65,15 +66,15 @@ class ComplexScalar extends ScalarType
         if ($value === 'SerializedValue') {
             return 'DeserializedValue';
         }
-        return null;
+        return Utils::undefined();
     }
 
-    public function parseLiteral($valueNode)
+    public function parseLiteral($valueNode, array $variables = null)
     {
         if ($valueNode->value === 'SerializedValue') {
             return 'DeserializedValue';
         }
-        return null;
+        return Utils::undefined();
     }
 }
 

--- a/tests/Utils/AstFromValueUntypedTest.php
+++ b/tests/Utils/AstFromValueUntypedTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace GraphQL\Tests\Utils;
+
+use GraphQL\Language\Parser;
+use GraphQL\Utils\AST;
+
+class ASTFromValueUntypedTest extends \PHPUnit_Framework_TestCase
+{
+    // Describe: valueFromASTUntyped
+
+    private function assertTestCase($valueText, $expected, array $variables = null) {
+        $this->assertEquals(
+            $expected,
+            AST::valueFromASTUntyped(Parser::parseValue($valueText), $variables)
+        );
+    }
+
+    /**
+     * @it parses simple values
+     */
+    public function testParsesSimpleValues()
+    {
+        $this->assertTestCase('null', null);
+        $this->assertTestCase('true', true);
+        $this->assertTestCase('false', false);
+        $this->assertTestCase('123', 123);
+        $this->assertTestCase('123.456', 123.456);
+        $this->assertTestCase('abc123', 'abc123');
+    }
+
+    /**
+     * @it parses lists of values
+     */
+    public function testParsesListsOfValues()
+    {
+        $this->assertTestCase('[true, false]', [true, false]);
+        $this->assertTestCase('[true, 123.45]', [true, 123.45]);
+        $this->assertTestCase('[true, null]', [true, null]);
+        $this->assertTestCase('[true, ["foo", 1.2]]', [true, ['foo', 1.2]]);
+    }
+
+    /**
+     * @it parses input objects
+     */
+    public function testParsesInputObjects()
+    {
+        $this->assertTestCase(
+            '{ int: 123, bool: false }',
+            ['int' => 123, 'bool' => false]
+        );
+
+        $this->assertTestCase(
+            '{ foo: [ { bar: "baz"} ] }',
+            ['foo' => [['bar' => 'baz']]]
+        );
+    }
+
+    /**
+     * @it parses enum values as plain strings
+     */
+    public function testParsesEnumValuesAsPlainStrings()
+    {
+        $this->assertTestCase(
+            'TEST_ENUM_VALUE',
+            'TEST_ENUM_VALUE'
+        );
+
+        $this->assertTestCase(
+            '[TEST_ENUM_VALUE]',
+            ['TEST_ENUM_VALUE']
+        );
+    }
+
+    /**
+     * @it parses enum values as plain strings
+     */
+    public function testParsesVariables()
+    {
+        $this->assertTestCase(
+            '$testVariable',
+            'foo',
+            ['testVariable' => 'foo']
+        );
+        $this->assertTestCase(
+            '[$testVariable]',
+            ['foo'],
+            ['testVariable' => 'foo']
+        );
+        $this->assertTestCase(
+            '{a:[$testVariable]}',
+            ['a' => ['foo']],
+            ['testVariable' => 'foo']
+        );
+        $this->assertTestCase(
+            '$testVariable',
+            null,
+            ['testVariable' => null]
+        );
+        $this->assertTestCase(
+            '$testVariable',
+            null,
+            []
+        );
+        $this->assertTestCase(
+            '$testVariable',
+            null,
+            null
+        );
+    }
+}

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -35,7 +35,7 @@ class BuildSchemaTest extends \PHPUnit_Framework_TestCase
                 str: String
             }
         '));
-        
+
         $result = GraphQL::execute($schema, '{ str }', ['str' => 123]);
         $this->assertEquals($result['data'], ['str' => 123]);
     }
@@ -465,6 +465,26 @@ schema {
 
 type Hello {
   str(int: Int = 2): String
+}
+';
+        $output = $this->cycleOutput($body);
+        $this->assertEquals($output, $body);
+    }
+
+    /**
+     * @it Custom scalar argument field with default
+     */
+    public function testCustomScalarArgumentFieldWithDefault()
+    {
+        $body = '
+schema {
+  query: Hello
+}
+
+scalar CustomScalar
+
+type Hello {
+  str(int: CustomScalar = 2): String
 }
 ';
         $output = $this->cycleOutput($body);


### PR DESCRIPTION
 * Generalizes building a value from an AST, since "scalar" could be misleading, and supporting variable values within custom scalar literals can be valuable.
* Replaces isNullish with isInvalid since `null` is a meaningful value as a result of literal parsing.
* Provide reasonable default version of 'parseLiteral'

ref: https://github.com/graphql/graphql-js/commit/714ee980aa17a4de42013d49a9839d43493d109e
ref: https://github.com/graphql/graphql-js/pull/903

BREAKING CHANGE: `parseLiteral()` and `parseValue()` in custom types now need to return `Utils::undefined()` or throw instead of `null` if the value/literal is invalid. Null is considered a valid value.