### PR TITLE
Remove use instance of deprecated class GraphQL\Schema

### DIFF
--- a/benchmarks/HugeSchemaBench.php
+++ b/benchmarks/HugeSchemaBench.php
@@ -2,10 +2,9 @@
 namespace GraphQL\Benchmarks;
 
 use GraphQL\GraphQL;
-use GraphQL\Schema;
 use GraphQL\Benchmarks\Utils\QueryGenerator;
 use GraphQL\Benchmarks\Utils\SchemaGenerator;
-use GraphQL\Type\LazyResolution;
+use GraphQL\Type\Schema;
 
 /**
  * @BeforeMethods({"setUp"})
@@ -22,8 +21,6 @@ class HugeSchemaBench
     private $schemaBuilder;
 
     private $schema;
-
-    private $lazySchema;
 
     /**
      * @var string

--- a/benchmarks/Utils/QueryGenerator.php
+++ b/benchmarks/Utils/QueryGenerator.php
@@ -7,11 +7,11 @@ use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\Printer;
-use GraphQL\Schema;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\WrappingType;
+use GraphQL\Type\Schema;
 use GraphQL\Utils\Utils;
 
 class QueryGenerator

--- a/benchmarks/Utils/SchemaGenerator.php
+++ b/benchmarks/Utils/SchemaGenerator.php
@@ -1,11 +1,11 @@
 <?php
 namespace GraphQL\Benchmarks\Utils;
 
-use GraphQL\Schema;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
 
 class SchemaGenerator
 {


### PR DESCRIPTION
- Replace use deprecated class `GraphQL\Schema` on use `GraphQL\Type\Schema`
- Remove unsed variable `$lazySchema`
- Remove unsed use `GraphQL\Type\LazyResolution`