### PR TITLE
Fix for fatal php error: Call to a member function getLocation() on null, before normal error handling

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -271,7 +271,7 @@ class Error extends \Exception implements \JsonSerializable, ClientAware
                 $this->locations = array_filter(
                     array_map(
                         function ($node) {
-                            if ($node->loc) {
+                            if ($node->loc && $node->loc->source) {
                                 return $node->loc->source->getLocation($node->loc->start);
                             }
                         },


### PR DESCRIPTION
If you do a graphql call with a field that is required & doesn't exists in your request -  
you'll get a php fatal error that is triggered in the error handling of graphql. 
Because source of that node is not parsed/ empty..  
so you can never catch errors from the normal graphql error handler.
