### PR TITLE
Fix node list iterator to check for offsets before accessing it becau…

### DIFF
--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -107,7 +107,9 @@ class NodeList implements \ArrayAccess, \IteratorAggregate, \Countable
     {
         $count = count($this->nodes);
         for ($i = 0; $i < $count; $i++) {
-            yield $this->offsetGet($i);
+            if ($this->offsetExists($i)) {
+                yield $this->offsetGet($i);
+            }
         }
     }
 


### PR DESCRIPTION
Fix node list iterator to check for offsets before accessing it because offsets can be unset by a public method of this class per \ArrayAccess interface