### PR TITLE
Drop support for EOL PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 
-# Required for HHVM, see https://github.com/travis-ci/travis-ci/issues/7712
 dist: trusty
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
+    - 7.2
     - nightly
 
 matrix:
@@ -20,7 +18,8 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
-    - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "5.6" ]]; then phpenv config-rm xdebug.ini || true; fi
+    - phpenv config-rm xdebug.ini || true
     - composer selfupdate
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "API"
   ],
   "require": {
-    "php": ">=5.5,<8.0-DEV",
+    "php": ">=5.6",
     "ext-mbstring": "*"
   },
   "require-dev": {
@@ -17,8 +17,13 @@
     "psr/http-message": "^1.0"
   },
   "config": {
-    "bin-dir": "bin"
-  },
+    "bin-dir": "bin",
+    "platform": {
+      "php": "5.6.0"
+    },
+    "preferred-install": "dist",
+    "sort-packages": true
+},
   "autoload": {
     "files": ["src/deprecated.php"],
     "psr-4": {


### PR DESCRIPTION
Support only current versions of php so we can leverage modern language features

http://php.net/supported-versions.php