### PR TITLE
Use multi-line block for trailing quote

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -275,15 +275,35 @@ class SchemaPrinter
             return self::printDescriptionWithComments($lines, $indentation, $firstInBlock);
         }
 
-        $description = ($indentation && !$firstInBlock) ? "\n" : '';
-        if (count($lines) === 1 && mb_strlen($lines[0]) < 70) {
-            $description .= $indentation . '"""' . self::escapeQuote($lines[0]) . "\"\"\"\n";
-            return $description;
+        $description = ($indentation && !$firstInBlock)
+            ? "\n" . $indentation . '"""'
+            : $indentation . '"""';
+
+        // In some circumstances, a single line can be used for the description.
+        if (
+            count($lines) === 1 &&
+            mb_strlen($lines[0]) < 70 &&
+            substr($lines[0], -1) !== '"'
+        ) {
+            return $description . self::escapeQuote($lines[0]) . "\"\"\"\n";
         }
 
-        $description .= $indentation . "\"\"\"\n";
-        foreach ($lines as $line) {
-            $description .= $indentation . self::escapeQuote($line) . "\n";
+        // Format a multi-line block quote to account for leading space.
+        $hasLeadingSpace = isset($lines[0]) &&
+            (
+                substr($lines[0], 0, 1) === ' ' ||
+                substr($lines[0], 0, 1) === '\t'
+            );
+        if (!$hasLeadingSpace) {
+            $description .= "\n";
+        }
+
+        $lineLength = count($lines);
+        for ($i = 0; $i < $lineLength; $i++) {
+            if ($i !== 0 || !$hasLeadingSpace) {
+                $description .= $indentation;
+            }
+            $description .= self::escapeQuote($lines[$i]) . "\n";
         }
         $description .= $indentation . "\"\"\"\n";
 


### PR DESCRIPTION
This fixes an issue that the following description `some "thing"` would be reprinted as `"""some "thing""""` which the parser cannot parse afterwards. Instead it will print now a multiline description
```
"""
some "thing"
"""
```

ref: https://github.com/graphql/graphql-js/commit/fdc10bb918e5d84ce6b34e122069851ca3e6f6a4#diff-ebaed8492e8d884ee4f2255e39909568