### PR TITLE
Fix wrong length being used in validator.

### DIFF
--- a/src/Validator/Rules/OverlappingFieldsCanBeMerged.php
+++ b/src/Validator/Rules/OverlappingFieldsCanBeMerged.php
@@ -426,7 +426,7 @@ class OverlappingFieldsCanBeMerged extends AbstractValidationRule
         $fragmentNames1Length = count($fragmentNames1);
         if ($fragmentNames1Length !== 0) {
             $comparedFragments = [];
-            for ($i = 0; $i < $fragmentNames2Length; $i++) {
+            for ($i = 0; $i < $fragmentNames1Length; $i++) {
                 $this->collectConflictsBetweenFieldsAndFragment(
                     $context,
                     $conflicts,


### PR DESCRIPTION
This makes the validator throw currently if the lengths do not match. Seems I copy and pasted it wrong. Comparing to graphql-js it is now the same with this PR.

```
 [rg\core\base\exceptions\NoticeException]  
Undefined offset: 1                        
                                            

Exception trace:
vendor/composer/webonyx/graphql-php/src/Validator/Rules/OverlappingFieldsCanBeMerged.php:436
GraphQL\Validator\Rules\OverlappingFieldsCanBeMerged->findConflictsBetweenSubSelectionSets() at /vendor/composer/webonyx/graphql-php/src/Validator/Rules/OverlappingFieldsCanBeMerged.php:628
```