### PR TITLE
RFC: PHP CS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.idea/
 composer.phar
 composer.lock
+phpcs.xml
 vendor/
-bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: trusty
 language: php
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - nightly
@@ -47,3 +45,21 @@ jobs:
       after_script:
         - wget https://scrutinizer-ci.com/ocular.phar
         - php ocular.phar code-coverage:upload --format=php-clover clover.xml
+    - stage: Pull request coding standard
+      if: type = pull_request
+      install: travis_retry composer install --prefer-dist
+      script:
+        - |
+          if [ $TRAVIS_BRANCH != "master" ]; then
+            git remote set-branches --add origin $TRAVIS_BRANCH;
+            git fetch origin $TRAVIS_BRANCH;
+          fi
+        - git merge-base origin/$TRAVIS_BRANCH $TRAVIS_PULL_REQUEST_SHA || git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge --unshallow
+        - wget https://github.com/diff-sniffer/git/releases/download/0.1.0/git-phpcs.phar
+        - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
+    - stage: Coding standard
+      if: NOT type = pull_request
+      php: 7.1
+      install: travis_retry composer install --prefer-dist
+      script:
+        - ./vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,8 @@
   "suggest": {
     "react/promise": "To leverage async resolving on React PHP platform",
     "psr/http-message": "To use standard GraphQL server"
+  },
+  "scripts": {
+    "lint" : "vendor/bin/phpcs"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
     "API"
   ],
   "require": {
-    "php": ">=5.6",
+    "php": "^7.1",
     "ext-mbstring": "*"
   },
   "require-dev": {
+    "doctrine/coding-standard": "^4.0",
     "phpunit/phpunit": "^4.8",
     "psr/http-message": "^1.0"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="." />
+    <arg name="extensions" value="php" />
+    <arg name="parallel" value="80" />
+    <arg name="cache" value=".phpcs-cache" />
+    <arg name="colors" />
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps" />
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="Doctrine">
+        <!--Disable PHP7+ features that might cause BC breaks for now -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+    </rule>
+
+    <!--@api annotation is required for now -->
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+        <properties>
+            <property
+                    name="usefulAnnotations"
+                    type="array"
+                    value="
+                    @after,
+                    @afterClass,
+                    @AfterMethods,
+                    @api,
+                    @Attribute,
+                    @Attributes,
+                    @before,
+                    @beforeClass,
+                    @BeforeMethods,
+                    @covers,
+                    @coversDefaultClass,
+                    @coversNothing,
+                    @dataProvider,
+                    @depends,
+                    @deprecated,
+                    @doesNotPerformAssertions,
+                    @Enum,
+                    @expectedDeprecation,
+                    @expectedException,
+                    @expectedExceptionCode,
+                    @expectedExceptionMessage,
+                    @expectedExceptionMessageRegExp,
+                    @group,
+                    @Groups,
+                    @IgnoreAnnotation,
+                    @internal,
+                    @Iterations,
+                    @link,
+                    @ODM\,
+                    @ORM\,
+                    @requires,
+                    @Required,
+                    @Revs,
+                    @runInSeparateProcess,
+                    @runTestsInSeparateProcesses,
+                    @see,
+                    @Target,
+                    @test,
+                    @throws,
+                    @uses
+                "
+            />
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+        <properties>
+            <property
+                    name="forbiddenAnnotations"
+                    type="array"
+                    value="
+                    @author,
+                    @category,
+                    @copyright,
+                    @created,
+                    @license,
+                    @package,
+                    @since,
+                    @subpackage,
+                    @version
+                "
+            />
+        </properties>
+    </rule>
+</ruleset>

--- a/src/Error/ClientAware.php
+++ b/src/Error/ClientAware.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 /**

--- a/src/Error/Debug.php
+++ b/src/Error/Debug.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 /**
@@ -6,7 +9,7 @@ namespace GraphQL\Error;
  */
 class Debug
 {
-    const INCLUDE_DEBUG_MESSAGE = 1;
-    const INCLUDE_TRACE = 2;
+    const INCLUDE_DEBUG_MESSAGE       = 1;
+    const INCLUDE_TRACE               = 2;
     const RETHROW_INTERNAL_EXCEPTIONS = 4;
 }

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 use GraphQL\Language\AST\Node;
@@ -7,6 +10,26 @@ use GraphQL\Language\SourceLocation;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Utils\Utils;
+use function addcslashes;
+use function array_filter;
+use function array_intersect_key;
+use function array_map;
+use function array_merge;
+use function array_shift;
+use function count;
+use function get_class;
+use function gettype;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_object;
+use function is_scalar;
+use function is_string;
+use function mb_strlen;
+use function preg_split;
+use function sprintf;
+use function str_repeat;
+use function strlen;
 
 /**
  * This class is used for [default error formatting](error-handling.md).
@@ -15,6 +38,7 @@ use GraphQL\Utils\Utils;
  */
 class FormattedError
 {
+    /** @var string */
     private static $internalErrorMessage = 'Internal server error';
 
     /**
@@ -33,7 +57,6 @@ class FormattedError
      * Prints a GraphQLError to a string, representing useful location information
      * about the error's position in the source.
      *
-     * @param Error $error
      * @return string
      */
     public static function printError(Error $error)
@@ -41,63 +64,65 @@ class FormattedError
         $printedLocations = [];
         if ($error->nodes) {
             /** @var Node $node */
-            foreach($error->nodes as $node) {
-                if ($node->loc) {
-                    $printedLocations[] = self::highlightSourceAtLocation(
-                        $node->loc->source,
-                        $node->loc->source->getLocation($node->loc->start)
-                    );
+            foreach ($error->nodes as $node) {
+                if (! $node->loc) {
+                    continue;
                 }
+
+                if ($node->loc->source === null) {
+                    continue;
+                }
+
+                $printedLocations[] = self::highlightSourceAtLocation(
+                    $node->loc->source,
+                    $node->loc->source->getLocation($node->loc->start)
+                );
             }
-        } else if ($error->getSource() && $error->getLocations()) {
+        } elseif ($error->getSource() && $error->getLocations()) {
             $source = $error->getSource();
-            foreach($error->getLocations() as $location) {
+            foreach ($error->getLocations() as $location) {
                 $printedLocations[] = self::highlightSourceAtLocation($source, $location);
             }
         }
 
-        return !$printedLocations
+        return ! $printedLocations
             ? $error->getMessage()
-            : join("\n\n", array_merge([$error->getMessage()], $printedLocations)) . "\n";
+            : implode("\n\n", array_merge([$error->getMessage()], $printedLocations)) . "\n";
     }
 
     /**
      * Render a helpful description of the location of the error in the GraphQL
      * Source document.
      *
-     * @param Source $source
-     * @param SourceLocation $location
      * @return string
      */
     private static function highlightSourceAtLocation(Source $source, SourceLocation $location)
     {
-        $line = $location->line;
-        $lineOffset = $source->locationOffset->line - 1;
-        $columnOffset = self::getColumnOffset($source, $location);
-        $contextLine = $line + $lineOffset;
+        $line          = $location->line;
+        $lineOffset    = $source->locationOffset->line - 1;
+        $columnOffset  = self::getColumnOffset($source, $location);
+        $contextLine   = $line + $lineOffset;
         $contextColumn = $location->column + $columnOffset;
-        $prevLineNum = (string) ($contextLine - 1);
-        $lineNum = (string) $contextLine;
-        $nextLineNum = (string) ($contextLine + 1);
-        $padLen = strlen($nextLineNum);
-        $lines = preg_split('/\r\n|[\n\r]/', $source->body);
+        $prevLineNum   = (string) ($contextLine - 1);
+        $lineNum       = (string) $contextLine;
+        $nextLineNum   = (string) ($contextLine + 1);
+        $padLen        = strlen($nextLineNum);
+        $lines         = preg_split('/\r\n|[\n\r]/', $source->body);
 
         $lines[0] = self::whitespace($source->locationOffset->column - 1) . $lines[0];
 
         $outputLines = [
-            "{$source->name} ($contextLine:$contextColumn)",
+            sprintf('%s (%s:%s)', $source->name, $contextLine, $contextColumn),
             $line >= 2 ? (self::lpad($padLen, $prevLineNum) . ': ' . $lines[$line - 2]) : null,
             self::lpad($padLen, $lineNum) . ': ' . $lines[$line - 1],
             self::whitespace(2 + $padLen + $contextColumn - 1) . '^',
-            $line < count($lines)? self::lpad($padLen, $nextLineNum) . ': ' . $lines[$line] : null
+            $line < count($lines) ? self::lpad($padLen, $nextLineNum) . ': ' . $lines[$line] : null,
         ];
 
-        return join("\n", array_filter($outputLines));
+        return implode("\n", array_filter($outputLines));
     }
 
     /**
-     * @param Source $source
-     * @param SourceLocation $location
      * @return int
      */
     private static function getColumnOffset(Source $source, SourceLocation $location)
@@ -109,7 +134,8 @@ class FormattedError
      * @param int $len
      * @return string
      */
-    private static function whitespace($len) {
+    private static function whitespace($len)
+    {
         return str_repeat(' ', $len);
     }
 
@@ -117,7 +143,8 @@ class FormattedError
      * @param int $len
      * @return string
      */
-    private static function lpad($len, $str) {
+    private static function lpad($len, $str)
+    {
         return self::whitespace($len - mb_strlen($str)) . $str;
     }
 
@@ -132,16 +159,16 @@ class FormattedError
      *
      * @api
      * @param \Throwable $e
-     * @param bool|int $debug
-     * @param string $internalErrorMessage
-     * @return array
+     * @param bool|int   $debug
+     * @param string     $internalErrorMessage
+     * @return mixed[]
      * @throws \Throwable
      */
     public static function createFromException($e, $debug = false, $internalErrorMessage = null)
     {
         Utils::invariant(
             $e instanceof \Exception || $e instanceof \Throwable,
-            "Expected exception, got %s",
+            'Expected exception, got %s',
             Utils::getVariableType($e)
         );
 
@@ -149,13 +176,13 @@ class FormattedError
 
         if ($e instanceof ClientAware) {
             $formattedError = [
-                'message' => $e->isClientSafe() ? $e->getMessage() : $internalErrorMessage,
-                'category' => $e->getCategory()
+                'message'  => $e->isClientSafe() ? $e->getMessage() : $internalErrorMessage,
+                'category' => $e->getCategory(),
             ];
         } else {
             $formattedError = [
-                'message' => $internalErrorMessage,
-                'category' => Error::CATEGORY_INTERNAL
+                'message'  => $internalErrorMessage,
+                'category' => Error::CATEGORY_INTERNAL,
             ];
         }
 
@@ -164,14 +191,17 @@ class FormattedError
                 $formattedError = array_merge($e->getExtensions(), $formattedError);
             }
 
-            $locations = Utils::map($e->getLocations(), function(SourceLocation $loc) {
-                return $loc->toSerializableArray();
-            });
+            $locations = Utils::map(
+                $e->getLocations(),
+                function (SourceLocation $loc) {
+                    return $loc->toSerializableArray();
+                }
+            );
 
-            if (!empty($locations)) {
+            if (! empty($locations)) {
                 $formattedError['locations'] = $locations;
             }
-            if (!empty($e->path)) {
+            if (! empty($e->path)) {
                 $formattedError['path'] = $e->path;
             }
         }
@@ -187,35 +217,37 @@ class FormattedError
      * Decorates spec-compliant $formattedError with debug entries according to $debug flags
      * (see GraphQL\Error\Debug for available flags)
      *
-     * @param array $formattedError
+     * @param mixed[]    $formattedError
      * @param \Throwable $e
-     * @param bool $debug
-     * @return array
+     * @param bool       $debug
+     * @return mixed[]
      * @throws \Throwable
      */
     public static function addDebugEntries(array $formattedError, $e, $debug)
     {
-        if (!$debug) {
+        if (! $debug) {
             return $formattedError;
         }
 
         Utils::invariant(
             $e instanceof \Exception || $e instanceof \Throwable,
-            "Expected exception, got %s",
+            'Expected exception, got %s',
             Utils::getVariableType($e)
         );
 
         $debug = (int) $debug;
 
         if ($debug & Debug::RETHROW_INTERNAL_EXCEPTIONS) {
-            if (!$e instanceof Error) {
+            if (! $e instanceof Error) {
                 throw $e;
-            } else if ($e->getPrevious()) {
+            }
+
+            if ($e->getPrevious()) {
                 throw $e->getPrevious();
             }
         }
 
-        $isInternal = !$e instanceof ClientAware || !$e->isClientSafe();
+        $isInternal = ! $e instanceof ClientAware || ! $e->isClientSafe();
 
         if (($debug & Debug::INCLUDE_DEBUG_MESSAGE) && $isInternal) {
             // Displaying debugMessage as a first entry:
@@ -230,13 +262,14 @@ class FormattedError
                 ];
             }
 
-            $isTrivial = $e instanceof Error && !$e->getPrevious();
+            $isTrivial = $e instanceof Error && ! $e->getPrevious();
 
-            if (!$isTrivial) {
-                $debugging = $e->getPrevious() ?: $e;
+            if (! $isTrivial) {
+                $debugging               = $e->getPrevious() ?: $e;
                 $formattedError['trace'] = static::toSafeTrace($debugging);
             }
         }
+
         return $formattedError;
     }
 
@@ -244,20 +277,20 @@ class FormattedError
      * Prepares final error formatter taking in account $debug flags.
      * If initial formatter is not set, FormattedError::createFromException is used
      *
-     * @param callable|null $formatter
-     * @param $debug
+     * @param  bool $debug
      * @return callable|\Closure
      */
-    public static function prepareFormatter(callable $formatter = null, $debug)
+    public static function prepareFormatter(?callable $formatter = null, $debug)
     {
-        $formatter = $formatter ?: function($e) {
+        $formatter = $formatter ?: function ($e) {
             return FormattedError::createFromException($e);
         };
         if ($debug) {
-            $formatter = function($e) use ($formatter, $debug) {
+            $formatter = function ($e) use ($formatter, $debug) {
                 return FormattedError::addDebugEntries($formatter($e), $e, $debug);
             };
         }
+
         return $formatter;
     }
 
@@ -266,45 +299,45 @@ class FormattedError
      *
      * @api
      * @param \Throwable $error
-     * @return array
+     * @return mixed[]
      */
     public static function toSafeTrace($error)
     {
         $trace = $error->getTrace();
 
-        // Remove invariant entries as they don't provide much value:
-        if (
-            isset($trace[0]['function']) && isset($trace[0]['class']) &&
-            ('GraphQL\Utils\Utils::invariant' === $trace[0]['class'].'::'.$trace[0]['function'])) {
+        if (isset($trace[0]['function']) && isset($trace[0]['class']) &&
+            // Remove invariant entries as they don't provide much value:
+            ($trace[0]['class'] . '::' . $trace[0]['function'] === 'GraphQL\Utils\Utils::invariant')) {
+            array_shift($trace);
+        } elseif (! isset($trace[0]['file'])) {
+            // Remove root call as it's likely error handler trace:
             array_shift($trace);
         }
 
-        // Remove root call as it's likely error handler trace:
-        else if (!isset($trace[0]['file'])) {
-            array_shift($trace);
-        }
+        return array_map(
+            function ($err) {
+                $safeErr = array_intersect_key($err, ['file' => true, 'line' => true]);
 
-        return array_map(function($err) {
-            $safeErr = array_intersect_key($err, ['file' => true, 'line' => true]);
+                if (isset($err['function'])) {
+                    $func    = $err['function'];
+                    $args    = ! empty($err['args']) ? array_map([__CLASS__, 'printVar'], $err['args']) : [];
+                    $funcStr = $func . '(' . implode(', ', $args) . ')';
 
-            if (isset($err['function'])) {
-                $func = $err['function'];
-                $args = !empty($err['args']) ? array_map([__CLASS__, 'printVar'], $err['args']) : [];
-                $funcStr = $func . '(' . implode(", ", $args) . ')';
-
-                if (isset($err['class'])) {
-                    $safeErr['call'] = $err['class'] . '::' . $funcStr;
-                } else {
-                    $safeErr['function'] = $funcStr;
+                    if (isset($err['class'])) {
+                        $safeErr['call'] = $err['class'] . '::' . $funcStr;
+                    } else {
+                        $safeErr['function'] = $funcStr;
+                    }
                 }
-            }
 
-            return $safeErr;
-        }, $trace);
+                return $safeErr;
+            },
+            $trace
+        );
     }
 
     /**
-     * @param $var
+     * @param mixed $var
      * @return string
      */
     public static function printVar($var)
@@ -314,6 +347,7 @@ class FormattedError
             if ($var instanceof WrappingType) {
                 $var = $var->getWrappedType(true);
             }
+
             return 'GraphQLType: ' . $var->name;
         }
 
@@ -323,7 +357,7 @@ class FormattedError
         if (is_array($var)) {
             return 'array(' . count($var) . ')';
         }
-        if ('' === $var) {
+        if ($var === '') {
             return '(empty string)';
         }
         if (is_string($var)) {
@@ -335,42 +369,45 @@ class FormattedError
         if (is_scalar($var)) {
             return $var;
         }
-        if (null === $var) {
+        if ($var === null) {
             return 'null';
         }
+
         return gettype($var);
     }
 
     /**
      * @deprecated as of v0.8.0
-     * @param $error
+     * @param string           $error
      * @param SourceLocation[] $locations
-     * @return array
+     * @return mixed[]
      */
     public static function create($error, array $locations = [])
     {
-        $formatted = [
-            'message' => $error
-        ];
+        $formatted = ['message' => $error];
 
-        if (!empty($locations)) {
-            $formatted['locations'] = array_map(function($loc) { return $loc->toArray();}, $locations);
+        if (! empty($locations)) {
+            $formatted['locations'] = array_map(
+                function ($loc) {
+                    return $loc->toArray();
+                },
+                $locations
+            );
         }
 
         return $formatted;
     }
 
     /**
-     * @param \ErrorException $e
      * @deprecated as of v0.10.0, use general purpose method createFromException() instead
-     * @return array
+     * @return mixed[]
      */
     public static function createFromPHPError(\ErrorException $e)
     {
         return [
-            'message' => $e->getMessage(),
+            'message'  => $e->getMessage(),
             'severity' => $e->getSeverity(),
-            'trace' => self::toSafeTrace($e)
+            'trace'    => self::toSafeTrace($e),
         ];
     }
 }

--- a/src/Error/InvariantViolation.php
+++ b/src/Error/InvariantViolation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 /**
@@ -7,8 +10,6 @@ namespace GraphQL\Error;
  * Note:
  * This exception should not inherit base Error exception as it is raised when there is an error somewhere in
  * user-land code
- *
- * @package GraphQL\Error
  */
 class InvariantViolation extends \LogicException
 {

--- a/src/Error/SyntaxError.php
+++ b/src/Error/SyntaxError.php
@@ -1,19 +1,22 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 use GraphQL\Language\Source;
+use function sprintf;
 
 class SyntaxError extends Error
 {
     /**
-     * @param Source $source
-     * @param int $position
+     * @param int    $position
      * @param string $description
      */
     public function __construct(Source $source, $position, $description)
     {
         parent::__construct(
-            "Syntax Error: $description",
+            sprintf('Syntax Error: %s', $description),
             null,
             $source,
             [$position]

--- a/src/Error/UserError.php
+++ b/src/Error/UserError.php
@@ -1,12 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
 
 /**
  * Class UserError
  *
  * Error caused by actions of GraphQL clients. Can be safely displayed to a client...
- *
- * @package GraphQL\Error
  */
 class UserError extends \RuntimeException implements ClientAware
 {

--- a/src/Error/Warning.php
+++ b/src/Error/Warning.php
@@ -1,5 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Error;
+
+use const E_USER_WARNING;
+use function trigger_error;
 
 /**
  * Encapsulates warnings produced by the library.
@@ -9,27 +15,29 @@ namespace GraphQL\Error;
  */
 final class Warning
 {
-    const WARNING_ASSIGN = 2;
-    const WARNING_CONFIG = 4;
-    const WARNING_FULL_SCHEMA_SCAN = 8;
+    const WARNING_ASSIGN             = 2;
+    const WARNING_CONFIG             = 4;
+    const WARNING_FULL_SCHEMA_SCAN   = 8;
     const WARNING_CONFIG_DEPRECATION = 16;
-    const WARNING_NOT_A_TYPE = 32;
-    const ALL = 63;
+    const WARNING_NOT_A_TYPE         = 32;
+    const ALL                        = 63;
 
-    static $enableWarnings = self::ALL;
+    /** @var int */
+    private static $enableWarnings = self::ALL;
 
-    static $warned = [];
+    /** @var mixed[] */
+    private static $warned = [];
 
-    static private $warningHandler;
+    /** @var callable|null */
+    private static $warningHandler;
 
     /**
      * Sets warning handler which can intercept all system warnings.
      * When not set, trigger_error() is used to notify about warnings.
      *
      * @api
-     * @param callable|null $warningHandler
      */
-    public static function setWarningHandler(callable $warningHandler = null)
+    public static function setWarningHandler(?callable $warningHandler = null)
     {
         self::$warningHandler = $warningHandler;
     }
@@ -45,14 +53,15 @@ final class Warning
      * @api
      * @param bool|int $suppress
      */
-    static function suppress($suppress = true)
+    public static function suppress($suppress = true)
     {
-        if (true === $suppress) {
+        if ($suppress === true) {
             self::$enableWarnings = 0;
-        } else if (false === $suppress) {
+        } elseif ($suppress === false) {
             self::$enableWarnings = self::ALL;
         } else {
             $suppress = (int) $suppress;
+
             self::$enableWarnings &= ~$suppress;
         }
     }
@@ -70,33 +79,34 @@ final class Warning
      */
     public static function enable($enable = true)
     {
-        if (true === $enable) {
+        if ($enable === true) {
             self::$enableWarnings = self::ALL;
-        } else if (false === $enable) {
+        } elseif ($enable === false) {
             self::$enableWarnings = 0;
         } else {
             $enable = (int) $enable;
+
             self::$enableWarnings |= $enable;
         }
     }
 
-    static function warnOnce($errorMessage, $warningId, $messageLevel = null)
+    public static function warnOnce($errorMessage, $warningId, $messageLevel = null)
     {
         if (self::$warningHandler) {
             $fn = self::$warningHandler;
             $fn($errorMessage, $warningId);
-        } else if ((self::$enableWarnings & $warningId) > 0 && !isset(self::$warned[$warningId])) {
+        } elseif ((self::$enableWarnings & $warningId) > 0 && ! isset(self::$warned[$warningId])) {
             self::$warned[$warningId] = true;
             trigger_error($errorMessage, $messageLevel ?: E_USER_WARNING);
         }
     }
 
-    static function warn($errorMessage, $warningId, $messageLevel = null)
+    public static function warn($errorMessage, $warningId, $messageLevel = null)
     {
         if (self::$warningHandler) {
             $fn = self::$warningHandler;
             $fn($errorMessage, $warningId);
-        } else if ((self::$enableWarnings & $warningId) > 0) {
+        } elseif ((self::$enableWarnings & $warningId) > 0) {
             trigger_error($errorMessage, $messageLevel ?: E_USER_WARNING);
         }
     }


### PR DESCRIPTION
Following https://github.com/webonyx/graphql-php/issues/284

- Added Code Sniffer with Doctrine CS
- Min PHP v is 7.1 as it's constraint for modern CS
- Fixed CS in `src/Errors`

For smoother transition typehint checks are now disabled and only modified lines are checked for CS compliance.

Doctrine and Slevomat CS require PHP ^7.1. Not sure, what's the roadmap of this project, can be merged after the PHP version constraint is set to not-outdated PHP versions.