### PR TITLE
from master to 0.12.x - Call to a member function getLocation() on null

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -265,7 +265,7 @@ class Error extends \Exception implements \JsonSerializable, ClientAware
                 }, $positions);
             } else if ($nodes) {
                 $this->locations = array_filter(array_map(function ($node) {
-                    if ($node->loc) {
+                    if ($node->loc && $node->loc->source) {
                         return $node->loc->source->getLocation($node->loc->start);
                     }
                 }, $nodes));


### PR DESCRIPTION
#319  I've encountered this error also and this pr fixed it, but its only on master branch currently :|

In my case I am serialising and persisting queries using `AST::toArray` `AST::fromArray` and when its deserialised if some error occurs in execution this fatal error is received. If query was parsed (`Parser::parse`) error does not occur.
