### PR TITLE
Fix missing sprintf in Schema.php

### DIFF
--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -271,11 +271,11 @@ class Schema
 
         foreach ($types as $index => $type) {
             if (!$type instanceof Type) {
-                throw new InvariantViolation(
+                throw new InvariantViolation(sprintf(
                     'Each entry of schema types must be instance of GraphQL\Type\Definition\Type but entry at %s is %s',
                     $index,
                     Utils::printSafe($type)
-                );
+                ));
             }
             yield $type;
         }


### PR DESCRIPTION
```
Wrong parameters for GraphQL\\Error\\InvariantViolation([string $message [, long $code [, Throwable $previous = NULL]]])
```