### PR TITLE
Use correct case for GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,4 +123,4 @@ Improvements:
 - New docs and examples
 
 ## Older versions
-Look at [Github Releases Page](https://github.com/webonyx/graphql-php/releases).
+Look at [GitHub Releases Page](https://github.com/webonyx/graphql-php/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Workflow
 
 If your contribution requires significant or breaking changes, or if you plan to propose a major new feature,
-we recommend you to create an issue on the [Github](https://github.com/webonyx/graphql-php/issues) with 
+we recommend you to create an issue on the [GitHub](https://github.com/webonyx/graphql-php/issues) with
 a brief proposal and discuss it with us first.
 
 For smaller contributions just use this workflow:

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,5 +51,5 @@ The current version (v0.10) supports all features described by GraphQL specifica
 
 Ready for real-world usage. 
 
-## Github
+## GitHub
 Project source code is [hosted on GitHub](https://github.com/webonyx/graphql-php).


### PR DESCRIPTION
This is a very minor fix for documentation.