### PR TITLE
Parse operation name from operationName instead of operation

### DIFF
--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -67,7 +67,7 @@ class OperationParams
             'queryid' => null,
             'documentid' => null, // alias to queryid
             'id' => null, // alias to queryid
-            'operation' => null,
+            'operationname' => null,
             'variables' => null
         ];
 
@@ -84,7 +84,7 @@ class OperationParams
 
         $instance->query = $params['query'];
         $instance->queryId = $params['queryid'] ?: $params['documentid'] ?: $params['id'];
-        $instance->operation = $params['operation'];
+        $instance->operation = $params['operationname'];
         $instance->variables = $params['variables'];
         $instance->readOnly = (bool) $readonly;
 

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -34,7 +34,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $post = [
             'query' => $query,
             'variables' => $variables,
-            'operation' => $operation
+            'operationName' => $operation
         ];
         $parsed = [
             'raw' => $this->parseRawFormUrlencodedRequest($post),
@@ -56,7 +56,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $get = [
             'query' => $query,
             'variables' => $variables,
-            'operation' => $operation
+            'operationName' => $operation
         ];
         $parsed = [
             'raw' => $this->parseRawGetRequest($get),
@@ -78,7 +78,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $body = [
             'query' => $query,
             'variables' => $variables,
-            'operation' => $operation
+            'operationName' => $operation
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
@@ -99,7 +99,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $body = [
             'query' => $query,
             'variables' => json_encode($variables),
-            'operation' => $operation
+            'operationName' => $operation
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
@@ -120,7 +120,7 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         $body = [
             'query' => $query,
             'variables' => $variables,
-            'operation' => $operation
+            'operationName' => $operation
         ];
         $parsed = [
             'raw' => $this->parseRawRequest('application/json', json_encode($body)),
@@ -138,12 +138,12 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
             [
                 'query' => '{my query}',
                 'variables' => ['test' => 1, 'test2' => 2],
-                'operation' => 'op'
+                'operationName' => 'op'
             ],
             [
                 'queryId' => 'my-query-id',
                 'variables' => ['test' => 1, 'test2' => 2],
-                'operation' => 'op2'
+                'operationName' => 'op2'
             ],
         ];
         $parsed = [
@@ -153,8 +153,8 @@ class RequestParsingTest extends \PHPUnit_Framework_TestCase
         foreach ($parsed as $method => $parsedBody) {
             $this->assertInternalType('array', $parsedBody, $method);
             $this->assertCount(2, $parsedBody, $method);
-            $this->assertValidOperationParams($parsedBody[0], $body[0]['query'], null, $body[0]['variables'], $body[0]['operation'], $method);
-            $this->assertValidOperationParams($parsedBody[1], null, $body[1]['queryId'], $body[1]['variables'], $body[1]['operation'], $method);
+            $this->assertValidOperationParams($parsedBody[0], $body[0]['query'], null, $body[0]['variables'], $body[0]['operationName'], $method);
+            $this->assertValidOperationParams($parsedBody[1], null, $body[1]['queryId'], $body[1]['variables'], $body[1]['operationName'], $method);
         }
     }
 

--- a/tests/Server/RequestValidationTest.php
+++ b/tests/Server/RequestValidationTest.php
@@ -15,7 +15,7 @@ class RequestValidationTest extends \PHPUnit_Framework_TestCase
         $parsedBody = OperationParams::create([
             'query' => $query,
             'variables' => $variables,
-            'operation' => $operation,
+            'operationName' => $operation,
         ]);
 
         $this->assertValid($parsedBody);
@@ -30,7 +30,7 @@ class RequestValidationTest extends \PHPUnit_Framework_TestCase
         $parsedBody = OperationParams::create([
             'queryId' => $queryId,
             'variables' => $variables,
-            'operation' => $operation,
+            'operationName' => $operation,
         ]);
 
         $this->assertValid($parsedBody);
@@ -40,7 +40,7 @@ class RequestValidationTest extends \PHPUnit_Framework_TestCase
     {
         $parsedBody = OperationParams::create([
             'variables' => ['foo' => 'bar'],
-            'operation' => 'op',
+            'operationName' => 'op',
         ]);
 
         $this->assertInputError(
@@ -90,7 +90,7 @@ class RequestValidationTest extends \PHPUnit_Framework_TestCase
     {
         $parsedBody = OperationParams::create([
             'query' => '{my query}',
-            'operation' => []
+            'operationName' => []
         ]);
 
         $this->assertInputError(

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -57,6 +57,23 @@ class StandardServerTest extends TestCase
         $this->assertPsrRequestEquals($expected, $request);
     }
 
+    public function testMultipleOperationPsrRequestExecution()
+    {
+        $body = [
+            'query' => 'query firstOp {fieldWithPhpError} query secondOp {f1}',
+            'operationName' => 'secondOp'
+        ];
+
+        $expected = [
+            'data' => [
+                'f1' => 'f1'
+            ]
+        ];
+
+        $request = $this->preparePsrRequest('application/json', $body);
+        $this->assertPsrRequestEquals($expected, $request);
+    }
+
     private function executePsrRequest($psrRequest)
     {
         $server = new StandardServer($this->config);


### PR DESCRIPTION
The operation name in `OperationParams` is attempting to pull from `operation` instead of `operationName`. Because of this, applications leveraging the `StandardServer` cannot handle a request with multiple operations (it returns an error saying the operation name is required).

In this PR, I only updated the way the class parses the data on the `create` function, to avoid changing the API. It might be good, however, if you are okay with it, to mark `operation` as deprecated and add a new `operationName` property on the class instead, such that `operation` can be removed on the next major version bump. 