### PR TITLE
Cleanup CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,29 @@
+build:
+    nodes:
+        analysis:
+            environment:
+                php:
+                    version: 5.6
+            cache:
+                disabled: false
+                directories:
+                    - ~/.composer/cache
+            project_setup:
+                override: true
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+    dependencies:
+        override:
+            - composer install --ignore-platform-reqs --no-interaction
+
+tools:
+    external_code_coverage:
+        timeout: 600
+
+build_failure_conditions:
+    - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
+    - 'issues.label("coding-style").new.exists'                 # No new coding style issues allowed
+    - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
+    - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-language: php
-
 dist: trusty
+language: php
 
 php:
     - 5.6
@@ -18,16 +17,33 @@ cache:
         - $HOME/.composer/cache
 
 before_install:
-    - if [[ "$TRAVIS_PHP_VERSION" != "5.6" ]]; then phpenv config-rm xdebug.ini || true; fi
-    - phpenv config-rm xdebug.ini || true
-    - composer selfupdate
+    - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+    - travis_retry composer self-update
 
 install:
-    - composer install --dev --prefer-dist
     - composer require react/promise:2.*
     - composer require psr/http-message:1.*
+    - travis_retry composer update --prefer-dist
 
-script: if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then bin/phpunit --coverage-clover build/logs/clover.xml --group default,ReactPromise; else bin/phpunit --group default,ReactPromise; fi
+script: ./vendor/bin/phpunit --group default,ReactPromise
 
-after_success:
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then composer require "satooshi/php-coveralls:^1.0" && travis_retry php bin/coveralls -v; fi
+jobs:
+  allow_failures:
+    - php: nightly
+
+  include:
+    - stage: Test
+      env: DEPENDENCIES=low
+      install:
+        - travis_retry composer update --prefer-dist --prefer-lowest
+
+    - stage: Test
+      env: COVERAGE
+      before_script:
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
+        - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
+      script:
+        - ./vendor/bin/phpunit --coverage-clover clover.xml
+      after_script:
+        - wget https://scrutinizer-ci.com/ocular.phar
+        - php ocular.phar code-coverage:upload --format=php-clover clover.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # graphql-php
 [![Build Status](https://travis-ci.org/webonyx/graphql-php.svg?branch=master)](https://travis-ci.org/webonyx/graphql-php)
-[![Coverage Status](https://coveralls.io/repos/github/webonyx/graphql-php/badge.svg)](https://coveralls.io/github/webonyx/graphql-php)
+[![Quality Score](https://scrutinizer-ci.com/g/webonyx/graphql-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/webonyx/graphql-php)
+[![Code Coverage](https://scrutinizer-ci.com/g/webonyx/graphql-php/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/webonyx/graphql-php)
 [![Latest Stable Version](https://poser.pugx.org/webonyx/graphql-php/version)](https://packagist.org/packages/webonyx/graphql-php)
 [![License](https://poser.pugx.org/webonyx/graphql-php/license)](https://packagist.org/packages/webonyx/graphql-php)
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,6 @@
     "psr/http-message": "^1.0"
   },
   "config": {
-    "bin-dir": "bin",
-    "platform": {
-      "php": "5.6.0"
-    },
     "preferred-install": "dist",
     "sort-packages": true
 },


### PR DESCRIPTION
I have started this https://github.com/webonyx/graphql-php/issues/284 by cleaning up travis config.

Also moved coverage info to Scrutinizer, hope it's ok (just enabling the project there activates it). We can add scrutinizer's code quality result into badges after as well if we fancy it.

[![Quality Score](https://scrutinizer-ci.com/g/simpod/graphql-php/badges/quality-score.png?b=cleanup-travis)](https://scrutinizer-ci.com/g/simpod/graphql-php)
[![Code Coverage](https://scrutinizer-ci.com/g/simpod/graphql-php/badges/coverage.png?b=cleanup-travis)](https://scrutinizer-ci.com/g/simpod/graphql-php)

Pretty much inspired by Doctrine's setup. I especially think moving coverage into its own step is way better that doing those [`if[]`s](https://github.com/webonyx/graphql-php/compare/master...simPod:cleanup-travis?expand=1#diff-354f30a63fb0907d4ad57269548329e3L21)