### PR TITLE
Return early if rules are empty to avoid visiting elements

### DIFF
--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -86,6 +86,12 @@ class DocumentValidator
         if (null === $rules) {
             $rules = static::allRules();
         }
+
+        if (true === is_array($rules) && 0 === count($rules)) {
+            // Skip validation if there are no rules
+            return [];
+        }
+
         $typeInfo = $typeInfo ?: new TypeInfo($schema);
         $errors = static::visitUsingRules($schema, $typeInfo, $ast, $rules);
         return $errors;


### PR DESCRIPTION
## What has been done
Although I passed an empty array to `DocumentValidator::validate()` I still saw visitor code running in a profile:
<img width="282" alt="screen shot 2018-04-12 at 17 06 23" src="https://user-images.githubusercontent.com/133832/38687944-2ddd6aa8-3e78-11e8-855e-6c10f14eb9e9.png">

This adds an early return if there are no rules given (empty array).

## Test
This is tested already in `testPassesValidationWithEmptyRules`.