### PR TITLE
FIX Ensure that __toString return value is always casted as a string

### DIFF
--- a/src/Language/AST/Node.php
+++ b/src/Language/AST/Node.php
@@ -84,7 +84,7 @@ abstract class Node
     public function __toString()
     {
         $tmp = $this->toArray(true);
-        return json_encode($tmp);
+        return (string) json_encode($tmp);
     }
 
     /**


### PR DESCRIPTION
`json_encode` can return false on failure, which causes PHP errors since `__toString` must return a string.