### PR TITLE
Remove the word "simply"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ first learn about GraphQL on [the official website](http://graphql.org/learn/).
 
 # Installation
 
-Using [composer](https://getcomposer.org/doc/00-intro.md), simply run:
+Using [composer](https://getcomposer.org/doc/00-intro.md), run:
 
 ```sh
 composer require webonyx/graphql-php


### PR DESCRIPTION
Using the word "simply" or "just" is probably intended to convey the ease of use, but it can have the unintended effect of making the reader feel like the instructions are being blasé.

https://adactio.com/journal/13521