### PR TITLE
Allow stringeable objects to be serialized by StringType

### DIFF
--- a/src/Type/Definition/StringType.php
+++ b/src/Type/Definition/StringType.php
@@ -40,6 +40,9 @@ represent free-form human-readable text.';
         if ($value === null) {
             return 'null';
         }
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string) $value;
+        }
         if (!is_scalar($value)) {
             throw new Error("String cannot represent non scalar value: " . Utils::printSafe($value));
         }

--- a/tests/Type/ScalarSerializationTest.php
+++ b/tests/Type/ScalarSerializationTest.php
@@ -150,6 +150,7 @@ class ScalarSerializationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('true', $stringType->serialize(true));
         $this->assertSame('false', $stringType->serialize(false));
         $this->assertSame('null', $stringType->serialize(null));
+        $this->assertSame('2', $stringType->serialize(new ObjectIdStub(2)));
     }
 
     public function testSerializesOutputStringsCannotRepresentArray()


### PR DESCRIPTION
Closes #302

Unlike initially thought, #210 did not fix that issue or rather did but only for _IDs_, this PR ensures this is the case for strings as well.

Hope this can be released soon :)