### PR TITLE
Fix Symfony PSR7 link

### DIFF
--- a/docs/executing-queries.md
+++ b/docs/executing-queries.md
@@ -87,7 +87,7 @@ $psrResponse = new SomePsr7ResponseImplementation(json_encode($result));
 PSR-7 is useful when you want to integrate the server into existing framework:
 
 - [PSR-7 for Laravel](https://laravel.com/docs/5.1/requests#psr7-requests)
-- [Symfony PSR-7 Bridge](https://symfony.com/doc/current/request/psr7.html)
+- [Symfony PSR-7 Bridge](https://symfony.com/doc/current/components/psr7.html)
 - [Slim](https://www.slimframework.com/docs/concepts/value-objects.html)
 - [Zend Expressive](http://zendframework.github.io/zend-expressive/)
 


### PR DESCRIPTION
Hi

Previous URL no longer exist and return a 404.
I've update the url to https://symfony.com/doc/current/components/psr7.html

Thanks