### PR TITLE
setRawVariableValues fix

### DIFF
--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -58,9 +58,9 @@ class QueryComplexity extends AbstractQuerySecurity
         return $this->maxQueryComplexity;
     }
 
-    public function setRawVariableValues(array $rawVariableValues = null)
+    public function setRawVariableValues($rawVariableValues = null)
     {
-        $this->rawVariableValues = $rawVariableValues ?: [];
+        $this->rawVariableValues = json_decode($rawVariableValues) ?: [];
     }
 
     public function getRawVariableValues()


### PR DESCRIPTION
In my experience, $rawVariableValues ​​is null or a string representing a json. 
Tested with different implementations of graphiql clients