### PR TITLE
Add link to GraphQL IDE in complementary-tools.md

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -19,3 +19,4 @@
 * [ChromeiQL](https://chrome.google.com/webstore/detail/chromeiql/fkkiamalmpiidkljmicmjfbieiclmeij)
   or [GraphiQL Feen](https://chrome.google.com/webstore/detail/graphiql-feen/mcbfdonlkfpbfdpimkjilhdneikhfklp) -
   GraphiQL as Google Chrome extension
+* [GraphQL Playground](https://github.com/prismagraphql/graphql-playground) - GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration).


### PR DESCRIPTION
I add link for GraphQL IDE - [GraphQL Playground](https://github.com/prismagraphql/graphql-playground). There are many  desktop versions for main platforms(Linux, MacOS, Wondows, Online version), support tabs, creating environments and others. 