### PR TITLE
Fix lost description in BuildSchema

### DIFF
--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -589,6 +589,10 @@ class BuildSchema
      */
     public function getDescription($node)
     {
+	    if (property_exists($node, 'description')) {
+		    return $node->description;
+	    }
+
         $loc = $node->loc;
         if (!$loc || !$loc->startToken) {
             return ;


### PR DESCRIPTION
Right now description get lost when calling:

```php
$source = AST::fromArray($array);
$schema = BuildSchema::build($source);
```

Mentioned in issues #201 and #88.