### PR TITLE
Resolve ambiguous `null` interpretation with regards to `defaultValue`s

### DIFF
--- a/tests/Executor/VariablesTest.php
+++ b/tests/Executor/VariablesTest.php
@@ -853,6 +853,36 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @it when null value variable provided
+     */
+    public function testWhenNullValueVariableProvided()
+    {
+        $ast = Parser::parse('query optionalVariable($optional: String) {
+            fieldWithDefaultArgumentValue(input: $optional)
+        }');
+
+        $this->assertEquals(
+            ['data' => ['fieldWithDefaultArgumentValue' => '"Hello World"']],
+            Executor::execute($this->schema(), $ast, null, null, ['optional' => null])->toArray()
+        );
+    }
+
+    /**
+     * @it when null value provided directly
+     */
+    public function testWhenNullValueProvidedDirectly()
+    {
+        $ast = Parser::parse('query {
+            fieldWithDefaultArgumentValue(input: null)
+        }');
+
+        $this->assertEquals(
+            ['data' => ['fieldWithDefaultArgumentValue' => '"Hello World"']],
+            Executor::execute($this->schema(), $ast)->toArray()
+        );
+    }
+
+    /**
      * @it not when argument cannot be coerced
      */
     public function testNotWhenArgumentCannotBeCoerced()


### PR DESCRIPTION
There is some ambiguity in both the GraphQL spec and various implementations with regards to when `defaultValue`s are applied to arguments.

A [spec change to resolve this](https://github.com/facebook/graphql/pull/418) is being considered and there is a proposed [PR for the JS implementation](https://github.com/graphql/graphql-js/pull/1274) as well.

I have run into this during use of graphql-php where I wanted `defaultValue` to be applied for an optional argument (which can't be `null` either), but the client used sends `null` as the value for the argument. I expected the `defaultValue` to be substituted, but `null` was the coerced value instead.

This PR tries to apply a similar fix for the ambiguity in the above PR for the JS implementation, always using the `defaultValue` for a node if the value is explicitly sent as `null` (either directly or via variables).