### PR TITLE
Use self:: in tests where appropriate

### DIFF
--- a/tests/Error/ErrorTest.php
+++ b/tests/Error/ErrorTest.php
@@ -20,7 +20,7 @@ class ErrorTest extends TestCase
         $prev = new \Exception('Original');
         $err  = new Error('msg', null, null, null, null, $prev);
 
-        $this->assertSame($err->getPrevious(), $prev);
+        self::assertSame($err->getPrevious(), $prev);
     }
 
     /**
@@ -35,10 +35,10 @@ class ErrorTest extends TestCase
         $fieldNode = $ast->definitions[0]->selectionSet->selections[0];
         $e         = new Error('msg', [$fieldNode]);
 
-        $this->assertEquals([$fieldNode], $e->nodes);
-        $this->assertEquals($source, $e->getSource());
-        $this->assertEquals([8], $e->getPositions());
-        $this->assertEquals([new SourceLocation(2, 7)], $e->getLocations());
+        self::assertEquals([$fieldNode], $e->nodes);
+        self::assertEquals($source, $e->getSource());
+        self::assertEquals([8], $e->getPositions());
+        self::assertEquals([new SourceLocation(2, 7)], $e->getLocations());
     }
 
     /**
@@ -53,10 +53,10 @@ class ErrorTest extends TestCase
         $fieldNode = $ast->definitions[0]->selectionSet->selections[0];
         $e         = new Error('msg', $fieldNode); // Non-array value.
 
-        $this->assertEquals([$fieldNode], $e->nodes);
-        $this->assertEquals($source, $e->getSource());
-        $this->assertEquals([8], $e->getPositions());
-        $this->assertEquals([new SourceLocation(2, 7)], $e->getLocations());
+        self::assertEquals([$fieldNode], $e->nodes);
+        self::assertEquals($source, $e->getSource());
+        self::assertEquals([8], $e->getPositions());
+        self::assertEquals([new SourceLocation(2, 7)], $e->getLocations());
     }
 
     /**
@@ -71,10 +71,10 @@ class ErrorTest extends TestCase
         $operationNode = $ast->definitions[0];
         $e             = new Error('msg', [$operationNode]);
 
-        $this->assertEquals([$operationNode], $e->nodes);
-        $this->assertEquals($source, $e->getSource());
-        $this->assertEquals([0], $e->getPositions());
-        $this->assertEquals([new SourceLocation(1, 1)], $e->getLocations());
+        self::assertEquals([$operationNode], $e->nodes);
+        self::assertEquals($source, $e->getSource());
+        self::assertEquals([0], $e->getPositions());
+        self::assertEquals([new SourceLocation(1, 1)], $e->getLocations());
     }
 
     /**
@@ -87,10 +87,10 @@ class ErrorTest extends TestCase
     }');
         $e      = new Error('msg', null, $source, [10]);
 
-        $this->assertEquals(null, $e->nodes);
-        $this->assertEquals($source, $e->getSource());
-        $this->assertEquals([10], $e->getPositions());
-        $this->assertEquals([new SourceLocation(2, 9)], $e->getLocations());
+        self::assertEquals(null, $e->nodes);
+        self::assertEquals($source, $e->getSource());
+        self::assertEquals([10], $e->getPositions());
+        self::assertEquals([new SourceLocation(2, 9)], $e->getLocations());
     }
 
     /**
@@ -99,7 +99,7 @@ class ErrorTest extends TestCase
     public function testSerializesToIncludeMessage() : void
     {
         $e = new Error('msg');
-        $this->assertEquals(['message' => 'msg'], $e->toSerializableArray());
+        self::assertEquals(['message' => 'msg'], $e->toSerializableArray());
     }
 
     /**
@@ -110,7 +110,7 @@ class ErrorTest extends TestCase
         $node = Parser::parse('{ field }')->definitions[0]->selectionSet->selections[0];
         $e    = new Error('msg', [$node]);
 
-        $this->assertEquals(
+        self::assertEquals(
             ['message' => 'msg', 'locations' => [['line' => 1, 'column' => 3]]],
             $e->toSerializableArray()
         );
@@ -129,8 +129,8 @@ class ErrorTest extends TestCase
             ['path', 3, 'to', 'field']
         );
 
-        $this->assertEquals(['path', 3, 'to', 'field'], $e->path);
-        $this->assertEquals(['message' => 'msg', 'path' => ['path', 3, 'to', 'field']], $e->toSerializableArray());
+        self::assertEquals(['path', 3, 'to', 'field'], $e->path);
+        self::assertEquals(['message' => 'msg', 'path' => ['path', 3, 'to', 'field']], $e->toSerializableArray());
     }
 
     /**
@@ -148,8 +148,8 @@ class ErrorTest extends TestCase
             ['foo' => 'bar']
         );
 
-        $this->assertEquals(['foo' => 'bar'], $e->getExtensions());
-        $this->assertEquals(
+        self::assertEquals(['foo' => 'bar'], $e->getExtensions());
+        self::assertEquals(
             [
                 'message'    => 'msg',
                 'extensions' => ['foo' => 'bar'],

--- a/tests/Error/PrintErrorTest.php
+++ b/tests/Error/PrintErrorTest.php
@@ -32,7 +32,7 @@ Test (9:1)
  9: *
     ^
 ';
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
 
         $doubleDigit = new Error(
             'Left padded first line number',
@@ -48,7 +48,7 @@ Test (9:1)
     ^
 10: 
 ';
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -82,7 +82,7 @@ Test (9:1)
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'Example error with two nodes
 
 SourceA (2:10)

--- a/tests/Executor/AbstractPromiseTest.php
+++ b/tests/Executor/AbstractPromiseTest.php
@@ -103,7 +103,7 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -196,7 +196,7 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -273,7 +273,7 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -380,7 +380,7 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -481,7 +481,7 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -566,7 +566,7 @@ class AbstractPromiseTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -654,6 +654,6 @@ class AbstractPromiseTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 }

--- a/tests/Executor/AbstractTest.php
+++ b/tests/Executor/AbstractTest.php
@@ -96,7 +96,7 @@ class AbstractTest extends TestCase
         ]);
 
         $result = Executor::execute($schema, Parser::parse($query));
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -164,7 +164,7 @@ class AbstractTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals($expected, Executor::execute($schema, Parser::parse($query)));
+        self::assertEquals($expected, Executor::execute($schema, Parser::parse($query)));
     }
 
     /**
@@ -269,7 +269,7 @@ class AbstractTest extends TestCase
         ];
         $actual   = GraphQL::executeQuery($schema, $query)->toArray(true);
 
-        $this->assertArraySubset($expected, $actual);
+        self::assertArraySubset($expected, $actual);
     }
 
     /**
@@ -369,7 +369,7 @@ class AbstractTest extends TestCase
             ],
             ],
         ];
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -424,7 +424,7 @@ class AbstractTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expected, $result->toArray(true));
     }
 
     /**
@@ -499,7 +499,7 @@ class AbstractTest extends TestCase
 
         $result = GraphQL::executeQuery($schema, $query)->toArray();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'data' => [
                     'pets' => [
@@ -557,7 +557,7 @@ class AbstractTest extends TestCase
 
         $result = Executor::execute($schema, Parser::parse($query), ['node' => ['a' => 'value']]);
 
-        $this->assertEquals(
+        self::assertEquals(
             'Schema must contain unique named types but contains multiple types named "Test". ' .
             'Make sure that `resolveType` function of abstract type "Node" returns the same type instance ' .
             'as referenced anywhere else within the schema ' .

--- a/tests/Executor/DeferredFieldsTest.php
+++ b/tests/Executor/DeferredFieldsTest.php
@@ -262,7 +262,7 @@ class DeferredFieldsTest extends TestCase
         ];
 
         $result = Executor::execute($schema, $query);
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         $expectedPath = [
             ['topStories'],
@@ -305,7 +305,7 @@ class DeferredFieldsTest extends TestCase
             ['featuredCategory', 'stories', 2, 'author', 'name'],
             ['featuredCategory', 'stories', 3, 'author', 'name'],
         ];
-        $this->assertEquals($expectedPath, $this->path);
+        self::assertEquals($expectedPath, $this->path);
     }
 
     public function testNestedDeferredFields() : void
@@ -347,7 +347,7 @@ class DeferredFieldsTest extends TestCase
         ];
 
         $result = Executor::execute($schema, $query);
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         $expectedPath = [
             ['categories'],
@@ -382,7 +382,7 @@ class DeferredFieldsTest extends TestCase
             ['categories', 1, 'topStory', 'author', 'bestFriend', 'name'],
             ['categories', 2, 'topStory', 'author', 'bestFriend', 'name'],
         ];
-        $this->assertEquals($expectedPath, $this->path);
+        self::assertEquals($expectedPath, $this->path);
     }
 
     public function testComplexRecursiveDeferredFields() : void
@@ -495,7 +495,7 @@ class DeferredFieldsTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         $expectedPath = [
             ['nest'],
@@ -531,6 +531,6 @@ class DeferredFieldsTest extends TestCase
             ['!dfd for: ', ['deferredNest', 'deferredNest', 'deferred']],
         ];
 
-        $this->assertEquals($expectedPath, $this->path);
+        self::assertEquals($expectedPath, $this->path);
     }
 }

--- a/tests/Executor/DirectivesTest.php
+++ b/tests/Executor/DirectivesTest.php
@@ -28,7 +28,7 @@ class DirectivesTest extends TestCase
      */
     public function testWorksWithoutDirectives() : void
     {
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery('{ a, b }'));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery('{ a, b }'));
     }
 
     /**
@@ -71,19 +71,19 @@ class DirectivesTest extends TestCase
     public function testWorksOnScalars() : void
     {
         // if true includes scalar
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['a' => 'a', 'b' => 'b']],
             $this->executeTestQuery('{ a, b @include(if: true) }')
         );
 
         // if false omits on scalar
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery('{ a, b @include(if: false) }'));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery('{ a, b @include(if: false) }'));
 
         // unless false includes scalar
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery('{ a, b @skip(if: false) }'));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery('{ a, b @skip(if: false) }'));
 
         // unless true omits scalar
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery('{ a, b @skip(if: true) }'));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery('{ a, b @skip(if: true) }'));
     }
 
     public function testWorksOnFragmentSpreads() : void
@@ -98,7 +98,7 @@ class DirectivesTest extends TestCase
           b
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
 
         // if true includes fragment spread
         $q = '
@@ -110,7 +110,7 @@ class DirectivesTest extends TestCase
           b
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless false includes fragment spread
         $q = '
@@ -122,7 +122,7 @@ class DirectivesTest extends TestCase
           b
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless true omits fragment spread
         $q = '
@@ -134,7 +134,7 @@ class DirectivesTest extends TestCase
           b
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
     }
 
     public function testWorksOnInlineFragment() : void
@@ -148,7 +148,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
 
         // if true includes inline fragment
         $q = '
@@ -159,7 +159,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless false includes inline fragment
         $q = '
@@ -170,7 +170,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless true includes inline fragment
         $q = '
@@ -181,7 +181,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
     }
 
     public function testWorksOnAnonymousInlineFragment() : void
@@ -195,7 +195,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
 
         // if true includes anonymous inline fragment
         $q = '
@@ -206,7 +206,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless false includes anonymous inline fragment
         $q = '
@@ -217,7 +217,7 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a', 'b' => 'b']], $this->executeTestQuery($q));
 
         // unless true includes anonymous inline fragment
         $q = '
@@ -228,25 +228,25 @@ class DirectivesTest extends TestCase
           }
         }
         ';
-        $this->assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
+        self::assertEquals(['data' => ['a' => 'a']], $this->executeTestQuery($q));
     }
 
     public function testWorksWithSkipAndIncludeDirectives() : void
     {
         // include and no skip
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['a' => 'a', 'b' => 'b']],
             $this->executeTestQuery('{ a, b @include(if: true) @skip(if: false) }')
         );
 
         // include and skip
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['a' => 'a']],
             $this->executeTestQuery('{ a, b @include(if: true) @skip(if: true) }')
         );
 
         // no include or skip
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['a' => 'a']],
             $this->executeTestQuery('{ a, b @include(if: false) @skip(if: false) }')
         );

--- a/tests/Executor/ExecutionResultTest.php
+++ b/tests/Executor/ExecutionResultTest.php
@@ -13,17 +13,17 @@ class ExecutionResultTest extends TestCase
     {
         $executionResult = new ExecutionResult();
 
-        $this->assertEquals([], $executionResult->toArray());
+        self::assertEquals([], $executionResult->toArray());
     }
 
     public function testToArrayExtensions() : void
     {
         $executionResult = new ExecutionResult(null, [], ['foo' => 'bar']);
 
-        $this->assertEquals(['extensions' => ['foo' => 'bar']], $executionResult->toArray());
+        self::assertEquals(['extensions' => ['foo' => 'bar']], $executionResult->toArray());
 
         $executionResult->extensions = ['bar' => 'foo'];
 
-        $this->assertEquals(['extensions' => ['bar' => 'foo']], $executionResult->toArray());
+        self::assertEquals(['extensions' => ['bar' => 'foo']], $executionResult->toArray());
     }
 }

--- a/tests/Executor/ExecutorLazySchemaTest.php
+++ b/tests/Executor/ExecutorLazySchemaTest.php
@@ -146,14 +146,14 @@ class ExecutorLazySchemaTest extends TestCase
 
         Warning::suppress(Warning::WARNING_FULL_SCHEMA_SCAN);
         $result = Executor::execute($schema, Parser::parse($query));
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
 
         Warning::enable(Warning::WARNING_FULL_SCHEMA_SCAN);
         $result = Executor::execute($schema, Parser::parse($query));
-        $this->assertEquals(1, count($result->errors));
-        $this->assertInstanceOf(Error::class, $result->errors[0]->getPrevious());
+        self::assertEquals(1, count($result->errors));
+        self::assertInstanceOf(Error::class, $result->errors[0]->getPrevious());
 
-        $this->assertEquals(
+        self::assertEquals(
             'GraphQL Interface Type `Pet` returned `null` from it`s `resolveType` function for value: instance of ' .
             'GraphQL\Tests\Executor\TestClasses\Dog. Switching to slow resolution method using `isTypeOf` of all possible ' .
             'implementations. It requires full schema scan and degrades query performance significantly.  ' .
@@ -204,17 +204,17 @@ class ExecutorLazySchemaTest extends TestCase
             }
         ';
 
-        $this->assertEquals([], $calls);
+        self::assertEquals([], $calls);
         $result = Executor::execute($schema, Parser::parse($query), ['test' => ['test' => 'value']]);
-        $this->assertEquals(['Test', 'Test'], $calls);
+        self::assertEquals(['Test', 'Test'], $calls);
 
-        $this->assertEquals(
+        self::assertEquals(
             'Schema must contain unique named types but contains multiple types named "Test". ' .
             'Make sure that type loader returns the same instance as defined in Query.test ' .
             '(see http://webonyx.github.io/graphql-php/type-system/#type-registry).',
             $result->errors[0]->getMessage()
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             InvariantViolation::class,
             $result->errors[0]->getPrevious()
         );
@@ -244,8 +244,8 @@ class ExecutorLazySchemaTest extends TestCase
             'SomeObject',
             'SomeObject.fields',
         ];
-        $this->assertEquals($expected, $result->toArray(true));
-        $this->assertEquals($expectedExecutorCalls, $this->calls);
+        self::assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expectedExecutorCalls, $this->calls);
     }
 
     public function loadType($name, $isExecutorCall = false)
@@ -380,15 +380,15 @@ class ExecutorLazySchemaTest extends TestCase
             'OtherObject' => true,
         ];
 
-        $this->assertEquals($expected, $result->toArray(true));
-        $this->assertEquals($expectedLoadedTypes, $this->loadedTypes);
+        self::assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expectedLoadedTypes, $this->loadedTypes);
 
         $expectedExecutorCalls = [
             'Query.fields',
             'SomeObject',
             'SomeObject.fields',
         ];
-        $this->assertEquals($expectedExecutorCalls, $this->calls);
+        self::assertEquals($expectedExecutorCalls, $this->calls);
     }
 
     public function testResolveUnion() : void
@@ -428,8 +428,8 @@ class ExecutorLazySchemaTest extends TestCase
             'SomeScalar'    => true,
         ];
 
-        $this->assertEquals($expected, $result->toArray(true));
-        $this->assertEquals($expectedLoadedTypes, $this->loadedTypes);
+        self::assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expectedLoadedTypes, $this->loadedTypes);
 
         $expectedCalls = [
             'Query.fields',
@@ -441,6 +441,6 @@ class ExecutorLazySchemaTest extends TestCase
             'DeeperObject',
             'SomeScalar',
         ];
-        $this->assertEquals($expectedCalls, $this->calls);
+        self::assertEquals($expectedCalls, $this->calls);
     }
 }

--- a/tests/Executor/ExecutorSchemaTest.php
+++ b/tests/Executor/ExecutorSchemaTest.php
@@ -195,7 +195,7 @@ class ExecutorSchemaTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($BlogSchema, Parser::parse($request))->toArray());
+        self::assertEquals($expected, Executor::execute($BlogSchema, Parser::parse($request))->toArray());
     }
 
     private function article($id)

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -178,7 +178,7 @@ class ExecutorTest extends TestCase
         ]);
         $schema       = new Schema(['query' => $dataType]);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             Executor::execute($schema, $ast, $data, null, ['size' => 100], 'Example')->toArray()
         );
@@ -252,7 +252,7 @@ class ExecutorTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($schema, $ast)->toArray());
+        self::assertEquals($expected, Executor::execute($schema, $ast)->toArray());
     }
 
     /**
@@ -282,7 +282,7 @@ class ExecutorTest extends TestCase
 
         Executor::execute($schema, $ast, $rootValue, null, ['var' => '123']);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'fieldName',
                 'fieldNodes',
@@ -298,16 +298,16 @@ class ExecutorTest extends TestCase
             array_keys((array) $info)
         );
 
-        $this->assertEquals('test', $info->fieldName);
-        $this->assertEquals(1, count($info->fieldNodes));
-        $this->assertSame($ast->definitions[0]->selectionSet->selections[0], $info->fieldNodes[0]);
-        $this->assertSame(Type::string(), $info->returnType);
-        $this->assertSame($schema->getQueryType(), $info->parentType);
-        $this->assertEquals(['result'], $info->path);
-        $this->assertSame($schema, $info->schema);
-        $this->assertSame($rootValue, $info->rootValue);
-        $this->assertEquals($ast->definitions[0], $info->operation);
-        $this->assertEquals(['var' => '123'], $info->variableValues);
+        self::assertEquals('test', $info->fieldName);
+        self::assertEquals(1, count($info->fieldNodes));
+        self::assertSame($ast->definitions[0]->selectionSet->selections[0], $info->fieldNodes[0]);
+        self::assertSame(Type::string(), $info->returnType);
+        self::assertSame($schema->getQueryType(), $info->parentType);
+        self::assertEquals(['result'], $info->path);
+        self::assertSame($schema, $info->schema);
+        self::assertSame($rootValue, $info->rootValue);
+        self::assertEquals($ast->definitions[0], $info->operation);
+        self::assertEquals(['var' => '123'], $info->variableValues);
     }
 
     /**
@@ -330,7 +330,7 @@ class ExecutorTest extends TestCase
                     'a' => [
                         'type'    => Type::string(),
                         'resolve' => function ($context) use (&$gotHere) {
-                            $this->assertEquals('thing', $context['contextThing']);
+                            self::assertEquals('thing', $context['contextThing']);
                             $gotHere = true;
                         },
                     ],
@@ -339,7 +339,7 @@ class ExecutorTest extends TestCase
         ]);
 
         Executor::execute($schema, $ast, $data, null, [], 'Example');
-        $this->assertEquals(true, $gotHere);
+        self::assertEquals(true, $gotHere);
     }
 
     /**
@@ -367,8 +367,8 @@ class ExecutorTest extends TestCase
                         ],
                         'type'    => Type::string(),
                         'resolve' => function ($_, $args) use (&$gotHere) {
-                            $this->assertEquals(123, $args['numArg']);
-                            $this->assertEquals('foo', $args['stringArg']);
+                            self::assertEquals(123, $args['numArg']);
+                            self::assertEquals('foo', $args['stringArg']);
                             $gotHere = true;
                         },
                     ],
@@ -376,7 +376,7 @@ class ExecutorTest extends TestCase
             ]),
         ]);
         Executor::execute($schema, $docAst, null, null, [], 'Example');
-        $this->assertSame($gotHere, true);
+        self::assertSame($gotHere, true);
     }
 
     /**
@@ -558,7 +558,7 @@ class ExecutorTest extends TestCase
 
         $result = Executor::execute($schema, $docAst, $data)->toArray();
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -580,7 +580,7 @@ class ExecutorTest extends TestCase
 
         $ex = Executor::execute($schema, $ast, $data);
 
-        $this->assertEquals(['data' => ['a' => 'b']], $ex->toArray());
+        self::assertEquals(['data' => ['a' => 'b']], $ex->toArray());
     }
 
     /**
@@ -601,7 +601,7 @@ class ExecutorTest extends TestCase
         ]);
 
         $ex = Executor::execute($schema, $ast, $data);
-        $this->assertEquals(['data' => ['a' => 'b']], $ex->toArray());
+        self::assertEquals(['data' => ['a' => 'b']], $ex->toArray());
     }
 
     /**
@@ -622,7 +622,7 @@ class ExecutorTest extends TestCase
         ]);
 
         $result = Executor::execute($schema, $ast, $data, null, null, 'OtherExample');
-        $this->assertEquals(['data' => ['second' => 'b']], $result->toArray());
+        self::assertEquals(['data' => ['second' => 'b']], $result->toArray());
     }
 
     /**
@@ -649,7 +649,7 @@ class ExecutorTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result->toArray());
+        self::assertArraySubset($expected, $result->toArray());
     }
 
     /**
@@ -677,7 +677,7 @@ class ExecutorTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result->toArray());
+        self::assertArraySubset($expected, $result->toArray());
     }
 
     /**
@@ -712,7 +712,7 @@ class ExecutorTest extends TestCase
 
         ];
 
-        $this->assertArraySubset($expected, $result->toArray());
+        self::assertArraySubset($expected, $result->toArray());
     }
 
     /**
@@ -739,7 +739,7 @@ class ExecutorTest extends TestCase
         ]);
 
         $queryResult = Executor::execute($schema, $ast, $data, null, [], 'Q');
-        $this->assertEquals(['data' => ['a' => 'b']], $queryResult->toArray());
+        self::assertEquals(['data' => ['a' => 'b']], $queryResult->toArray());
     }
 
     /**
@@ -765,7 +765,7 @@ class ExecutorTest extends TestCase
             ]),
         ]);
         $mutationResult = Executor::execute($schema, $ast, $data, null, [], 'M');
-        $this->assertEquals(['data' => ['c' => 'd']], $mutationResult->toArray());
+        self::assertEquals(['data' => ['c' => 'd']], $mutationResult->toArray());
     }
 
     /**
@@ -792,7 +792,7 @@ class ExecutorTest extends TestCase
         ]);
 
         $subscriptionResult = Executor::execute($schema, $ast, $data, null, [], 'S');
-        $this->assertEquals(['data' => ['a' => 'b']], $subscriptionResult->toArray());
+        self::assertEquals(['data' => ['a' => 'b']], $subscriptionResult->toArray());
     }
 
     public function testCorrectFieldOrderingDespiteExecutionOrder() : void
@@ -850,7 +850,7 @@ class ExecutorTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($schema, $ast, $data)->toArray());
+        self::assertEquals($expected, Executor::execute($schema, $ast, $data)->toArray());
     }
 
     /**
@@ -882,7 +882,7 @@ class ExecutorTest extends TestCase
         ]);
 
         $queryResult = Executor::execute($schema, $ast, $data, null, [], 'Q');
-        $this->assertEquals(['data' => ['a' => 'b']], $queryResult->toArray());
+        self::assertEquals(['data' => ['a' => 'b']], $queryResult->toArray());
     }
 
     /**
@@ -909,7 +909,7 @@ class ExecutorTest extends TestCase
             ]),
         ]);
         $mutationResult = Executor::execute($schema, $ast);
-        $this->assertEquals(['data' => []], $mutationResult->toArray());
+        self::assertEquals(['data' => []], $mutationResult->toArray());
     }
 
     /**
@@ -944,7 +944,7 @@ class ExecutorTest extends TestCase
             'data' => ['field' => '{"a":true,"c":false,"e":0}'],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -982,7 +982,7 @@ class ExecutorTest extends TestCase
         ];
         $result = Executor::execute($schema, $query, $value);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'specials' => [
                     ['value' => 'foo'],
@@ -992,8 +992,8 @@ class ExecutorTest extends TestCase
             $result->data
         );
 
-        $this->assertEquals(1, count($result->errors));
-        $this->assertEquals(
+        self::assertEquals(1, count($result->errors));
+        self::assertEquals(
             [
                 'message'   => 'Expected value of type "SpecialType" but got: instance of GraphQL\Tests\Executor\TestClasses\NotSpecial.',
                 'locations' => [['line' => 1, 'column' => 3]],
@@ -1029,7 +1029,7 @@ class ExecutorTest extends TestCase
             'data' => ['foo' => null],
         ];
 
-        $this->assertArraySubset($expected, $result->toArray());
+        self::assertArraySubset($expected, $result->toArray());
     }
 
     /**
@@ -1067,7 +1067,7 @@ class ExecutorTest extends TestCase
             'data' => ['foo' => 'foo'],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     public function testSubstitutesArgumentWithDefaultValue() : void
@@ -1110,7 +1110,7 @@ class ExecutorTest extends TestCase
             'data' => ['field' => '{"a":1,"b":null,"c":0,"d":false,"e":"0","f":"some-string","h":{"a":1,"b":"test"}}'],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -1181,7 +1181,7 @@ class ExecutorTest extends TestCase
 
         $result = Executor::execute($schema, $query, $data, null);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'data' => [
                     'ab' => [

--- a/tests/Executor/LazyInterfaceTest.php
+++ b/tests/Executor/LazyInterfaceTest.php
@@ -50,7 +50,7 @@ class LazyInterfaceTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($this->schema, Parser::parse($request))->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, Parser::parse($request))->toArray());
     }
 
     /**

--- a/tests/Executor/ListsTest.php
+++ b/tests/Executor/ListsTest.php
@@ -71,7 +71,7 @@ class ListsTest extends TestCase
         $ast = Parser::parse('{ nest { test } }');
 
         $result = Executor::execute($schema, $ast, $data);
-        $this->assertArraySubset($expected, $result->toArray($debug));
+        self::assertArraySubset($expected, $result->toArray($debug));
     }
 
     /**

--- a/tests/Executor/MutationsTest.php
+++ b/tests/Executor/MutationsTest.php
@@ -48,7 +48,7 @@ class MutationsTest extends TestCase
                 'fifth'  => ['theNumber' => 5],
             ],
         ];
-        $this->assertEquals($expected, $mutationResult->toArray());
+        self::assertEquals($expected, $mutationResult->toArray());
     }
 
     private function schema() : Schema
@@ -151,6 +151,6 @@ class MutationsTest extends TestCase
                 ],
             ],
         ];
-        $this->assertArraySubset($expected, $mutationResult->toArray(true));
+        self::assertArraySubset($expected, $mutationResult->toArray(true));
     }
 }

--- a/tests/Executor/NonNullTest.php
+++ b/tests/Executor/NonNullTest.php
@@ -158,7 +158,7 @@ class NonNullTest extends TestCase
                 ),
             ],
         ];
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -184,7 +184,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -209,7 +209,7 @@ class NonNullTest extends TestCase
                 FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(4, 11)]),
             ],
         ];
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -234,7 +234,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -259,7 +259,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -284,7 +284,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -369,7 +369,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -443,7 +443,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -462,7 +462,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data' => ['sync' => null],
         ];
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray()
         );
@@ -482,7 +482,7 @@ class NonNullTest extends TestCase
             'data' => ['promise' => null],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray()
         );
@@ -509,7 +509,7 @@ class NonNullTest extends TestCase
                 ],
             ],
         ];
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );
@@ -537,7 +537,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );
@@ -565,7 +565,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );
@@ -593,7 +593,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );
@@ -662,7 +662,7 @@ class NonNullTest extends TestCase
         ];
 
         $actual = Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray();
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testNullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOfFieldsThatAreNonNull() : void
@@ -733,7 +733,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );
@@ -754,7 +754,7 @@ class NonNullTest extends TestCase
             ],
         ];
         $actual   = Executor::execute($this->schema, Parser::parse($doc), $this->throwingData)->toArray();
-        $this->assertArraySubset($expected, $actual);
+        self::assertArraySubset($expected, $actual);
     }
 
     public function testNullsTheTopLevelIfAsyncNonNullableFieldErrors() : void
@@ -771,7 +771,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->throwingData, null, [], 'Q')->toArray()
         );
@@ -792,7 +792,7 @@ class NonNullTest extends TestCase
                 ],
             ],
         ];
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, Parser::parse($doc), $this->nullingData)->toArray(true)
         );
@@ -815,7 +815,7 @@ class NonNullTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             $expected,
             Executor::execute($this->schema, $ast, $this->nullingData, null, [], 'Q')->toArray(true)
         );

--- a/tests/Executor/Promise/ReactPromiseAdapterTest.php
+++ b/tests/Executor/Promise/ReactPromiseAdapterTest.php
@@ -31,24 +31,24 @@ class ReactPromiseAdapterTest extends TestCase
     {
         $reactAdapter = new ReactPromiseAdapter();
 
-        $this->assertTrue(
+        self::assertTrue(
             $reactAdapter->isThenable(new ReactPromise(function () {
             }))
         );
-        $this->assertTrue($reactAdapter->isThenable(new FulfilledPromise()));
-        $this->assertTrue($reactAdapter->isThenable(new RejectedPromise()));
-        $this->assertTrue(
+        self::assertTrue($reactAdapter->isThenable(new FulfilledPromise()));
+        self::assertTrue($reactAdapter->isThenable(new RejectedPromise()));
+        self::assertTrue(
             $reactAdapter->isThenable(new LazyPromise(function () {
             }))
         );
-        $this->assertFalse($reactAdapter->isThenable(false));
-        $this->assertFalse($reactAdapter->isThenable(true));
-        $this->assertFalse($reactAdapter->isThenable(1));
-        $this->assertFalse($reactAdapter->isThenable(0));
-        $this->assertFalse($reactAdapter->isThenable('test'));
-        $this->assertFalse($reactAdapter->isThenable(''));
-        $this->assertFalse($reactAdapter->isThenable([]));
-        $this->assertFalse($reactAdapter->isThenable(new \stdClass()));
+        self::assertFalse($reactAdapter->isThenable(false));
+        self::assertFalse($reactAdapter->isThenable(true));
+        self::assertFalse($reactAdapter->isThenable(1));
+        self::assertFalse($reactAdapter->isThenable(0));
+        self::assertFalse($reactAdapter->isThenable('test'));
+        self::assertFalse($reactAdapter->isThenable(''));
+        self::assertFalse($reactAdapter->isThenable([]));
+        self::assertFalse($reactAdapter->isThenable(new \stdClass()));
     }
 
     public function testConvertsReactPromisesToGraphQlOnes() : void
@@ -58,8 +58,8 @@ class ReactPromiseAdapterTest extends TestCase
 
         $promise = $reactAdapter->convertThenable($reactPromise);
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
-        $this->assertInstanceOf('React\Promise\FulfilledPromise', $promise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
+        self::assertInstanceOf('React\Promise\FulfilledPromise', $promise->adoptedPromise);
     }
 
     public function testThen() : void
@@ -77,9 +77,9 @@ class ReactPromiseAdapterTest extends TestCase
             }
         );
 
-        $this->assertSame(1, $result);
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $resultPromise);
-        $this->assertInstanceOf('React\Promise\FulfilledPromise', $resultPromise->adoptedPromise);
+        self::assertSame(1, $result);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $resultPromise);
+        self::assertInstanceOf('React\Promise\FulfilledPromise', $resultPromise->adoptedPromise);
     }
 
     public function testCreate() : void
@@ -89,8 +89,8 @@ class ReactPromiseAdapterTest extends TestCase
             $resolve(1);
         });
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $resolvedPromise);
-        $this->assertInstanceOf('React\Promise\Promise', $resolvedPromise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $resolvedPromise);
+        self::assertInstanceOf('React\Promise\Promise', $resolvedPromise->adoptedPromise);
 
         $result = null;
 
@@ -98,7 +98,7 @@ class ReactPromiseAdapterTest extends TestCase
             $result = $value;
         });
 
-        $this->assertSame(1, $result);
+        self::assertSame(1, $result);
     }
 
     public function testCreateFulfilled() : void
@@ -106,8 +106,8 @@ class ReactPromiseAdapterTest extends TestCase
         $reactAdapter     = new ReactPromiseAdapter();
         $fulfilledPromise = $reactAdapter->createFulfilled(1);
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $fulfilledPromise);
-        $this->assertInstanceOf('React\Promise\FulfilledPromise', $fulfilledPromise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $fulfilledPromise);
+        self::assertInstanceOf('React\Promise\FulfilledPromise', $fulfilledPromise->adoptedPromise);
 
         $result = null;
 
@@ -115,7 +115,7 @@ class ReactPromiseAdapterTest extends TestCase
             $result = $value;
         });
 
-        $this->assertSame(1, $result);
+        self::assertSame(1, $result);
     }
 
     public function testCreateRejected() : void
@@ -123,8 +123,8 @@ class ReactPromiseAdapterTest extends TestCase
         $reactAdapter    = new ReactPromiseAdapter();
         $rejectedPromise = $reactAdapter->createRejected(new \Exception('I am a bad promise'));
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $rejectedPromise);
-        $this->assertInstanceOf('React\Promise\RejectedPromise', $rejectedPromise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $rejectedPromise);
+        self::assertInstanceOf('React\Promise\RejectedPromise', $rejectedPromise->adoptedPromise);
 
         $exception = null;
 
@@ -135,8 +135,8 @@ class ReactPromiseAdapterTest extends TestCase
             }
         );
 
-        $this->assertInstanceOf('\Exception', $exception);
-        $this->assertEquals('I am a bad promise', $exception->getMessage());
+        self::assertInstanceOf('\Exception', $exception);
+        self::assertEquals('I am a bad promise', $exception->getMessage());
     }
 
     public function testAll() : void
@@ -146,8 +146,8 @@ class ReactPromiseAdapterTest extends TestCase
 
         $allPromise = $reactAdapter->all($promises);
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $allPromise);
-        $this->assertInstanceOf('React\Promise\FulfilledPromise', $allPromise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $allPromise);
+        self::assertInstanceOf('React\Promise\FulfilledPromise', $allPromise->adoptedPromise);
 
         $result = null;
 
@@ -155,7 +155,7 @@ class ReactPromiseAdapterTest extends TestCase
             $result = $values;
         });
 
-        $this->assertSame([1, 2, 3], $result);
+        self::assertSame([1, 2, 3], $result);
     }
 
     public function testAllShouldPreserveTheOrderOfTheArrayWhenResolvingAsyncPromises() : void
@@ -171,6 +171,6 @@ class ReactPromiseAdapterTest extends TestCase
 
         // Resolve the async promise
         $deferred->resolve(2);
-        $this->assertSame([1, 2, 3], $result);
+        self::assertSame([1, 2, 3], $result);
     }
 }

--- a/tests/Executor/Promise/SyncPromiseAdapterTest.php
+++ b/tests/Executor/Promise/SyncPromiseAdapterTest.php
@@ -23,19 +23,19 @@ class SyncPromiseAdapterTest extends TestCase
 
     public function testIsThenable() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             true,
             $this->promises->isThenable(new Deferred(function () {
             }))
         );
-        $this->assertEquals(false, $this->promises->isThenable(false));
-        $this->assertEquals(false, $this->promises->isThenable(true));
-        $this->assertEquals(false, $this->promises->isThenable(1));
-        $this->assertEquals(false, $this->promises->isThenable(0));
-        $this->assertEquals(false, $this->promises->isThenable('test'));
-        $this->assertEquals(false, $this->promises->isThenable(''));
-        $this->assertEquals(false, $this->promises->isThenable([]));
-        $this->assertEquals(false, $this->promises->isThenable(new \stdClass()));
+        self::assertEquals(false, $this->promises->isThenable(false));
+        self::assertEquals(false, $this->promises->isThenable(true));
+        self::assertEquals(false, $this->promises->isThenable(1));
+        self::assertEquals(false, $this->promises->isThenable(0));
+        self::assertEquals(false, $this->promises->isThenable('test'));
+        self::assertEquals(false, $this->promises->isThenable(''));
+        self::assertEquals(false, $this->promises->isThenable([]));
+        self::assertEquals(false, $this->promises->isThenable(new \stdClass()));
     }
 
     public function testConvert() : void
@@ -44,8 +44,8 @@ class SyncPromiseAdapterTest extends TestCase
         });
         $result = $this->promises->convertThenable($dfd);
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $result);
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $result->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $result);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $result->adoptedPromise);
 
         $this->expectException(InvariantViolation::class);
         $this->expectExceptionMessage('Expected instance of GraphQL\Deferred, got (empty string)');
@@ -60,8 +60,8 @@ class SyncPromiseAdapterTest extends TestCase
 
         $result = $this->promises->then($promise);
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $result);
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $result->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $result);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $result->adoptedPromise);
     }
 
     public function testCreatePromise() : void
@@ -69,20 +69,20 @@ class SyncPromiseAdapterTest extends TestCase
         $promise = $this->promises->create(function ($resolve, $reject) {
         });
 
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $promise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $promise->adoptedPromise);
 
         $promise = $this->promises->create(function ($resolve, $reject) {
             $resolve('A');
         });
 
-        $this->assertValidPromise($promise, null, 'A', SyncPromise::FULFILLED);
+        self::assertValidPromise($promise, null, 'A', SyncPromise::FULFILLED);
     }
 
-    private function assertValidPromise($promise, $expectedNextReason, $expectedNextValue, $expectedNextState)
+    private static function assertValidPromise($promise, $expectedNextReason, $expectedNextValue, $expectedNextState)
     {
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
-        $this->assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $promise->adoptedPromise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Promise', $promise);
+        self::assertInstanceOf('GraphQL\Executor\Promise\Adapter\SyncPromise', $promise->adoptedPromise);
 
         $actualNextValue   = null;
         $actualNextReason  = null;
@@ -100,40 +100,40 @@ class SyncPromiseAdapterTest extends TestCase
             }
         );
 
-        $this->assertSame($onFulfilledCalled, false);
-        $this->assertSame($onRejectedCalled, false);
+        self::assertSame($onFulfilledCalled, false);
+        self::assertSame($onRejectedCalled, false);
 
         SyncPromise::runQueue();
 
         if ($expectedNextState !== SyncPromise::PENDING) {
-            $this->assertSame(! $expectedNextReason, $onFulfilledCalled);
-            $this->assertSame(! ! $expectedNextReason, $onRejectedCalled);
+            self::assertSame(! $expectedNextReason, $onFulfilledCalled);
+            self::assertSame(! ! $expectedNextReason, $onRejectedCalled);
         }
 
-        $this->assertSame($expectedNextValue, $actualNextValue);
-        $this->assertSame($expectedNextReason, $actualNextReason);
-        $this->assertSame($expectedNextState, $promise->adoptedPromise->state);
+        self::assertSame($expectedNextValue, $actualNextValue);
+        self::assertSame($expectedNextReason, $actualNextReason);
+        self::assertSame($expectedNextState, $promise->adoptedPromise->state);
     }
 
     public function testCreateFulfilledPromise() : void
     {
         $promise = $this->promises->createFulfilled('test');
-        $this->assertValidPromise($promise, null, 'test', SyncPromise::FULFILLED);
+        self::assertValidPromise($promise, null, 'test', SyncPromise::FULFILLED);
     }
 
     public function testCreateRejectedPromise() : void
     {
         $promise = $this->promises->createRejected(new \Exception('test reason'));
-        $this->assertValidPromise($promise, 'test reason', null, SyncPromise::REJECTED);
+        self::assertValidPromise($promise, 'test reason', null, SyncPromise::REJECTED);
     }
 
     public function testCreatePromiseAll() : void
     {
         $promise = $this->promises->all([]);
-        $this->assertValidPromise($promise, null, [], SyncPromise::FULFILLED);
+        self::assertValidPromise($promise, null, [], SyncPromise::FULFILLED);
 
         $promise = $this->promises->all(['1']);
-        $this->assertValidPromise($promise, null, ['1'], SyncPromise::FULFILLED);
+        self::assertValidPromise($promise, null, ['1'], SyncPromise::FULFILLED);
 
         $promise1 = new SyncPromise();
         $promise2 = new SyncPromise();
@@ -153,12 +153,12 @@ class SyncPromiseAdapterTest extends TestCase
         ];
 
         $promise = $this->promises->all($data);
-        $this->assertValidPromise($promise, null, null, SyncPromise::PENDING);
+        self::assertValidPromise($promise, null, null, SyncPromise::PENDING);
 
         $promise1->resolve('value1');
-        $this->assertValidPromise($promise, null, null, SyncPromise::PENDING);
+        self::assertValidPromise($promise, null, null, SyncPromise::PENDING);
         $promise2->resolve('value2');
-        $this->assertValidPromise(
+        self::assertValidPromise(
             $promise,
             null,
             ['1', 'value1', 'value2', 3, 'value2-value3', []],
@@ -205,15 +205,15 @@ class SyncPromiseAdapterTest extends TestCase
         $all = $this->promises->all([0, $p1, $p2, $p3, $p4]);
 
         $result = $this->promises->wait($p2);
-        $this->assertEquals(2, $result);
-        $this->assertEquals(SyncPromise::PENDING, $p3->adoptedPromise->state);
-        $this->assertEquals(SyncPromise::PENDING, $all->adoptedPromise->state);
-        $this->assertEquals([1, 2], $called);
+        self::assertEquals(2, $result);
+        self::assertEquals(SyncPromise::PENDING, $p3->adoptedPromise->state);
+        self::assertEquals(SyncPromise::PENDING, $all->adoptedPromise->state);
+        self::assertEquals([1, 2], $called);
 
         $expectedResult = [0, 1, 2, 3, 4];
         $result         = $this->promises->wait($all);
-        $this->assertEquals($expectedResult, $result);
-        $this->assertEquals([1, 2, 3, 4], $called);
-        $this->assertValidPromise($all, null, [0, 1, 2, 3, 4], SyncPromise::FULFILLED);
+        self::assertEquals($expectedResult, $result);
+        self::assertEquals([1, 2, 3, 4], $called);
+        self::assertValidPromise($all, null, [0, 1, 2, 3, 4], SyncPromise::FULFILLED);
     }
 }

--- a/tests/Executor/Promise/SyncPromiseTest.php
+++ b/tests/Executor/Promise/SyncPromiseTest.php
@@ -50,10 +50,10 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->resolve($resolvedValue);
-        $this->assertEquals(SyncPromise::FULFILLED, $promise->state);
+        self::assertEquals(SyncPromise::FULFILLED, $promise->state);
 
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage('Cannot change value of fulfilled promise');
@@ -71,10 +71,10 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->resolve($resolvedValue);
-        $this->assertEquals(SyncPromise::FULFILLED, $promise->state);
+        self::assertEquals(SyncPromise::FULFILLED, $promise->state);
 
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage('Cannot reject fulfilled promise');
@@ -92,17 +92,17 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->resolve($resolvedValue);
-        $this->assertEquals(SyncPromise::FULFILLED, $promise->state);
+        self::assertEquals(SyncPromise::FULFILLED, $promise->state);
 
         $nextPromise = $promise->then(
             null,
             function () {
             }
         );
-        $this->assertSame($promise, $nextPromise);
+        self::assertSame($promise, $nextPromise);
 
         $onRejectedCalled = false;
         $nextPromise      = $promise->then(
@@ -113,61 +113,61 @@ class SyncPromiseTest extends TestCase
         );
 
         if ($onFulfilled) {
-            $this->assertNotSame($promise, $nextPromise);
-            $this->assertEquals(SyncPromise::PENDING, $nextPromise->state);
+            self::assertNotSame($promise, $nextPromise);
+            self::assertEquals(SyncPromise::PENDING, $nextPromise->state);
         } else {
-            $this->assertEquals(SyncPromise::FULFILLED, $nextPromise->state);
+            self::assertEquals(SyncPromise::FULFILLED, $nextPromise->state);
         }
-        $this->assertEquals(false, $onRejectedCalled);
+        self::assertEquals(false, $onRejectedCalled);
 
-        $this->assertValidPromise($nextPromise, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertValidPromise($nextPromise, $expectedNextReason, $expectedNextValue, $expectedNextState);
 
         $nextPromise2 = $promise->then($onFulfilled);
         $nextPromise3 = $promise->then($onFulfilled);
 
         if ($onFulfilled) {
-            $this->assertNotSame($nextPromise, $nextPromise2);
+            self::assertNotSame($nextPromise, $nextPromise2);
         }
 
         SyncPromise::runQueue();
 
-        $this->assertValidPromise($nextPromise2, $expectedNextReason, $expectedNextValue, $expectedNextState);
-        $this->assertValidPromise($nextPromise3, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertValidPromise($nextPromise2, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertValidPromise($nextPromise3, $expectedNextReason, $expectedNextValue, $expectedNextState);
     }
 
-    private function assertValidPromise(
+    private static function assertValidPromise(
         SyncPromise $promise,
         $expectedNextReason,
         $expectedNextValue,
         $expectedNextState
-    ) {
+    ) : void {
         $actualNextValue   = null;
         $actualNextReason  = null;
         $onFulfilledCalled = false;
         $onRejectedCalled  = false;
 
         $promise->then(
-            function ($nextValue) use (&$actualNextValue, &$onFulfilledCalled) {
+            static function ($nextValue) use (&$actualNextValue, &$onFulfilledCalled) {
                 $onFulfilledCalled = true;
                 $actualNextValue   = $nextValue;
             },
-            function (\Throwable $reason) use (&$actualNextReason, &$onRejectedCalled) {
+            static function (\Throwable $reason) use (&$actualNextReason, &$onRejectedCalled) {
                 $onRejectedCalled = true;
                 $actualNextReason = $reason->getMessage();
             }
         );
 
-        $this->assertEquals($onFulfilledCalled, false);
-        $this->assertEquals($onRejectedCalled, false);
+        self::assertEquals($onFulfilledCalled, false);
+        self::assertEquals($onRejectedCalled, false);
 
         SyncPromise::runQueue();
 
-        $this->assertEquals(! $expectedNextReason, $onFulfilledCalled);
-        $this->assertEquals(! ! $expectedNextReason, $onRejectedCalled);
+        self::assertEquals(! $expectedNextReason, $onFulfilledCalled);
+        self::assertEquals(! ! $expectedNextReason, $onRejectedCalled);
 
-        $this->assertEquals($expectedNextValue, $actualNextValue);
-        $this->assertEquals($expectedNextReason, $actualNextReason);
-        $this->assertEquals($expectedNextState, $promise->state);
+        self::assertEquals($expectedNextValue, $actualNextValue);
+        self::assertEquals($expectedNextReason, $actualNextReason);
+        self::assertEquals($expectedNextState, $promise->state);
     }
 
     public function getRejectedPromiseData()
@@ -209,10 +209,10 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->reject($rejectedReason);
-        $this->assertEquals(SyncPromise::REJECTED, $promise->state);
+        self::assertEquals(SyncPromise::REJECTED, $promise->state);
 
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage('Cannot change rejection reason');
@@ -230,10 +230,10 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->reject($rejectedReason);
-        $this->assertEquals(SyncPromise::REJECTED, $promise->state);
+        self::assertEquals(SyncPromise::REJECTED, $promise->state);
 
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage('Cannot resolve rejected promise');
@@ -251,23 +251,23 @@ class SyncPromiseTest extends TestCase
         $expectedNextState
     ) {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $promise->reject($rejectedReason);
-        $this->assertEquals(SyncPromise::REJECTED, $promise->state);
+        self::assertEquals(SyncPromise::REJECTED, $promise->state);
 
         try {
             $promise->reject(new \Exception('other-reason'));
             $this->fail('Expected exception not thrown');
         } catch (\Throwable $e) {
-            $this->assertEquals('Cannot change rejection reason', $e->getMessage());
+            self::assertEquals('Cannot change rejection reason', $e->getMessage());
         }
 
         try {
             $promise->resolve('anything');
             $this->fail('Expected exception not thrown');
         } catch (\Throwable $e) {
-            $this->assertEquals('Cannot resolve rejected promise', $e->getMessage());
+            self::assertEquals('Cannot resolve rejected promise', $e->getMessage());
         }
 
         $nextPromise = $promise->then(
@@ -275,7 +275,7 @@ class SyncPromiseTest extends TestCase
             },
             null
         );
-        $this->assertSame($promise, $nextPromise);
+        self::assertSame($promise, $nextPromise);
 
         $onFulfilledCalled = false;
         $nextPromise       = $promise->then(
@@ -286,60 +286,60 @@ class SyncPromiseTest extends TestCase
         );
 
         if ($onRejected) {
-            $this->assertNotSame($promise, $nextPromise);
-            $this->assertEquals(SyncPromise::PENDING, $nextPromise->state);
+            self::assertNotSame($promise, $nextPromise);
+            self::assertEquals(SyncPromise::PENDING, $nextPromise->state);
         } else {
-            $this->assertEquals(SyncPromise::REJECTED, $nextPromise->state);
+            self::assertEquals(SyncPromise::REJECTED, $nextPromise->state);
         }
-        $this->assertEquals(false, $onFulfilledCalled);
-        $this->assertValidPromise($nextPromise, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertEquals(false, $onFulfilledCalled);
+        self::assertValidPromise($nextPromise, $expectedNextReason, $expectedNextValue, $expectedNextState);
 
         $nextPromise2 = $promise->then(null, $onRejected);
         $nextPromise3 = $promise->then(null, $onRejected);
 
         if ($onRejected) {
-            $this->assertNotSame($nextPromise, $nextPromise2);
+            self::assertNotSame($nextPromise, $nextPromise2);
         }
 
         SyncPromise::runQueue();
 
-        $this->assertValidPromise($nextPromise2, $expectedNextReason, $expectedNextValue, $expectedNextState);
-        $this->assertValidPromise($nextPromise3, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertValidPromise($nextPromise2, $expectedNextReason, $expectedNextValue, $expectedNextState);
+        self::assertValidPromise($nextPromise3, $expectedNextReason, $expectedNextValue, $expectedNextState);
     }
 
     public function testPendingPromise() : void
     {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         try {
             $promise->resolve($promise);
             $this->fail('Expected exception not thrown');
         } catch (\Throwable $e) {
-            $this->assertEquals('Cannot resolve promise with self', $e->getMessage());
-            $this->assertEquals(SyncPromise::PENDING, $promise->state);
+            self::assertEquals('Cannot resolve promise with self', $e->getMessage());
+            self::assertEquals(SyncPromise::PENDING, $promise->state);
         }
 
         // Try to resolve with other promise (must resolve when other promise resolves)
         $otherPromise = new SyncPromise();
         $promise->resolve($otherPromise);
 
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
-        $this->assertEquals(SyncPromise::PENDING, $otherPromise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $otherPromise->state);
 
         $otherPromise->resolve('the value');
-        $this->assertEquals(SyncPromise::FULFILLED, $otherPromise->state);
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
-        $this->assertValidPromise($promise, null, 'the value', SyncPromise::FULFILLED);
+        self::assertEquals(SyncPromise::FULFILLED, $otherPromise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertValidPromise($promise, null, 'the value', SyncPromise::FULFILLED);
 
         $promise = new SyncPromise();
         $promise->resolve('resolved!');
 
-        $this->assertValidPromise($promise, null, 'resolved!', SyncPromise::FULFILLED);
+        self::assertValidPromise($promise, null, 'resolved!', SyncPromise::FULFILLED);
 
         // Test rejections
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         try {
             $promise->reject('a');
@@ -347,11 +347,11 @@ class SyncPromiseTest extends TestCase
         } catch (Error $e) {
             throw $e;
         } catch (\Throwable $e) {
-            $this->assertEquals(SyncPromise::PENDING, $promise->state);
+            self::assertEquals(SyncPromise::PENDING, $promise->state);
         }
 
         $promise->reject(new \Exception('Rejected Reason'));
-        $this->assertValidPromise($promise, 'Rejected Reason', null, SyncPromise::REJECTED);
+        self::assertValidPromise($promise, 'Rejected Reason', null, SyncPromise::REJECTED);
 
         $promise  = new SyncPromise();
         $promise2 = $promise->then(
@@ -361,23 +361,23 @@ class SyncPromiseTest extends TestCase
             }
         );
         $promise->reject(new \Exception('Rejected Again'));
-        $this->assertValidPromise($promise2, null, 'value', SyncPromise::FULFILLED);
+        self::assertValidPromise($promise2, null, 'value', SyncPromise::FULFILLED);
 
         $promise  = new SyncPromise();
         $promise2 = $promise->then();
         $promise->reject(new \Exception('Rejected Once Again'));
-        $this->assertValidPromise($promise2, 'Rejected Once Again', null, SyncPromise::REJECTED);
+        self::assertValidPromise($promise2, 'Rejected Once Again', null, SyncPromise::REJECTED);
     }
 
     public function testPendingPromiseThen() : void
     {
         $promise = new SyncPromise();
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
 
         $nextPromise = $promise->then();
-        $this->assertNotSame($promise, $nextPromise);
-        $this->assertEquals(SyncPromise::PENDING, $promise->state);
-        $this->assertEquals(SyncPromise::PENDING, $nextPromise->state);
+        self::assertNotSame($promise, $nextPromise);
+        self::assertEquals(SyncPromise::PENDING, $promise->state);
+        self::assertEquals(SyncPromise::PENDING, $nextPromise->state);
 
         // Make sure that it queues derivative promises until resolution:
         $onFulfilledCount = 0;
@@ -397,26 +397,26 @@ class SyncPromiseTest extends TestCase
         $nextPromise3 = $promise->then($onFulfilled, $onRejected);
         $nextPromise4 = $promise->then($onFulfilled, $onRejected);
 
-        $this->assertEquals(SyncPromise::getQueue()->count(), 0);
-        $this->assertEquals($onFulfilledCount, 0);
-        $this->assertEquals($onRejectedCount, 0);
+        self::assertEquals(SyncPromise::getQueue()->count(), 0);
+        self::assertEquals($onFulfilledCount, 0);
+        self::assertEquals($onRejectedCount, 0);
         $promise->resolve(1);
 
-        $this->assertEquals(SyncPromise::getQueue()->count(), 4);
-        $this->assertEquals($onFulfilledCount, 0);
-        $this->assertEquals($onRejectedCount, 0);
-        $this->assertEquals(SyncPromise::PENDING, $nextPromise->state);
-        $this->assertEquals(SyncPromise::PENDING, $nextPromise2->state);
-        $this->assertEquals(SyncPromise::PENDING, $nextPromise3->state);
-        $this->assertEquals(SyncPromise::PENDING, $nextPromise4->state);
+        self::assertEquals(SyncPromise::getQueue()->count(), 4);
+        self::assertEquals($onFulfilledCount, 0);
+        self::assertEquals($onRejectedCount, 0);
+        self::assertEquals(SyncPromise::PENDING, $nextPromise->state);
+        self::assertEquals(SyncPromise::PENDING, $nextPromise2->state);
+        self::assertEquals(SyncPromise::PENDING, $nextPromise3->state);
+        self::assertEquals(SyncPromise::PENDING, $nextPromise4->state);
 
         SyncPromise::runQueue();
-        $this->assertEquals(SyncPromise::getQueue()->count(), 0);
-        $this->assertEquals($onFulfilledCount, 3);
-        $this->assertEquals($onRejectedCount, 0);
-        $this->assertValidPromise($nextPromise, null, 1, SyncPromise::FULFILLED);
-        $this->assertValidPromise($nextPromise2, null, 1, SyncPromise::FULFILLED);
-        $this->assertValidPromise($nextPromise3, null, 2, SyncPromise::FULFILLED);
-        $this->assertValidPromise($nextPromise4, null, 3, SyncPromise::FULFILLED);
+        self::assertEquals(SyncPromise::getQueue()->count(), 0);
+        self::assertEquals($onFulfilledCount, 3);
+        self::assertEquals($onRejectedCount, 0);
+        self::assertValidPromise($nextPromise, null, 1, SyncPromise::FULFILLED);
+        self::assertValidPromise($nextPromise2, null, 1, SyncPromise::FULFILLED);
+        self::assertValidPromise($nextPromise3, null, 2, SyncPromise::FULFILLED);
+        self::assertValidPromise($nextPromise4, null, 3, SyncPromise::FULFILLED);
     }
 }

--- a/tests/Executor/ResolveTest.php
+++ b/tests/Executor/ResolveTest.php
@@ -26,7 +26,7 @@ class ResolveTest extends TestCase
 
         $source = ['test' => 'testValue'];
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => 'testValue']],
             GraphQL::executeQuery($schema, '{ test }', $source)->toArray()
         );
@@ -55,7 +55,7 @@ class ResolveTest extends TestCase
                 return $_secret;
             },
         ];
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => $_secret]],
             GraphQL::executeQuery($schema, '{ test }', $source)->toArray()
         );
@@ -76,7 +76,7 @@ class ResolveTest extends TestCase
         $source = new Adder(700);
 
         $result = GraphQL::executeQuery($schema, '{ test(addend1: 80) }', $source, ['addend2' => 9])->toArray();
-        $this->assertEquals(['data' => ['test' => 789]], $result);
+        self::assertEquals(['data' => ['test' => 789]], $result);
     }
 
     /**
@@ -95,22 +95,22 @@ class ResolveTest extends TestCase
             },
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => '[null,[]]']],
             GraphQL::executeQuery($schema, '{ test }')->toArray()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => '["Source!",[]]']],
             GraphQL::executeQuery($schema, '{ test }', 'Source!')->toArray()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => '["Source!",{"aStr":"String!"}]']],
             GraphQL::executeQuery($schema, '{ test(aStr: "String!") }', 'Source!')->toArray()
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['test' => '["Source!",{"aStr":"String!","aInt":-123}]']],
             GraphQL::executeQuery($schema, '{ test(aInt: -123, aStr: "String!") }', 'Source!')->toArray()
         );

--- a/tests/Executor/SyncTest.php
+++ b/tests/Executor/SyncTest.php
@@ -79,7 +79,7 @@ class SyncTest extends TestCase
             Parser::parse($doc),
             'rootValue'
         );
-        $this->assertSync(['errors' => [['message' => 'Must provide an operation.']]], $result);
+        self::assertSync(['errors' => [['message' => 'Must provide an operation.']]], $result);
     }
 
     private function execute($schema, $doc, $rootValue = null)
@@ -87,14 +87,14 @@ class SyncTest extends TestCase
         return Executor::promiseToExecute($this->promiseAdapter, $schema, $doc, $rootValue);
     }
 
-    private function assertSync($expectedFinalArray, $actualResult)
+    private static function assertSync($expectedFinalArray, $actualResult) : void
     {
         $message = 'Failed assertion that execution was synchronous';
-        $this->assertInstanceOf(Promise::class, $actualResult, $message);
-        $this->assertInstanceOf(SyncPromise::class, $actualResult->adoptedPromise, $message);
-        $this->assertEquals(SyncPromise::FULFILLED, $actualResult->adoptedPromise->state, $message);
-        $this->assertInstanceOf(ExecutionResult::class, $actualResult->adoptedPromise->result, $message);
-        $this->assertArraySubset(
+        self::assertInstanceOf(Promise::class, $actualResult, $message);
+        self::assertInstanceOf(SyncPromise::class, $actualResult->adoptedPromise, $message);
+        self::assertEquals(SyncPromise::FULFILLED, $actualResult->adoptedPromise->state, $message);
+        self::assertInstanceOf(ExecutionResult::class, $actualResult->adoptedPromise->result, $message);
+        self::assertArraySubset(
             $expectedFinalArray,
             $actualResult->adoptedPromise->result->toArray(),
             false,
@@ -113,7 +113,7 @@ class SyncTest extends TestCase
             Parser::parse($doc),
             'rootValue'
         );
-        $this->assertSync(['data' => ['syncField' => 'rootValue']], $result);
+        self::assertSync(['data' => ['syncField' => 'rootValue']], $result);
     }
 
     // Describe: graphqlSync
@@ -129,7 +129,7 @@ class SyncTest extends TestCase
             Parser::parse($doc),
             'rootValue'
         );
-        $this->assertSync(['data' => ['syncMutationField' => 'rootValue']], $result);
+        self::assertSync(['data' => ['syncMutationField' => 'rootValue']], $result);
     }
 
     /**
@@ -149,12 +149,12 @@ class SyncTest extends TestCase
     private function assertAsync($expectedFinalArray, $actualResult)
     {
         $message = 'Failed assertion that execution was asynchronous';
-        $this->assertInstanceOf(Promise::class, $actualResult, $message);
-        $this->assertInstanceOf(SyncPromise::class, $actualResult->adoptedPromise, $message);
-        $this->assertEquals(SyncPromise::PENDING, $actualResult->adoptedPromise->state, $message);
+        self::assertInstanceOf(Promise::class, $actualResult, $message);
+        self::assertInstanceOf(SyncPromise::class, $actualResult->adoptedPromise, $message);
+        self::assertEquals(SyncPromise::PENDING, $actualResult->adoptedPromise->state, $message);
         $resolvedResult = $this->promiseAdapter->wait($actualResult);
-        $this->assertInstanceOf(ExecutionResult::class, $resolvedResult, $message);
-        $this->assertArraySubset($expectedFinalArray, $resolvedResult->toArray(), false, $message);
+        self::assertInstanceOf(ExecutionResult::class, $resolvedResult, $message);
+        self::assertArraySubset($expectedFinalArray, $resolvedResult->toArray(), false, $message);
     }
 
     /**
@@ -167,7 +167,7 @@ class SyncTest extends TestCase
             $this->schema,
             $doc
         );
-        $this->assertSync(
+        self::assertSync(
             [
                 'errors' => [
                     [
@@ -204,7 +204,7 @@ class SyncTest extends TestCase
                 }
             ),
         ];
-        $this->assertSync($expected, $result);
+        self::assertSync($expected, $result);
     }
 
     /**
@@ -218,6 +218,6 @@ class SyncTest extends TestCase
             $doc,
             'rootValue'
         );
-        $this->assertSync(['data' => ['syncField' => 'rootValue']], $result);
+        self::assertSync(['data' => ['syncField' => 'rootValue']], $result);
     }
 }

--- a/tests/Executor/UnionInterfaceTest.php
+++ b/tests/Executor/UnionInterfaceTest.php
@@ -166,7 +166,7 @@ class UnionInterfaceTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast)->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, $ast)->toArray());
     }
 
     /**
@@ -198,7 +198,7 @@ class UnionInterfaceTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
     }
 
     /**
@@ -235,7 +235,7 @@ class UnionInterfaceTest extends TestCase
 
             ],
         ];
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
     }
 
     /**
@@ -267,7 +267,7 @@ class UnionInterfaceTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
     }
 
     /**
@@ -303,7 +303,7 @@ class UnionInterfaceTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray(true));
+        self::assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray(true));
     }
 
     /**
@@ -358,7 +358,7 @@ class UnionInterfaceTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
+        self::assertEquals($expected, Executor::execute($this->schema, $ast, $this->john)->toArray());
     }
 
     /**
@@ -412,12 +412,12 @@ class UnionInterfaceTest extends TestCase
 
         $ast = Parser::parse('{ name, friends { name } }');
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['name' => 'John', 'friends' => [['name' => 'Liz']]]],
             GraphQL::executeQuery($schema2, $ast, $john2, $context)->toArray()
         );
-        $this->assertSame($context, $encounteredContext);
-        $this->assertSame($schema2, $encounteredSchema);
-        $this->assertSame($john2, $encounteredRootValue);
+        self::assertSame($context, $encounteredContext);
+        self::assertSame($schema2, $encounteredSchema);
+        self::assertSame($john2, $encounteredRootValue);
     }
 }

--- a/tests/Executor/ValuesTest.php
+++ b/tests/Executor/ValuesTest.php
@@ -25,7 +25,7 @@ class ValuesTest extends TestCase
     public function testGetIDVariableValues() : void
     {
         $this->expectInputVariablesMatchOutputVariables(['idInput' => '123456789']);
-        $this->assertEquals(
+        self::assertEquals(
             ['errors' => [], 'coerced' => ['idInput' => '123456789']],
             $this->runTestCase(['idInput' => 123456789]),
             'Integer ID was not converted to string'
@@ -34,7 +34,7 @@ class ValuesTest extends TestCase
 
     private function expectInputVariablesMatchOutputVariables($variables) : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             $variables,
             $this->runTestCase($variables)['coerced'],
             'Output variables did not match input variables' . PHP_EOL . var_export($variables, true) . PHP_EOL
@@ -148,7 +148,7 @@ class ValuesTest extends TestCase
     private function expectGraphQLError($variables) : void
     {
         $result = $this->runTestCase($variables);
-        $this->assertGreaterThan(0, count($result['errors']));
+        self::assertGreaterThan(0, count($result['errors']));
     }
 
     public function testFloatForIDVariableThrowsError() : void

--- a/tests/Executor/VariablesTest.php
+++ b/tests/Executor/VariablesTest.php
@@ -33,7 +33,7 @@ class VariablesTest extends TestCase
         $expected = [
             'data' => ['fieldWithObjectInput' => '{"a":"foo","b":["bar"],"c":"baz"}'],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // properly parses single value to list:
         $result   = $this->executeQuery('
@@ -43,7 +43,7 @@ class VariablesTest extends TestCase
         ');
         $expected = ['data' => ['fieldWithObjectInput' => '{"a":"foo","b":["bar"],"c":"baz"}']];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // properly parses null value to null
         $result   = $this->executeQuery('
@@ -53,7 +53,7 @@ class VariablesTest extends TestCase
         ');
         $expected = ['data' => ['fieldWithObjectInput' => '{"a":null,"b":null,"c":"C","d":null}']];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // properly parses null value in list
         $result   = $this->executeQuery('
@@ -63,7 +63,7 @@ class VariablesTest extends TestCase
         ');
         $expected = ['data' => ['fieldWithObjectInput' => '{"b":["A",null,"C"],"c":"C"}']];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // does not use incorrect value
         $result = $this->executeQuery('
@@ -81,7 +81,7 @@ class VariablesTest extends TestCase
             ],
             ],
         ];
-        $this->assertArraySubset($expected, $result->toArray());
+        self::assertArraySubset($expected, $result->toArray());
 
         // properly runs parseLiteral on complex scalar types
         $result = $this->executeQuery('
@@ -89,7 +89,7 @@ class VariablesTest extends TestCase
           fieldWithObjectInput(input: {c: "foo", d: "SerializedValue"})
         }
         ');
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['fieldWithObjectInput' => '{"c":"foo","d":"DeserializedValue"}']],
             $result->toArray()
         );
@@ -178,7 +178,7 @@ class VariablesTest extends TestCase
         $params = ['input' => ['a' => 'foo', 'b' => ['bar'], 'c' => 'baz']];
         $result = $this->executeQuery($doc, $params);
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['fieldWithObjectInput' => '{"a":"foo","b":["bar"],"c":"baz"}']],
             $result->toArray()
         );
@@ -193,12 +193,12 @@ class VariablesTest extends TestCase
         $expected = [
             'data' => ['fieldWithObjectInput' => '{"a":"foo","b":["bar"],"c":"baz"}'],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // properly parses single value to list:
         $params = ['input' => ['a' => 'foo', 'b' => 'bar', 'c' => 'baz']];
         $result = $this->executeQuery($doc, $params);
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['fieldWithObjectInput' => '{"a":"foo","b":["bar"],"c":"baz"}']],
             $result->toArray()
         );
@@ -209,7 +209,7 @@ class VariablesTest extends TestCase
         $expected = [
             'data' => ['fieldWithObjectInput' => '{"c":"foo","d":"DeserializedValue"}'],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // errors on null for nested non-null:
         $params   = ['input' => ['a' => 'foo', 'b' => 'bar', 'c' => null]];
@@ -227,7 +227,7 @@ class VariablesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // errors on incorrect type:
         $params   = ['input' => 'foo bar'];
@@ -243,7 +243,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // errors on omission of nested non-null:
         $params = ['input' => ['a' => 'foo', 'b' => 'bar']];
@@ -260,7 +260,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // errors on deep nested errors and with many errors
         $nestedDoc = '
@@ -289,7 +289,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // errors on addition of unknown input field
         $params   = ['input' => ['a' => 'foo', 'b' => 'bar', 'c' => 'baz', 'extra' => 'dog']];
@@ -306,7 +306,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -323,7 +323,7 @@ class VariablesTest extends TestCase
             'data' => ['fieldWithNullableStringInput' => null],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -338,7 +338,7 @@ class VariablesTest extends TestCase
         ');
         $expected = ['data' => ['fieldWithNullableStringInput' => null]];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -352,7 +352,7 @@ class VariablesTest extends TestCase
       }
       ');
         $expected = ['data' => ['fieldWithNullableStringInput' => null]];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
 
@@ -370,7 +370,7 @@ class VariablesTest extends TestCase
         ');
         $expected = ['data' => ['fieldWithNullableStringInput' => null]];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -385,7 +385,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['value' => 'a']);
         $expected = ['data' => ['fieldWithNullableStringInput' => '"a"']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -399,7 +399,7 @@ class VariablesTest extends TestCase
       }
         ');
         $expected = ['data' => ['fieldWithNullableStringInput' => '"a"']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -415,7 +415,7 @@ class VariablesTest extends TestCase
         $expected = [
             'data' => ['fieldWithNonNullableStringInput' => '"default"'],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -438,7 +438,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -463,7 +463,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -478,7 +478,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['value' => 'a']);
         $expected = ['data' => ['fieldWithNonNullableStringInput' => '"a"']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -492,7 +492,7 @@ class VariablesTest extends TestCase
       }
         ');
         $expected = ['data' => ['fieldWithNonNullableStringInput' => '"a"']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -515,7 +515,7 @@ class VariablesTest extends TestCase
             ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     // Describe: Handles lists and nullability
@@ -545,7 +545,7 @@ class VariablesTest extends TestCase
             ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -585,7 +585,7 @@ class VariablesTest extends TestCase
             ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -601,7 +601,7 @@ class VariablesTest extends TestCase
         $result   = $this->executeQuery($doc, ['input' => null]);
         $expected = ['data' => ['list' => null]];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -616,7 +616,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A']]);
         $expected = ['data' => ['list' => '["A"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -631,7 +631,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A', null, 'B']]);
         $expected = ['data' => ['list' => '["A",null,"B"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -656,7 +656,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -671,7 +671,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A']]);
         $expected = ['data' => ['nnList' => '["A"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -686,7 +686,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A', null, 'B']]);
         $expected = ['data' => ['nnList' => '["A",null,"B"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -701,7 +701,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => null]);
         $expected = ['data' => ['listNN' => null]];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -716,7 +716,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A']]);
         $expected = ['data' => ['listNN' => '["A"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -741,7 +741,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -766,7 +766,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -781,7 +781,7 @@ class VariablesTest extends TestCase
         ';
         $result   = $this->executeQuery($doc, ['input' => ['A']]);
         $expected = ['data' => ['nnListNN' => '["A"]']];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     // Describe: Execute: Uses argument default values
@@ -808,7 +808,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -834,7 +834,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -861,7 +861,7 @@ class VariablesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     /**
@@ -873,7 +873,7 @@ class VariablesTest extends TestCase
         fieldWithDefaultArgumentValue
         }');
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['fieldWithDefaultArgumentValue' => '"Hello World"']],
             $result->toArray()
         );
@@ -888,7 +888,7 @@ class VariablesTest extends TestCase
             fieldWithDefaultArgumentValue(input: $optional)
         }');
 
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['fieldWithDefaultArgumentValue' => '"Hello World"']],
             $result->toArray()
         );
@@ -915,6 +915,6 @@ class VariablesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 }

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -35,7 +35,7 @@ class LexerTest extends TestCase
         try {
             $this->lexOne($text);
         } catch (SyntaxError $error) {
-            $this->assertEquals([$location], $error->getLocations());
+            self::assertEquals([$location], $error->getLocations());
             throw $error;
         }
     }
@@ -69,7 +69,7 @@ class LexerTest extends TestCase
             'value' => 'foo',
         ];
 
-        $this->assertArraySubset($expected, (array) $this->lexOne($bom . ' foo'));
+        self::assertArraySubset($expected, (array) $this->lexOne($bom . ' foo'));
     }
 
     /**
@@ -85,7 +85,7 @@ class LexerTest extends TestCase
             'column' => 3,
             'value'  => 'foo',
         ];
-        $this->assertArraySubset($expected, (array) $this->lexOne("\n \r\n \r  foo\n"));
+        self::assertArraySubset($expected, (array) $this->lexOne("\n \r\n \r  foo\n"));
     }
 
     /**
@@ -105,7 +105,7 @@ class LexerTest extends TestCase
             'end'   => 9,
             'value' => 'foo',
         ];
-        $this->assertArraySubset($expected, (array) $this->lexOne($example1));
+        self::assertArraySubset($expected, (array) $this->lexOne($example1));
 
         $example2 = '
     #comment
@@ -118,7 +118,7 @@ class LexerTest extends TestCase
             'end'   => 21,
             'value' => 'foo',
         ];
-        $this->assertArraySubset($expected, (array) $this->lexOne($example2));
+        self::assertArraySubset($expected, (array) $this->lexOne($example2));
 
         $expected = [
             'kind'  => Token::NAME,
@@ -128,7 +128,7 @@ class LexerTest extends TestCase
         ];
 
         $example3 = ',,,foo,,,';
-        $this->assertArraySubset($expected, (array) $this->lexOne($example3));
+        self::assertArraySubset($expected, (array) $this->lexOne($example3));
     }
 
     /**
@@ -146,7 +146,7 @@ class LexerTest extends TestCase
             $this->lexOne($str);
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $error) {
-            $this->assertEquals(
+            self::assertEquals(
                 'Syntax Error: Cannot parse the unexpected character "?".' . "\n" .
                 "\n" .
                 "GraphQL request (3:5)\n" .
@@ -176,7 +176,7 @@ class LexerTest extends TestCase
             $lexer->advance();
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $error) {
-            $this->assertEquals(
+            self::assertEquals(
                 'Syntax Error: Cannot parse the unexpected character "?".' . "\n" .
                 "\n" .
                 "foo.js (13:6)\n" .
@@ -198,7 +198,7 @@ class LexerTest extends TestCase
             $lexer->advance();
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $error) {
-            $this->assertEquals(
+            self::assertEquals(
                 'Syntax Error: Cannot parse the unexpected character "?".' . "\n" .
                 "\n" .
                 "foo.js (1:5)\n" .
@@ -214,7 +214,7 @@ class LexerTest extends TestCase
      */
     public function testLexesStrings() : void
     {
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -224,7 +224,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"simple"')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -234,7 +234,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('" white space "')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -244,7 +244,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"quote \\""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -254,7 +254,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"escaped \\\\n\\\\r\\\\b\\\\t\\\\f"')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -264,7 +264,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"slashes \\\\ \\\\/"')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -275,7 +275,7 @@ class LexerTest extends TestCase
         );
 
         $unicode = json_decode('"\u1234\u5678\u90AB\uCDEF"');
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -285,7 +285,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"unicode \u1234\u5678\u90AB\uCDEF"')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::STRING,
                 'start' => 0,
@@ -301,7 +301,7 @@ class LexerTest extends TestCase
      */
     public function testLexesBlockString() : void
     {
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -311,7 +311,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"""simple"""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -321,7 +321,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('""" white space """')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -331,7 +331,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"""contains " quote"""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -341,7 +341,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"""contains \\""" triplequote"""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -351,7 +351,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne("\"\"\"multi\nline\"\"\"")
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -361,7 +361,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne("\"\"\"multi\rline\r\nnormalized\"\"\"")
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -371,7 +371,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"""unescaped \\n\\r\\b\\t\\f\\u1234"""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -381,7 +381,7 @@ class LexerTest extends TestCase
             (array) $this->lexOne('"""slashes \\\\ \\/"""')
         );
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'kind'  => Token::BLOCK_STRING,
                 'start' => 0,
@@ -479,67 +479,67 @@ class LexerTest extends TestCase
      */
     public function testLexesNumbers() : void
     {
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::INT, 'start' => 0, 'end' => 1, 'value' => '4'],
             (array) $this->lexOne('4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 5, 'value' => '4.123'],
             (array) $this->lexOne('4.123')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::INT, 'start' => 0, 'end' => 2, 'value' => '-4'],
             (array) $this->lexOne('-4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::INT, 'start' => 0, 'end' => 1, 'value' => '9'],
             (array) $this->lexOne('9')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::INT, 'start' => 0, 'end' => 1, 'value' => '0'],
             (array) $this->lexOne('0')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 6, 'value' => '-4.123'],
             (array) $this->lexOne('-4.123')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 5, 'value' => '0.123'],
             (array) $this->lexOne('0.123')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 5, 'value' => '123e4'],
             (array) $this->lexOne('123e4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 5, 'value' => '123E4'],
             (array) $this->lexOne('123E4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 6, 'value' => '123e-4'],
             (array) $this->lexOne('123e-4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 6, 'value' => '123e+4'],
             (array) $this->lexOne('123e+4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 8, 'value' => '-1.123e4'],
             (array) $this->lexOne('-1.123e4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 8, 'value' => '-1.123E4'],
             (array) $this->lexOne('-1.123E4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 9, 'value' => '-1.123e-4'],
             (array) $this->lexOne('-1.123e-4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 9, 'value' => '-1.123e+4'],
             (array) $this->lexOne('-1.123e+4')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::FLOAT, 'start' => 0, 'end' => 11, 'value' => '-1.123e4567'],
             (array) $this->lexOne('-1.123e4567')
         );
@@ -574,55 +574,55 @@ class LexerTest extends TestCase
      */
     public function testLexesPunctuation() : void
     {
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::BANG, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('!')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::DOLLAR, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('$')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::PAREN_L, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('(')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::PAREN_R, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne(')')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::SPREAD, 'start' => 0, 'end' => 3, 'value' => null],
             (array) $this->lexOne('...')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::COLON, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne(':')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::EQUALS, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('=')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::AT, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('@')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::BRACKET_L, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('[')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::BRACKET_R, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne(']')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::BRACE_L, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('{')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::PIPE, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('|')
         );
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::BRACE_R, 'start' => 0, 'end' => 1, 'value' => null],
             (array) $this->lexOne('}')
         );
@@ -657,7 +657,7 @@ class LexerTest extends TestCase
     {
         $q     = 'a-b';
         $lexer = new Lexer(new Source($q));
-        $this->assertArraySubset(
+        self::assertArraySubset(
             ['kind' => Token::NAME, 'start' => 0, 'end' => 1, 'value' => 'a'],
             (array) $lexer->advance()
         );
@@ -668,7 +668,7 @@ class LexerTest extends TestCase
             $lexer->advance();
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $error) {
-            $this->assertEquals([$this->loc(1, 3)], $error->getLocations());
+            self::assertEquals([$this->loc(1, 3)], $error->getLocations());
             throw $error;
         }
     }
@@ -688,22 +688,22 @@ class LexerTest extends TestCase
             $endToken = $lexer->advance();
             // Lexer advances over ignored comment tokens to make writing parsers
             // easier, but will include them in the linked list result.
-            $this->assertNotEquals('Comment', $endToken->kind);
+            self::assertNotEquals('Comment', $endToken->kind);
         } while ($endToken->kind !== '<EOF>');
 
-        $this->assertEquals(null, $startToken->prev);
-        $this->assertEquals(null, $endToken->next);
+        self::assertEquals(null, $startToken->prev);
+        self::assertEquals(null, $endToken->next);
 
         $tokens = [];
         for ($tok = $startToken; $tok; $tok = $tok->next) {
             if (! empty($tokens)) {
                 // Tokens are double-linked, prev should point to last seen token.
-                $this->assertSame($tokens[count($tokens) - 1], $tok->prev);
+                self::assertSame($tokens[count($tokens) - 1], $tok->prev);
             }
             $tokens[] = $tok;
         }
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 '<SOF>',
                 '{',

--- a/tests/Language/ParserTest.php
+++ b/tests/Language/ParserTest.php
@@ -86,15 +86,15 @@ fragment MissingOn Type
             Parser::parse($str);
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $e) {
-            $this->assertEquals($expectedMessage, $e->getMessage());
-            $this->assertEquals($stringRepresentation, (string) $e);
+            self::assertEquals($expectedMessage, $e->getMessage());
+            self::assertEquals($stringRepresentation, (string) $e);
 
             if ($expectedPositions) {
-                $this->assertEquals($expectedPositions, $e->getPositions());
+                self::assertEquals($expectedPositions, $e->getPositions());
             }
 
             if ($expectedLocations) {
-                $this->assertEquals($expectedLocations, $e->getLocations());
+                self::assertEquals($expectedLocations, $e->getLocations());
             }
         }
     }
@@ -108,7 +108,7 @@ fragment MissingOn Type
             Parser::parse(new Source('query', 'MyQuery.graphql'));
             $this->fail('Expected exception not thrown');
         } catch (SyntaxError $error) {
-            $this->assertEquals(
+            self::assertEquals(
                 "Syntax Error: Expected {, found <EOF>\n\nMyQuery.graphql (1:6)\n1: query\n        ^\n",
                 (string) $error
             );
@@ -144,7 +144,7 @@ fragment MissingOn Type
         try {
             Parser::parse($text);
         } catch (SyntaxError $error) {
-            $this->assertEquals([$location], $error->getLocations());
+            self::assertEquals([$location], $error->getLocations());
             throw $error;
         }
     }
@@ -210,7 +210,7 @@ HEREDOC;
             ]),
         ]);
 
-        $this->assertEquals($expected, $result->definitions[0]->selectionSet);
+        self::assertEquals($expected, $result->definitions[0]->selectionSet);
     }
 
     /**
@@ -221,7 +221,7 @@ HEREDOC;
         // Following should not throw:
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
         $result      = Parser::parse($kitchenSink);
-        $this->assertNotEmpty($result);
+        self::assertNotEmpty($result);
     }
 
     /**
@@ -258,7 +258,7 @@ fragment $fragmentName on Type {
 }
 GRAPHQL
             );
-            $this->assertNotEmpty($result);
+            self::assertNotEmpty($result);
         }
     }
 
@@ -418,7 +418,7 @@ GRAPHQL
             ],
         ];
 
-        $this->assertEquals($expected, self::nodeToArray($result));
+        self::assertEquals($expected, self::nodeToArray($result));
     }
 
     /**
@@ -501,7 +501,7 @@ GRAPHQL
             ],
         ];
 
-        $this->assertEquals($expected, $this->nodeToArray($result));
+        self::assertEquals($expected, $this->nodeToArray($result));
     }
 
     /**
@@ -512,7 +512,7 @@ GRAPHQL
         $source = new Source('{ id }');
         $result = Parser::parse($source, ['noLocation' => true]);
 
-        $this->assertEquals(null, $result->loc);
+        self::assertEquals(null, $result->loc);
     }
 
     /**
@@ -537,7 +537,7 @@ GRAPHQL
     {
         $source = new Source('{ id }');
         $result = Parser::parse($source);
-        $this->assertEquals(['start' => 0, 'end' => '6'], TestUtils::locationToArray($result->loc));
+        self::assertEquals(['start' => 0, 'end' => '6'], TestUtils::locationToArray($result->loc));
     }
 
     /**
@@ -547,7 +547,7 @@ GRAPHQL
     {
         $source = new Source('{ id }');
         $result = Parser::parse($source);
-        $this->assertEquals($source, $result->loc->source);
+        self::assertEquals($source, $result->loc->source);
     }
 
     // Describe: parseType
@@ -559,8 +559,8 @@ GRAPHQL
     {
         $source = new Source('{ id }');
         $result = Parser::parse($source);
-        $this->assertEquals('<SOF>', $result->loc->startToken->kind);
-        $this->assertEquals('<EOF>', $result->loc->endToken->kind);
+        self::assertEquals('<SOF>', $result->loc->startToken->kind);
+        self::assertEquals('<EOF>', $result->loc->endToken->kind);
     }
 
     /**
@@ -568,7 +568,7 @@ GRAPHQL
      */
     public function testParsesNullValues() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::NULL,
                 'loc'  => ['start' => 0, 'end' => 4],
@@ -582,7 +582,7 @@ GRAPHQL
      */
     public function testParsesListValues() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind'   => NodeKind::LST,
                 'loc'    => ['start' => 0, 'end' => 11],
@@ -609,7 +609,7 @@ GRAPHQL
      */
     public function testParsesWellKnownTypes() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::NAMED_TYPE,
                 'loc'  => ['start' => 0, 'end' => 6],
@@ -628,7 +628,7 @@ GRAPHQL
      */
     public function testParsesCustomTypes() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::NAMED_TYPE,
                 'loc'  => ['start' => 0, 'end' => 6],
@@ -647,7 +647,7 @@ GRAPHQL
      */
     public function testParsesListTypes() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::LIST_TYPE,
                 'loc'  => ['start' => 0, 'end' => 8],
@@ -670,7 +670,7 @@ GRAPHQL
      */
     public function testParsesNonNullTypes() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::NON_NULL_TYPE,
                 'loc'  => ['start' => 0, 'end' => 7],
@@ -693,7 +693,7 @@ GRAPHQL
      */
     public function testParsesNestedTypes() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'kind' => NodeKind::LIST_TYPE,
                 'loc'  => ['start' => 0, 'end' => 9],

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -22,10 +22,10 @@ class PrinterTest extends TestCase
         $ast         = Parser::parse($kitchenSink);
 
         $astCopy = $ast->cloneDeep();
-        $this->assertEquals($astCopy, $ast);
+        self::assertEquals($astCopy, $ast);
 
         Printer::doPrint($ast);
-        $this->assertEquals($astCopy, $ast);
+        self::assertEquals($astCopy, $ast);
     }
 
     /**
@@ -34,7 +34,7 @@ class PrinterTest extends TestCase
     public function testPrintsMinimalAst() : void
     {
         $ast = new FieldNode(['name' => new NameNode(['value' => 'foo'])]);
-        $this->assertEquals('foo', Printer::doPrint($ast));
+        self::assertEquals('foo', Printer::doPrint($ast));
     }
 
     /**
@@ -60,7 +60,7 @@ class PrinterTest extends TestCase
   name
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($queryAstShorthanded));
+        self::assertEquals($expected, Printer::doPrint($queryAstShorthanded));
 
         $mutationAst = Parser::parse('mutation { id, name }');
         $expected    = 'mutation {
@@ -68,7 +68,7 @@ class PrinterTest extends TestCase
   name
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($mutationAst));
+        self::assertEquals($expected, Printer::doPrint($mutationAst));
 
         $queryAstWithArtifacts = Parser::parse(
             'query ($foo: TestType) @testDirective { id, name }'
@@ -78,7 +78,7 @@ class PrinterTest extends TestCase
   name
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($queryAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($queryAstWithArtifacts));
 
         $mutationAstWithArtifacts = Parser::parse(
             'mutation ($foo: TestType) @testDirective { id, name }'
@@ -88,7 +88,7 @@ class PrinterTest extends TestCase
   name
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
     /**
@@ -103,7 +103,7 @@ class PrinterTest extends TestCase
   field(arg: """    space-led value""")
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
     /**
@@ -128,7 +128,7 @@ class PrinterTest extends TestCase
   """)
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
     /**
@@ -149,7 +149,7 @@ class PrinterTest extends TestCase
 }
 
 END;
-        $this->assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
     /**
@@ -166,7 +166,7 @@ END;
             ['experimentalFragmentVariables' => true]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Printer::doPrint($fragmentWithVariable),
             'fragment Foo($a: ComplexType, $b: Boolean = false) on TestType {
   id
@@ -191,7 +191,7 @@ END;
   """)
 }
 ';
-        $this->assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
+        self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
     /**
@@ -259,6 +259,6 @@ fragment frag on Friend {
 }
 
 EOT;
-        $this->assertEquals($expected, $printed);
+        self::assertEquals($expected, $printed);
     }
 }

--- a/tests/Language/SchemaParserTest.php
+++ b/tests/Language/SchemaParserTest.php
@@ -48,7 +48,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 31),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     private function nameNode($name, $loc)
@@ -128,7 +128,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 45),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -175,7 +175,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 85),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -213,7 +213,7 @@ extend type Hello {
             ],
             'loc'         => $loc(0, 39),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -243,7 +243,7 @@ extend type Hello {
             ],
             'loc'         => $loc(0, 37),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -279,7 +279,7 @@ extend type Hello {
             ],
             'loc'         => ['start' => 0, 'end' => 116],
         ];
-        $this->assertEquals($expected, $doc->toArray(true));
+        self::assertEquals($expected, $doc->toArray(true));
     }
 
     /**
@@ -301,7 +301,7 @@ extend type Hello {
         try {
             Parser::parse($text);
         } catch (SyntaxError $error) {
-            $this->assertEquals([$location], $error->getLocations());
+            self::assertEquals([$location], $error->getLocations());
             throw $error;
         }
     }
@@ -386,7 +386,7 @@ type Hello {
             'loc'         => $loc(0, 32),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -424,7 +424,7 @@ type Hello {
             'loc'         => $loc(0, 45),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -463,7 +463,7 @@ type Hello {
             'loc'         => $loc(0, 48),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -501,7 +501,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 50),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -530,7 +530,7 @@ type Hello {
             'loc'         => $loc(0, 20),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     private function enumValueNode($name, $loc)
@@ -573,7 +573,7 @@ type Hello {
             'loc'         => $loc(0, 22),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -610,7 +610,7 @@ interface Hello {
             ],
             'loc'         => $loc(0, 36),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -657,7 +657,7 @@ type Hello {
             'loc'         => $loc(0, 46),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     private function inputValueNode($name, $type, $defaultValue, $loc)
@@ -716,7 +716,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 53),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -769,7 +769,7 @@ type Hello {
             'loc'         => $loc(0, 49),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -822,7 +822,7 @@ type Hello {
             'loc'         => $loc(0, 61),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -851,7 +851,7 @@ type Hello {
             'loc'         => $loc(0, 19),
         ];
 
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -882,7 +882,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 22),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -909,7 +909,7 @@ type Hello {
             ],
             'loc'         => ['start' => 0, 'end' => 24],
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -984,7 +984,7 @@ type Hello {
             ],
             'loc'         => $loc(0, 12),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -1022,7 +1022,7 @@ input Hello {
             ],
             'loc'         => $loc(0, 32),
         ];
-        $this->assertEquals($expected, TestUtils::nodeToArray($doc));
+        self::assertEquals($expected, TestUtils::nodeToArray($doc));
     }
 
     /**
@@ -1076,7 +1076,7 @@ input Hello {
                 ],
             ],
         ];
-        $this->assertArraySubset($expected, $doc->toArray(true));
+        self::assertArraySubset($expected, $doc->toArray(true));
     }
 
     public function testDoesntAllowLegacySDLImplementsInterfacesByDefault() : void
@@ -1102,6 +1102,6 @@ input Hello {
                 ],
             ],
         ];
-        $this->assertArraySubset($expected, $doc->toArray(true));
+        self::assertArraySubset($expected, $doc->toArray(true));
     }
 }

--- a/tests/Language/SchemaPrinterTest.php
+++ b/tests/Language/SchemaPrinterTest.php
@@ -22,7 +22,7 @@ class SchemaPrinterTest extends TestCase
         $ast = new ScalarTypeDefinitionNode([
             'name' => new NameNode(['value' => 'foo']),
         ]);
-        $this->assertEquals('scalar foo', Printer::doPrint($ast));
+        self::assertEquals('scalar foo', Printer::doPrint($ast));
     }
 
     /**
@@ -49,7 +49,7 @@ class SchemaPrinterTest extends TestCase
         $astCopy = $ast->cloneDeep();
         Printer::doPrint($ast);
 
-        $this->assertEquals($astCopy, $ast);
+        self::assertEquals($astCopy, $ast);
     }
 
     public function testPrintsKitchenSink() : void
@@ -166,6 +166,6 @@ directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 ';
-        $this->assertEquals($expected, $printed);
+        self::assertEquals($expected, $printed);
     }
 }

--- a/tests/Language/SerializationTest.php
+++ b/tests/Language/SerializationTest.php
@@ -25,7 +25,7 @@ class SerializationTest extends TestCase
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
         $ast         = Parser::parse($kitchenSink);
         $expectedAst = json_decode(file_get_contents(__DIR__ . '/kitchen-sink.ast'), true);
-        $this->assertEquals($expectedAst, $ast->toArray(true));
+        self::assertEquals($expectedAst, $ast->toArray(true));
     }
 
     public function testUnserializesAst() : void
@@ -34,7 +34,7 @@ class SerializationTest extends TestCase
         $serializedAst = json_decode(file_get_contents(__DIR__ . '/kitchen-sink.ast'), true);
         $actualAst     = AST::fromArray($serializedAst);
         $parsedAst     = Parser::parse($kitchenSink);
-        $this->assertNodesAreEqual($parsedAst, $actualAst);
+        self::assertNodesAreEqual($parsedAst, $actualAst);
     }
 
     /**
@@ -42,17 +42,17 @@ class SerializationTest extends TestCase
      *
      * @param string[] $path
      */
-    private function assertNodesAreEqual(Node $expected, Node $actual, array $path = []) : void
+    private static function assertNodesAreEqual(Node $expected, Node $actual, array $path = []) : void
     {
         $err = 'Mismatch at AST path: ' . implode(', ', $path);
 
-        $this->assertInstanceOf(Node::class, $actual, $err);
-        $this->assertEquals(get_class($expected), get_class($actual), $err);
+        self::assertInstanceOf(Node::class, $actual, $err);
+        self::assertEquals(get_class($expected), get_class($actual), $err);
 
         $expectedVars = get_object_vars($expected);
         $actualVars   = get_object_vars($actual);
-        $this->assertCount(count($expectedVars), $actualVars, $err);
-        $this->assertEquals(array_keys($expectedVars), array_keys($actualVars), $err);
+        self::assertCount(count($expectedVars), $actualVars, $err);
+        self::assertEquals(array_keys($expectedVars), array_keys($actualVars), $err);
 
         foreach ($expectedVars as $name => $expectedValue) {
             $actualValue = $actualVars[$name];
@@ -61,22 +61,22 @@ class SerializationTest extends TestCase
             $err         = 'Mismatch at AST path: ' . implode(', ', $tmpPath);
 
             if ($expectedValue instanceof Node) {
-                $this->assertNodesAreEqual($expectedValue, $actualValue, $tmpPath);
+                self::assertNodesAreEqual($expectedValue, $actualValue, $tmpPath);
             } elseif ($expectedValue instanceof NodeList) {
-                $this->assertEquals(count($expectedValue), count($actualValue), $err);
-                $this->assertInstanceOf(NodeList::class, $actualValue, $err);
+                self::assertEquals(count($expectedValue), count($actualValue), $err);
+                self::assertInstanceOf(NodeList::class, $actualValue, $err);
 
                 foreach ($expectedValue as $index => $listNode) {
                     $tmpPath2   = $tmpPath;
                     $tmpPath2[] = $index;
-                    $this->assertNodesAreEqual($listNode, $actualValue[$index], $tmpPath2);
+                    self::assertNodesAreEqual($listNode, $actualValue[$index], $tmpPath2);
                 }
             } elseif ($expectedValue instanceof Location) {
-                $this->assertInstanceOf(Location::class, $actualValue, $err);
-                $this->assertSame($expectedValue->start, $actualValue->start, $err);
-                $this->assertSame($expectedValue->end, $actualValue->end, $err);
+                self::assertInstanceOf(Location::class, $actualValue, $err);
+                self::assertSame($expectedValue->start, $actualValue->start, $err);
+                self::assertSame($expectedValue->end, $actualValue->end, $err);
             } else {
-                $this->assertEquals($expectedValue, $actualValue, $err);
+                self::assertEquals($expectedValue, $actualValue, $err);
             }
         }
     }
@@ -86,7 +86,7 @@ class SerializationTest extends TestCase
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
         $ast         = Parser::parse($kitchenSink, ['noLocation' => true]);
         $expectedAst = json_decode(file_get_contents(__DIR__ . '/kitchen-sink-noloc.ast'), true);
-        $this->assertEquals($expectedAst, $ast->toArray(true));
+        self::assertEquals($expectedAst, $ast->toArray(true));
     }
 
     public function testUnserializeSupportsNoLocationOption() : void
@@ -95,6 +95,6 @@ class SerializationTest extends TestCase
         $serializedAst = json_decode(file_get_contents(__DIR__ . '/kitchen-sink-noloc.ast'), true);
         $actualAst     = AST::fromArray($serializedAst);
         $parsedAst     = Parser::parse($kitchenSink, ['noLocation' => true]);
-        $this->assertNodesAreEqual($parsedAst, $actualAst);
+        self::assertNodesAreEqual($parsedAst, $actualAst);
     }
 }

--- a/tests/Language/TokenTest.php
+++ b/tests/Language/TokenTest.php
@@ -19,6 +19,6 @@ class TokenTest extends TestCase
             'column' => 5,
         ];
 
-        $this->assertEquals($expected, $token->toArray());
+        self::assertEquals($expected, $token->toArray());
     }
 }

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -62,7 +62,7 @@ class VisitorTest extends ValidatorTestCase
             ['leave', []],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     private function checkVisitorFnArgs($ast, $args, $isEdited = false)
@@ -72,41 +72,41 @@ class VisitorTest extends ValidatorTestCase
 
         $parentArray = $parent && ! is_array($parent) ? ($parent instanceof NodeList ? iterator_to_array($parent) : $parent->toArray()) : $parent;
 
-        $this->assertInstanceOf(Node::class, $node);
-        $this->assertContains($node->kind, array_keys(NodeKind::$classMap));
+        self::assertInstanceOf(Node::class, $node);
+        self::assertContains($node->kind, array_keys(NodeKind::$classMap));
 
         $isRoot = $key === null;
         if ($isRoot) {
             if (! $isEdited) {
-                $this->assertEquals($ast, $node);
+                self::assertEquals($ast, $node);
             }
-            $this->assertEquals(null, $parent);
-            $this->assertEquals([], $path);
-            $this->assertEquals([], $ancestors);
+            self::assertEquals(null, $parent);
+            self::assertEquals([], $path);
+            self::assertEquals([], $ancestors);
 
             return;
         }
 
-        $this->assertContains(gettype($key), ['integer', 'string']);
+        self::assertContains(gettype($key), ['integer', 'string']);
 
-        $this->assertArrayHasKey($key, $parentArray);
+        self::assertArrayHasKey($key, $parentArray);
 
-        $this->assertInternalType('array', $path);
-        $this->assertEquals($key, $path[count($path) - 1]);
+        self::assertInternalType('array', $path);
+        self::assertEquals($key, $path[count($path) - 1]);
 
-        $this->assertInternalType('array', $ancestors);
-        $this->assertCount(count($path) - 1, $ancestors);
+        self::assertInternalType('array', $ancestors);
+        self::assertCount(count($path) - 1, $ancestors);
 
         if ($isEdited) {
             return;
         }
 
-        $this->assertEquals($node, $parentArray[$key]);
-        $this->assertEquals($node, $this->getNodeByPath($ast, $path));
+        self::assertEquals($node, $parentArray[$key]);
+        self::assertEquals($node, $this->getNodeByPath($ast, $path));
         $ancestorsLength = count($ancestors);
         for ($i = 0; $i < $ancestorsLength; ++$i) {
             $ancestorPath = array_slice($path, 0, $i);
-            $this->assertEquals($ancestors[$i], $this->getNodeByPath($ast, $ancestorPath));
+            self::assertEquals($ancestors[$i], $this->getNodeByPath($ast, $ancestorPath));
         }
     }
 
@@ -115,7 +115,7 @@ class VisitorTest extends ValidatorTestCase
         $result = $ast;
         foreach ($path as $key) {
             $resultArray = $result instanceof NodeList ? iterator_to_array($result) : $result->toArray();
-            $this->assertArrayHasKey($key, $resultArray);
+            self::assertArrayHasKey($key, $resultArray);
             $result = $resultArray[$key];
         }
 
@@ -155,13 +155,13 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertNotEquals($ast, $editedAst);
+        self::assertNotEquals($ast, $editedAst);
 
         $expected                           = $ast->cloneDeep();
         $expected->definitions[0]->didEnter = true;
         $expected->definitions[0]->didLeave = true;
 
-        $this->assertEquals($expected, $editedAst);
+        self::assertEquals($expected, $editedAst);
     }
 
     public function testAllowsEditingRootNodeOnEnterAndLeave() : void
@@ -190,13 +190,13 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertNotEquals($ast, $editedAst);
+        self::assertNotEquals($ast, $editedAst);
 
         $tmp           = $ast->cloneDeep();
         $tmp->didEnter = true;
         $tmp->didLeave = true;
 
-        $this->assertEquals($tmp, $editedAst);
+        self::assertEquals($tmp, $editedAst);
     }
 
     public function testAllowsForEditingOnEnter() : void
@@ -214,11 +214,11 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a, b, c { a, b, c } }', ['noLocation' => true]),
             $ast
         );
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a,    c { a,    c } }', ['noLocation' => true]),
             $editedAst
         );
@@ -239,12 +239,12 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a, b, c { a, b, c } }', ['noLocation' => true]),
             $ast
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a,    c { a,    c } }', ['noLocation' => true]),
             $editedAst
         );
@@ -281,7 +281,7 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertTrue($didVisitAddedField);
+        self::assertTrue($didVisitAddedField);
     }
 
     public function testAllowsSkippingASubTree() : void
@@ -324,7 +324,7 @@ class VisitorTest extends ValidatorTestCase
             ['leave', 'Document', null],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     public function testAllowsEarlyExitWhileVisiting() : void
@@ -365,7 +365,7 @@ class VisitorTest extends ValidatorTestCase
             ['enter', 'Name', 'x'],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     public function testAllowsEarlyExitWhileLeaving() : void
@@ -391,7 +391,7 @@ class VisitorTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $visited,
             [
                 ['enter', 'Document', null],
@@ -448,7 +448,7 @@ class VisitorTest extends ValidatorTestCase
             ['leave', 'SelectionSet', null],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     public function testExperimentalVisitsVariablesDefinedInFragments() : void
@@ -507,7 +507,7 @@ class VisitorTest extends ValidatorTestCase
             ['leave', 'Document', null],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     public function testVisitsKitchenSink() : void
@@ -845,7 +845,7 @@ class VisitorTest extends ValidatorTestCase
             ['leave', 'Document', null, null],
         ];
 
-        $this->assertEquals($expected, $visited);
+        self::assertEquals($expected, $visited);
     }
 
     /**
@@ -878,7 +878,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null],
             ['enter', 'OperationDefinition', null],
@@ -937,7 +937,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['no-a', 'enter', 'Document', null],
             ['no-b', 'enter', 'Document', null],
@@ -1002,7 +1002,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null],
             ['enter', 'OperationDefinition', null],
@@ -1061,7 +1061,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['break-a', 'enter', 'Document', null],
             ['break-b', 'enter', 'Document', null],
@@ -1112,7 +1112,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null],
             ['enter', 'OperationDefinition', null],
@@ -1170,7 +1170,7 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['break-a', 'enter', 'Document', null],
             ['break-b', 'enter', 'Document', null],
@@ -1242,17 +1242,17 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a, b, c { a, b, c } }', ['noLocation' => true]),
             $ast
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a,    c { a,    c } }', ['noLocation' => true]),
             $editedAst
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null],
             ['enter', 'OperationDefinition', null],
@@ -1312,17 +1312,17 @@ class VisitorTest extends ValidatorTestCase
             ])
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a, b, c { a, b, c } }', ['noLocation' => true]),
             $ast
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Parser::parse('{ a,    c { a,    c } }', ['noLocation' => true]),
             $editedAst
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null],
             ['enter', 'OperationDefinition', null],
@@ -1406,7 +1406,7 @@ class VisitorTest extends ValidatorTestCase
             )
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null, null, null, null],
             ['enter', 'OperationDefinition', null, null, 'QueryRoot', null],
@@ -1518,21 +1518,21 @@ class VisitorTest extends ValidatorTestCase
             )
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Printer::doPrint(Parser::parse(
                 '{ human(id: 4) { name, pets }, alien }'
             )),
             Printer::doPrint($ast)
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             Printer::doPrint(Parser::parse(
                 '{ human(id: 4) { name, pets { __typename } }, alien { __typename } }'
             )),
             Printer::doPrint($editedAst)
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
             ['enter', 'Document', null, null, null, null],
             ['enter', 'OperationDefinition', null, null, 'QueryRoot', null],

--- a/tests/Server/PsrResponseTest.php
+++ b/tests/Server/PsrResponseTest.php
@@ -23,7 +23,7 @@ class PsrResponseTest extends TestCase
 
         /** @var PsrResponseStub $resp */
         $resp = $helper->toPsrResponse($result, $psrResponse, $stream);
-        $this->assertSame(json_encode($result), $resp->body->content);
-        $this->assertSame(['Content-Type' => ['application/json']], $resp->headers);
+        self::assertSame(json_encode($result), $resp->body->content);
+        self::assertSame(['Content-Type' => ['application/json']], $resp->headers);
     }
 }

--- a/tests/Server/QueryExecutionTest.php
+++ b/tests/Server/QueryExecutionTest.php
@@ -46,7 +46,7 @@ class QueryExecutionTest extends ServerTestCase
     private function assertQueryResultEquals($expected, $query, $variables = null)
     {
         $result = $this->executeQuery($query, $variables);
-        $this->assertArraySubset($expected, $result->toArray(true));
+        self::assertArraySubset($expected, $result->toArray(true));
 
         return $result;
     }
@@ -56,7 +56,7 @@ class QueryExecutionTest extends ServerTestCase
         $op     = OperationParams::create(['query' => $query, 'variables' => $variables], $readonly);
         $helper = new Helper();
         $result = $helper->executeOperation($this->config, $op);
-        $this->assertInstanceOf(ExecutionResult::class, $result);
+        self::assertInstanceOf(ExecutionResult::class, $result);
 
         return $result;
     }
@@ -66,9 +66,9 @@ class QueryExecutionTest extends ServerTestCase
         $query = '{f1';
 
         $result = $this->executeQuery($query);
-        $this->assertNull($result->data);
-        $this->assertCount(1, $result->errors);
-        $this->assertContains(
+        self::assertNull($result->data);
+        self::assertCount(1, $result->errors);
+        self::assertContains(
             'Syntax Error: Expected Name, found <EOF>',
             $result->errors[0]->getMessage()
         );
@@ -101,7 +101,7 @@ class QueryExecutionTest extends ServerTestCase
         ];
 
         $result = $this->executeQuery($query)->toArray();
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     public function testRethrowUnsafeExceptions() : void
@@ -131,9 +131,9 @@ class QueryExecutionTest extends ServerTestCase
         }
         ';
 
-        $this->assertTrue(! isset($context->testedRootValue));
+        self::assertTrue(! isset($context->testedRootValue));
         $this->executeQuery($query);
-        $this->assertSame($rootValue, $context->testedRootValue);
+        self::assertSame($rootValue, $context->testedRootValue);
     }
 
     public function testPassesVariables() : void
@@ -182,7 +182,7 @@ class QueryExecutionTest extends ServerTestCase
             'data' => [],
         ];
         $this->assertQueryResultEquals($expected, $query);
-        $this->assertTrue($called);
+        self::assertTrue($called);
     }
 
     public function testAllowsValidationRulesAsClosure() : void
@@ -199,12 +199,12 @@ class QueryExecutionTest extends ServerTestCase
             return [];
         });
 
-        $this->assertFalse($called);
+        self::assertFalse($called);
         $this->executeQuery('{f1}');
-        $this->assertTrue($called);
-        $this->assertInstanceOf(OperationParams::class, $params);
-        $this->assertInstanceOf(DocumentNode::class, $doc);
-        $this->assertEquals('query', $operationType);
+        self::assertTrue($called);
+        self::assertInstanceOf(OperationParams::class, $params);
+        self::assertInstanceOf(DocumentNode::class, $doc);
+        self::assertEquals('query', $operationType);
     }
 
     public function testAllowsDifferentValidationRulesDependingOnOperation() : void
@@ -232,15 +232,15 @@ class QueryExecutionTest extends ServerTestCase
 
         $expected = ['data' => ['f1' => 'f1']];
         $this->assertQueryResultEquals($expected, $q1);
-        $this->assertTrue($called1);
-        $this->assertFalse($called2);
+        self::assertTrue($called1);
+        self::assertFalse($called2);
 
         $called1  = false;
         $called2  = false;
         $expected = ['errors' => [['message' => 'This is the error we are looking for!']]];
         $this->assertQueryResultEquals($expected, $q2);
-        $this->assertFalse($called1);
-        $this->assertTrue($called2);
+        self::assertFalse($called1);
+        self::assertTrue($called2);
     }
 
     public function testAllowsSkippingValidation() : void
@@ -263,7 +263,7 @@ class QueryExecutionTest extends ServerTestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     private function executePersistedQuery($queryId, $variables = null)
@@ -271,7 +271,7 @@ class QueryExecutionTest extends ServerTestCase
         $op     = OperationParams::create(['queryId' => $queryId, 'variables' => $variables]);
         $helper = new Helper();
         $result = $helper->executeOperation($this->config, $op);
-        $this->assertInstanceOf(ExecutionResult::class, $result);
+        self::assertInstanceOf(ExecutionResult::class, $result);
 
         return $result;
     }
@@ -304,8 +304,8 @@ class QueryExecutionTest extends ServerTestCase
             ],
         ];
 
-        $this->assertEquals($expected[0], $result[0]->toArray());
-        $this->assertEquals($expected[1], $result[1]->toArray());
+        self::assertEquals($expected[0], $result[0]->toArray());
+        self::assertEquals($expected[1], $result[1]->toArray());
     }
 
     /**
@@ -319,11 +319,11 @@ class QueryExecutionTest extends ServerTestCase
         }
         $helper = new Helper();
         $result = $helper->executeBatch($this->config, $batch);
-        $this->assertInternalType('array', $result);
-        $this->assertCount(count($qs), $result);
+        self::assertInternalType('array', $result);
+        self::assertCount(count($qs), $result);
 
         foreach ($result as $index => $entry) {
-            $this->assertInstanceOf(
+            self::assertInstanceOf(
                 ExecutionResult::class,
                 $entry,
                 sprintf('Result at %s is not an instance of %s', $index, ExecutionResult::class)
@@ -347,7 +347,7 @@ class QueryExecutionTest extends ServerTestCase
         ];
 
         $result = $this->executeQuery($mutation, null, true);
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     public function testAllowsPersistentQueries() : void
@@ -355,30 +355,30 @@ class QueryExecutionTest extends ServerTestCase
         $called = false;
         $this->config->setPersistentQueryLoader(function ($queryId, OperationParams $params) use (&$called) {
             $called = true;
-            $this->assertEquals('some-id', $queryId);
+            self::assertEquals('some-id', $queryId);
 
             return '{f1}';
         });
 
         $result = $this->executePersistedQuery('some-id');
-        $this->assertTrue($called);
+        self::assertTrue($called);
 
         $expected = [
             'data' => ['f1' => 'f1'],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         // Make sure it allows returning document node:
         $called = false;
         $this->config->setPersistentQueryLoader(function ($queryId, OperationParams $params) use (&$called) {
             $called = true;
-            $this->assertEquals('some-id', $queryId);
+            self::assertEquals('some-id', $queryId);
 
             return Parser::parse('{f1}');
         });
         $result = $this->executePersistedQuery('some-id');
-        $this->assertTrue($called);
-        $this->assertEquals($expected, $result->toArray());
+        self::assertTrue($called);
+        self::assertEquals($expected, $result->toArray());
     }
 
     public function testProhibitsInvalidPersistedQueryLoader() : void
@@ -409,7 +409,7 @@ class QueryExecutionTest extends ServerTestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     public function testAllowSkippingValidationForPersistedQueries() : void
@@ -434,7 +434,7 @@ class QueryExecutionTest extends ServerTestCase
         $expected = [
             'data' => [],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
 
         $result   = $this->executePersistedQuery('some-other-id');
         $expected = [
@@ -446,7 +446,7 @@ class QueryExecutionTest extends ServerTestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, $result->toArray());
+        self::assertEquals($expected, $result->toArray());
     }
 
     public function testProhibitsUnexpectedValidationRules() : void
@@ -500,9 +500,9 @@ class QueryExecutionTest extends ServerTestCase
             ],
         ];
 
-        $this->assertArraySubset($expected[0], $result[0]->toArray());
-        $this->assertArraySubset($expected[1], $result[1]->toArray());
-        $this->assertArraySubset($expected[2], $result[2]->toArray());
+        self::assertArraySubset($expected[0], $result[0]->toArray());
+        self::assertArraySubset($expected[1], $result[1]->toArray());
+        self::assertArraySubset($expected[2], $result[2]->toArray());
     }
 
     public function testDeferredsAreSharedAmongAllBatchedQueries() : void
@@ -539,7 +539,7 @@ class QueryExecutionTest extends ServerTestCase
             'load: 2',
             'load: 3',
         ];
-        $this->assertEquals($expectedCalls, $calls);
+        self::assertEquals($expectedCalls, $calls);
 
         $expected = [
             [
@@ -553,9 +553,9 @@ class QueryExecutionTest extends ServerTestCase
             ],
         ];
 
-        $this->assertEquals($expected[0], $result[0]->toArray());
-        $this->assertEquals($expected[1], $result[1]->toArray());
-        $this->assertEquals($expected[2], $result[2]->toArray());
+        self::assertEquals($expected[0], $result[0]->toArray());
+        self::assertEquals($expected[1], $result[1]->toArray());
+        self::assertEquals($expected[2], $result[2]->toArray());
     }
 
     public function testValidatesParamsBeforeExecution() : void
@@ -563,17 +563,17 @@ class QueryExecutionTest extends ServerTestCase
         $op     = OperationParams::create(['queryBad' => '{f1}']);
         $helper = new Helper();
         $result = $helper->executeOperation($this->config, $op);
-        $this->assertInstanceOf(ExecutionResult::class, $result);
+        self::assertInstanceOf(ExecutionResult::class, $result);
 
-        $this->assertEquals(null, $result->data);
-        $this->assertCount(1, $result->errors);
+        self::assertEquals(null, $result->data);
+        self::assertCount(1, $result->errors);
 
-        $this->assertEquals(
+        self::assertEquals(
             'GraphQL Request must include at least one of those two parameters: "query" or "queryId"',
             $result->errors[0]->getMessage()
         );
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             RequestError::class,
             $result->errors[0]->getPrevious()
         );
@@ -591,12 +591,12 @@ class QueryExecutionTest extends ServerTestCase
             $operationType = $o;
         });
 
-        $this->assertFalse($called);
+        self::assertFalse($called);
         $this->executeQuery('{f1}');
-        $this->assertTrue($called);
-        $this->assertInstanceOf(OperationParams::class, $params);
-        $this->assertInstanceOf(DocumentNode::class, $doc);
-        $this->assertEquals('query', $operationType);
+        self::assertTrue($called);
+        self::assertInstanceOf(OperationParams::class, $params);
+        self::assertInstanceOf(DocumentNode::class, $doc);
+        self::assertEquals('query', $operationType);
     }
 
     public function testAllowsRootValueAsClosure() : void
@@ -611,12 +611,12 @@ class QueryExecutionTest extends ServerTestCase
             $operationType = $o;
         });
 
-        $this->assertFalse($called);
+        self::assertFalse($called);
         $this->executeQuery('{f1}');
-        $this->assertTrue($called);
-        $this->assertInstanceOf(OperationParams::class, $params);
-        $this->assertInstanceOf(DocumentNode::class, $doc);
-        $this->assertEquals('query', $operationType);
+        self::assertTrue($called);
+        self::assertInstanceOf(OperationParams::class, $params);
+        self::assertInstanceOf(DocumentNode::class, $doc);
+        self::assertEquals('query', $operationType);
     }
 
     public function testAppliesErrorFormatter() : void
@@ -631,16 +631,16 @@ class QueryExecutionTest extends ServerTestCase
         });
 
         $result = $this->executeQuery('{fieldWithSafeException}');
-        $this->assertFalse($called);
+        self::assertFalse($called);
         $formatted = $result->toArray();
         $expected  = [
             'errors' => [
                 ['test' => 'formatted'],
             ],
         ];
-        $this->assertTrue($called);
-        $this->assertArraySubset($expected, $formatted);
-        $this->assertInstanceOf(Error::class, $error);
+        self::assertTrue($called);
+        self::assertArraySubset($expected, $formatted);
+        self::assertInstanceOf(Error::class, $error);
 
         // Assert debugging still works even with custom formatter
         $formatted = $result->toArray(Debug::INCLUDE_TRACE);
@@ -652,7 +652,7 @@ class QueryExecutionTest extends ServerTestCase
                 ],
             ],
         ];
-        $this->assertArraySubset($expected, $formatted);
+        self::assertArraySubset($expected, $formatted);
     }
 
     public function testAppliesErrorsHandler() : void
@@ -672,18 +672,18 @@ class QueryExecutionTest extends ServerTestCase
 
         $result = $this->executeQuery('{fieldWithSafeException,test: fieldWithSafeException}');
 
-        $this->assertFalse($called);
+        self::assertFalse($called);
         $formatted = $result->toArray();
         $expected  = [
             'errors' => [
                 ['test' => 'handled'],
             ],
         ];
-        $this->assertTrue($called);
-        $this->assertArraySubset($expected, $formatted);
-        $this->assertInternalType('array', $errors);
-        $this->assertCount(2, $errors);
-        $this->assertInternalType('callable', $formatter);
-        $this->assertArraySubset($expected, $formatted);
+        self::assertTrue($called);
+        self::assertArraySubset($expected, $formatted);
+        self::assertInternalType('array', $errors);
+        self::assertCount(2, $errors);
+        self::assertInternalType('callable', $formatter);
+        self::assertArraySubset($expected, $formatted);
     }
 }

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -25,8 +25,8 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $source => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, null, null, $source);
-            $this->assertFalse($parsedBody->isReadOnly(), $source);
+            self::assertValidOperationParams($parsedBody, $query, null, null, null, $source);
+            self::assertFalse($parsedBody->isReadOnly(), $source);
         }
     }
 
@@ -85,7 +85,7 @@ class RequestParsingTest extends TestCase
      * @param mixed|null      $variables
      * @param string          $operation
      */
-    private function assertValidOperationParams(
+    private static function assertValidOperationParams(
         $params,
         $query,
         $queryId = null,
@@ -93,12 +93,12 @@ class RequestParsingTest extends TestCase
         $operation = null,
         $message = ''
     ) {
-        $this->assertInstanceOf(OperationParams::class, $params, $message);
+        self::assertInstanceOf(OperationParams::class, $params, $message);
 
-        $this->assertSame($query, $params->query, $message);
-        $this->assertSame($queryId, $params->queryId, $message);
-        $this->assertSame($variables, $params->variables, $message);
-        $this->assertSame($operation, $params->operation, $message);
+        self::assertSame($query, $params->query, $message);
+        self::assertSame($queryId, $params->queryId, $message);
+        self::assertSame($variables, $params->variables, $message);
+        self::assertSame($operation, $params->operation, $message);
     }
 
     public function testParsesUrlencodedRequest() : void
@@ -118,8 +118,8 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertFalse($parsedBody->isReadOnly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
 
@@ -173,8 +173,8 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertTrue($parsedBody->isReadonly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertTrue($parsedBody->isReadonly(), $method);
         }
     }
 
@@ -226,8 +226,8 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertFalse($parsedBody->isReadOnly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
 
@@ -280,8 +280,8 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertFalse($parsedBody->isReadOnly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
 
@@ -301,8 +301,8 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertFalse($parsedBody->isReadOnly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
 
@@ -322,8 +322,8 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
-            $this->assertFalse($parsedBody->isReadOnly(), $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
 
@@ -346,9 +346,9 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            $this->assertInternalType('array', $parsedBody, $method);
-            $this->assertCount(2, $parsedBody, $method);
-            $this->assertValidOperationParams(
+            self::assertInternalType('array', $parsedBody, $method);
+            self::assertCount(2, $parsedBody, $method);
+            self::assertValidOperationParams(
                 $parsedBody[0],
                 $body[0]['query'],
                 null,
@@ -356,7 +356,7 @@ class RequestParsingTest extends TestCase
                 $body[0]['operationName'],
                 $method
             );
-            $this->assertValidOperationParams(
+            self::assertValidOperationParams(
                 $parsedBody[1],
                 null,
                 $body[1]['queryId'],
@@ -392,7 +392,7 @@ class RequestParsingTest extends TestCase
             $this->fail('Expected exception not thrown');
         } catch (InvariantViolation $e) {
             // Expecting parsing exception to be thrown somewhere else:
-            $this->assertEquals(
+            self::assertEquals(
                 'PSR-7 request is expected to provide parsed body for "application/json" requests but got null',
                 $e->getMessage()
             );

--- a/tests/Server/RequestValidationTest.php
+++ b/tests/Server/RequestValidationTest.php
@@ -22,14 +22,14 @@ class RequestValidationTest extends TestCase
             'operationName' => $operation,
         ]);
 
-        $this->assertValid($parsedBody);
+        self::assertValid($parsedBody);
     }
 
-    private function assertValid($parsedRequest)
+    private static function assertValid($parsedRequest)
     {
         $helper = new Helper();
         $errors = $helper->validateOperationParams($parsedRequest);
-        $this->assertEmpty($errors, isset($errors[0]) ? $errors[0]->getMessage() : '');
+        self::assertEmpty($errors, isset($errors[0]) ? $errors[0]->getMessage() : '');
     }
 
     public function testRequestWithQueryIdShouldValidate() : void
@@ -44,7 +44,7 @@ class RequestValidationTest extends TestCase
             'operationName' => $operation,
         ]);
 
-        $this->assertValid($parsedBody);
+        self::assertValid($parsedBody);
     }
 
     public function testRequiresQueryOrQueryId() : void
@@ -65,7 +65,7 @@ class RequestValidationTest extends TestCase
         $helper = new Helper();
         $errors = $helper->validateOperationParams($parsedRequest);
         if (! empty($errors[0])) {
-            $this->assertEquals($expectedMessage, $errors[0]->getMessage());
+            self::assertEquals($expectedMessage, $errors[0]->getMessage());
         } else {
             $this->fail('Expected error not returned');
         }
@@ -131,14 +131,14 @@ class RequestValidationTest extends TestCase
             'query'     => $query,
             'variables' => null,
         ]);
-        $this->assertValid($parsedBody);
+        self::assertValid($parsedBody);
 
         $variables  = '';
         $parsedBody = OperationParams::create([
             'query'     => $query,
             'variables' => $variables,
         ]);
-        $this->assertValid($parsedBody);
+        self::assertValid($parsedBody);
     }
 
     public function testFailsWhenVariablesParameterIsNotObject() : void

--- a/tests/Server/ServerConfigTest.php
+++ b/tests/Server/ServerConfigTest.php
@@ -17,17 +17,17 @@ class ServerConfigTest extends TestCase
     public function testDefaults() : void
     {
         $config = ServerConfig::create();
-        $this->assertNull($config->getSchema());
-        $this->assertNull($config->getContext());
-        $this->assertNull($config->getRootValue());
-        $this->assertNull($config->getErrorFormatter());
-        $this->assertNull($config->getErrorsHandler());
-        $this->assertNull($config->getPromiseAdapter());
-        $this->assertNull($config->getValidationRules());
-        $this->assertNull($config->getFieldResolver());
-        $this->assertNull($config->getPersistentQueryLoader());
-        $this->assertFalse($config->getDebug());
-        $this->assertFalse($config->getQueryBatching());
+        self::assertNull($config->getSchema());
+        self::assertNull($config->getContext());
+        self::assertNull($config->getRootValue());
+        self::assertNull($config->getErrorFormatter());
+        self::assertNull($config->getErrorsHandler());
+        self::assertNull($config->getPromiseAdapter());
+        self::assertNull($config->getValidationRules());
+        self::assertNull($config->getFieldResolver());
+        self::assertNull($config->getPersistentQueryLoader());
+        self::assertFalse($config->getDebug());
+        self::assertFalse($config->getQueryBatching());
     }
 
     public function testAllowsSettingSchema() : void
@@ -36,11 +36,11 @@ class ServerConfigTest extends TestCase
         $config = ServerConfig::create()
             ->setSchema($schema);
 
-        $this->assertSame($schema, $config->getSchema());
+        self::assertSame($schema, $config->getSchema());
 
         $schema2 = new Schema(['query' => new ObjectType(['name' => 'a', 'fields' => []])]);
         $config->setSchema($schema2);
-        $this->assertSame($schema2, $config->getSchema());
+        self::assertSame($schema2, $config->getSchema());
     }
 
     public function testAllowsSettingContext() : void
@@ -49,11 +49,11 @@ class ServerConfigTest extends TestCase
 
         $context = [];
         $config->setContext($context);
-        $this->assertSame($context, $config->getContext());
+        self::assertSame($context, $config->getContext());
 
         $context2 = new \stdClass();
         $config->setContext($context2);
-        $this->assertSame($context2, $config->getContext());
+        self::assertSame($context2, $config->getContext());
     }
 
     public function testAllowsSettingRootValue() : void
@@ -62,11 +62,11 @@ class ServerConfigTest extends TestCase
 
         $rootValue = [];
         $config->setRootValue($rootValue);
-        $this->assertSame($rootValue, $config->getRootValue());
+        self::assertSame($rootValue, $config->getRootValue());
 
         $context2 = new \stdClass();
         $config->setRootValue($context2);
-        $this->assertSame($context2, $config->getRootValue());
+        self::assertSame($context2, $config->getRootValue());
     }
 
     public function testAllowsSettingErrorFormatter() : void
@@ -76,11 +76,11 @@ class ServerConfigTest extends TestCase
         $formatter = function () {
         };
         $config->setErrorFormatter($formatter);
-        $this->assertSame($formatter, $config->getErrorFormatter());
+        self::assertSame($formatter, $config->getErrorFormatter());
 
         $formatter = 'date'; // test for callable
         $config->setErrorFormatter($formatter);
-        $this->assertSame($formatter, $config->getErrorFormatter());
+        self::assertSame($formatter, $config->getErrorFormatter());
     }
 
     public function testAllowsSettingErrorsHandler() : void
@@ -90,11 +90,11 @@ class ServerConfigTest extends TestCase
         $handler = function () {
         };
         $config->setErrorsHandler($handler);
-        $this->assertSame($handler, $config->getErrorsHandler());
+        self::assertSame($handler, $config->getErrorsHandler());
 
         $handler = 'date'; // test for callable
         $config->setErrorsHandler($handler);
-        $this->assertSame($handler, $config->getErrorsHandler());
+        self::assertSame($handler, $config->getErrorsHandler());
     }
 
     public function testAllowsSettingPromiseAdapter() : void
@@ -103,11 +103,11 @@ class ServerConfigTest extends TestCase
 
         $adapter1 = new SyncPromiseAdapter();
         $config->setPromiseAdapter($adapter1);
-        $this->assertSame($adapter1, $config->getPromiseAdapter());
+        self::assertSame($adapter1, $config->getPromiseAdapter());
 
         $adapter2 = new SyncPromiseAdapter();
         $config->setPromiseAdapter($adapter2);
-        $this->assertSame($adapter2, $config->getPromiseAdapter());
+        self::assertSame($adapter2, $config->getPromiseAdapter());
     }
 
     public function testAllowsSettingValidationRules() : void
@@ -116,13 +116,13 @@ class ServerConfigTest extends TestCase
 
         $rules = [];
         $config->setValidationRules($rules);
-        $this->assertSame($rules, $config->getValidationRules());
+        self::assertSame($rules, $config->getValidationRules());
 
         $rules = [function () {
         },
         ];
         $config->setValidationRules($rules);
-        $this->assertSame($rules, $config->getValidationRules());
+        self::assertSame($rules, $config->getValidationRules());
 
         $rules = function () {
             return [function () {
@@ -130,7 +130,7 @@ class ServerConfigTest extends TestCase
             ];
         };
         $config->setValidationRules($rules);
-        $this->assertSame($rules, $config->getValidationRules());
+        self::assertSame($rules, $config->getValidationRules());
     }
 
     public function testAllowsSettingDefaultFieldResolver() : void
@@ -140,11 +140,11 @@ class ServerConfigTest extends TestCase
         $resolver = function () {
         };
         $config->setFieldResolver($resolver);
-        $this->assertSame($resolver, $config->getFieldResolver());
+        self::assertSame($resolver, $config->getFieldResolver());
 
         $resolver = 'date'; // test for callable
         $config->setFieldResolver($resolver);
-        $this->assertSame($resolver, $config->getFieldResolver());
+        self::assertSame($resolver, $config->getFieldResolver());
     }
 
     public function testAllowsSettingPersistedQueryLoader() : void
@@ -154,11 +154,11 @@ class ServerConfigTest extends TestCase
         $loader = function () {
         };
         $config->setPersistentQueryLoader($loader);
-        $this->assertSame($loader, $config->getPersistentQueryLoader());
+        self::assertSame($loader, $config->getPersistentQueryLoader());
 
         $loader = 'date'; // test for callable
         $config->setPersistentQueryLoader($loader);
-        $this->assertSame($loader, $config->getPersistentQueryLoader());
+        self::assertSame($loader, $config->getPersistentQueryLoader());
     }
 
     public function testAllowsSettingCatchPhpErrors() : void
@@ -166,10 +166,10 @@ class ServerConfigTest extends TestCase
         $config = ServerConfig::create();
 
         $config->setDebug(true);
-        $this->assertTrue($config->getDebug());
+        self::assertTrue($config->getDebug());
 
         $config->setDebug(false);
-        $this->assertFalse($config->getDebug());
+        self::assertFalse($config->getDebug());
     }
 
     public function testAcceptsArray() : void
@@ -196,16 +196,16 @@ class ServerConfigTest extends TestCase
 
         $config = ServerConfig::create($arr);
 
-        $this->assertSame($arr['schema'], $config->getSchema());
-        $this->assertSame($arr['context'], $config->getContext());
-        $this->assertSame($arr['rootValue'], $config->getRootValue());
-        $this->assertSame($arr['errorFormatter'], $config->getErrorFormatter());
-        $this->assertSame($arr['promiseAdapter'], $config->getPromiseAdapter());
-        $this->assertSame($arr['validationRules'], $config->getValidationRules());
-        $this->assertSame($arr['fieldResolver'], $config->getFieldResolver());
-        $this->assertSame($arr['persistentQueryLoader'], $config->getPersistentQueryLoader());
-        $this->assertTrue($config->getDebug());
-        $this->assertTrue($config->getQueryBatching());
+        self::assertSame($arr['schema'], $config->getSchema());
+        self::assertSame($arr['context'], $config->getContext());
+        self::assertSame($arr['rootValue'], $config->getRootValue());
+        self::assertSame($arr['errorFormatter'], $config->getErrorFormatter());
+        self::assertSame($arr['promiseAdapter'], $config->getPromiseAdapter());
+        self::assertSame($arr['validationRules'], $config->getValidationRules());
+        self::assertSame($arr['fieldResolver'], $config->getFieldResolver());
+        self::assertSame($arr['persistentQueryLoader'], $config->getPersistentQueryLoader());
+        self::assertTrue($config->getDebug());
+        self::assertTrue($config->getQueryBatching());
     }
 
     public function testThrowsOnInvalidArrayKey() : void

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -35,7 +35,7 @@ class StandardServerTest extends ServerTestCase
             'data' => ['f1' => 'f1'],
         ];
 
-        $this->assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expected, $result->toArray(true));
     }
 
     private function parseRawRequest($contentType, $content, $method = 'POST')
@@ -75,7 +75,7 @@ class StandardServerTest extends ServerTestCase
     private function assertPsrRequestEquals($expected, $request)
     {
         $result = $this->executePsrRequest($request);
-        $this->assertArraySubset($expected, $result->toArray(true));
+        self::assertArraySubset($expected, $result->toArray(true));
 
         return $result;
     }
@@ -84,7 +84,7 @@ class StandardServerTest extends ServerTestCase
     {
         $server = new StandardServer($this->config);
         $result = $server->executePsrRequest($psrRequest);
-        $this->assertInstanceOf(ExecutionResult::class, $result);
+        self::assertInstanceOf(ExecutionResult::class, $result);
 
         return $result;
     }

--- a/tests/StarWarsIntrospectionTest.php
+++ b/tests/StarWarsIntrospectionTest.php
@@ -50,15 +50,15 @@ class StarWarsIntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
      * Helper function to test a query and the expected response.
      */
-    private function assertValidQuery($query, $expected) : void
+    private static function assertValidQuery($query, $expected) : void
     {
-        $this->assertEquals(['data' => $expected], GraphQL::executeQuery(StarWarsSchema::build(), $query)->toArray());
+        self::assertEquals(['data' => $expected], GraphQL::executeQuery(StarWarsSchema::build(), $query)->toArray());
     }
 
     /**
@@ -80,7 +80,7 @@ class StarWarsIntrospectionTest extends TestCase
                 'queryType' => ['name' => 'Query'],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -98,7 +98,7 @@ class StarWarsIntrospectionTest extends TestCase
         $expected = [
             '__type' => ['name' => 'Droid'],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -120,7 +120,7 @@ class StarWarsIntrospectionTest extends TestCase
                 'kind' => 'OBJECT',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -142,7 +142,7 @@ class StarWarsIntrospectionTest extends TestCase
                 'kind' => 'INTERFACE',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -213,7 +213,7 @@ class StarWarsIntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -303,7 +303,7 @@ class StarWarsIntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -397,7 +397,7 @@ class StarWarsIntrospectionTest extends TestCase
             ],
         ];
 
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -419,6 +419,6 @@ class StarWarsIntrospectionTest extends TestCase
                 'description' => 'A mechanical creature in the Star Wars universe.',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 }

--- a/tests/StarWarsQueryTest.php
+++ b/tests/StarWarsQueryTest.php
@@ -24,15 +24,15 @@ class StarWarsQueryTest extends TestCase
         $expected = [
             'hero' => ['name' => 'R2-D2'],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
      * Helper function to test a query and the expected response.
      */
-    private function assertValidQuery($query, $expected) : void
+    private static function assertValidQuery($query, $expected) : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => $expected],
             GraphQL::executeQuery(StarWarsSchema::build(), $query)->toArray()
         );
@@ -67,7 +67,7 @@ class StarWarsQueryTest extends TestCase
                 ],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     // Describe: Using IDs and query parameters to refetch objects
@@ -128,7 +128,7 @@ class StarWarsQueryTest extends TestCase
                 ],
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -147,7 +147,7 @@ class StarWarsQueryTest extends TestCase
             'human' => ['name' => 'Luke Skywalker'],
         ];
 
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -167,15 +167,15 @@ class StarWarsQueryTest extends TestCase
             'human' => ['name' => 'Luke Skywalker'],
         ];
 
-        $this->assertValidQueryWithParams($query, $params, $expected);
+        self::assertValidQueryWithParams($query, $params, $expected);
     }
 
     /**
      * Helper function to test a query with params and the expected response.
      */
-    private function assertValidQueryWithParams($query, $params, $expected)
+    private static function assertValidQueryWithParams($query, $params, $expected)
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => $expected],
             GraphQL::executeQuery(StarWarsSchema::build(), $query, null, null, $params)->toArray()
         );
@@ -199,7 +199,7 @@ class StarWarsQueryTest extends TestCase
         $expected = [
             'human' => ['name' => 'Han Solo'],
         ];
-        $this->assertValidQueryWithParams($query, $params, $expected);
+        self::assertValidQueryWithParams($query, $params, $expected);
     }
 
     /**
@@ -216,7 +216,7 @@ class StarWarsQueryTest extends TestCase
         ';
         $params   = ['id' => 'not a valid id'];
         $expected = ['human' => null];
-        $this->assertValidQueryWithParams($query, $params, $expected);
+        self::assertValidQueryWithParams($query, $params, $expected);
     }
 
     // Uses fragments to express more complex queries
@@ -236,7 +236,7 @@ class StarWarsQueryTest extends TestCase
         $expected = [
             'luke' => ['name' => 'Luke Skywalker'],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -258,7 +258,7 @@ class StarWarsQueryTest extends TestCase
             'luke' => ['name' => 'Luke Skywalker'],
             'leia' => ['name' => 'Leia Organa'],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -288,7 +288,7 @@ class StarWarsQueryTest extends TestCase
                 'homePlanet' => 'Alderaan',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -322,7 +322,7 @@ class StarWarsQueryTest extends TestCase
                 'homePlanet' => 'Alderaan',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -344,7 +344,7 @@ class StarWarsQueryTest extends TestCase
                 'name'       => 'R2-D2',
             ],
         ];
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 
     /**
@@ -368,6 +368,6 @@ class StarWarsQueryTest extends TestCase
             ],
         ];
 
-        $this->assertValidQuery($query, $expected);
+        self::assertValidQuery($query, $expected);
     }
 }

--- a/tests/StarWarsValidationTest.php
+++ b/tests/StarWarsValidationTest.php
@@ -37,7 +37,7 @@ class StarWarsValidationTest extends TestCase
         }
       ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(true, empty($errors));
+        self::assertEquals(true, empty($errors));
     }
 
     /**
@@ -63,7 +63,7 @@ class StarWarsValidationTest extends TestCase
         }
         ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(false, empty($errors));
+        self::assertEquals(false, empty($errors));
     }
 
     /**
@@ -78,7 +78,7 @@ class StarWarsValidationTest extends TestCase
         ';
 
         $errors = $this->validationErrors($query);
-        $this->assertEquals(false, empty($errors));
+        self::assertEquals(false, empty($errors));
     }
 
     /**
@@ -96,7 +96,7 @@ class StarWarsValidationTest extends TestCase
         }
         ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(false, empty($errors));
+        self::assertEquals(false, empty($errors));
     }
 
     /**
@@ -113,7 +113,7 @@ class StarWarsValidationTest extends TestCase
         }
         ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(false, empty($errors));
+        self::assertEquals(false, empty($errors));
     }
 
     /**
@@ -134,7 +134,7 @@ class StarWarsValidationTest extends TestCase
         }
         ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(true, empty($errors));
+        self::assertEquals(true, empty($errors));
     }
 
     /**
@@ -153,6 +153,6 @@ class StarWarsValidationTest extends TestCase
         }
         ';
         $errors = $this->validationErrors($query);
-        $this->assertEquals(true, empty($errors));
+        self::assertEquals(true, empty($errors));
     }
 }

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -168,39 +168,39 @@ class DefinitionTest extends TestCase
             'query' => $this->blogQuery,
         ]);
 
-        $this->assertSame($blogSchema->getQueryType(), $this->blogQuery);
+        self::assertSame($blogSchema->getQueryType(), $this->blogQuery);
 
         $articleField = $this->blogQuery->getField('article');
-        $this->assertSame($articleField->getType(), $this->blogArticle);
-        $this->assertSame($articleField->getType()->name, 'Article');
-        $this->assertSame($articleField->name, 'article');
+        self::assertSame($articleField->getType(), $this->blogArticle);
+        self::assertSame($articleField->getType()->name, 'Article');
+        self::assertSame($articleField->name, 'article');
 
         /** @var ObjectType $articleFieldType */
         $articleFieldType = $articleField->getType();
         $titleField       = $articleFieldType->getField('title');
 
-        $this->assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $titleField);
-        $this->assertSame('title', $titleField->name);
-        $this->assertSame(Type::string(), $titleField->getType());
+        self::assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $titleField);
+        self::assertSame('title', $titleField->name);
+        self::assertSame(Type::string(), $titleField->getType());
 
         $authorField = $articleFieldType->getField('author');
-        $this->assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $authorField);
+        self::assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $authorField);
 
         /** @var ObjectType $authorFieldType */
         $authorFieldType = $authorField->getType();
-        $this->assertSame($this->blogAuthor, $authorFieldType);
+        self::assertSame($this->blogAuthor, $authorFieldType);
 
         $recentArticleField = $authorFieldType->getField('recentArticle');
-        $this->assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $recentArticleField);
-        $this->assertSame($this->blogArticle, $recentArticleField->getType());
+        self::assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $recentArticleField);
+        self::assertSame($this->blogArticle, $recentArticleField->getType());
 
         $feedField = $this->blogQuery->getField('feed');
-        $this->assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $feedField);
+        self::assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $feedField);
 
         /** @var ListOfType $feedFieldType */
         $feedFieldType = $feedField->getType();
-        $this->assertInstanceOf('GraphQL\Type\Definition\ListOfType', $feedFieldType);
-        $this->assertSame($this->blogArticle, $feedFieldType->getWrappedType());
+        self::assertInstanceOf('GraphQL\Type\Definition\ListOfType', $feedFieldType);
+        self::assertSame($this->blogArticle, $feedFieldType->getWrappedType());
     }
 
     /**
@@ -213,13 +213,13 @@ class DefinitionTest extends TestCase
             'mutation' => $this->blogMutation,
         ]);
 
-        $this->assertSame($this->blogMutation, $schema->getMutationType());
+        self::assertSame($this->blogMutation, $schema->getMutationType());
         $writeMutation = $this->blogMutation->getField('writeArticle');
 
-        $this->assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $writeMutation);
-        $this->assertSame($this->blogArticle, $writeMutation->getType());
-        $this->assertSame('Article', $writeMutation->getType()->name);
-        $this->assertSame('writeArticle', $writeMutation->name);
+        self::assertInstanceOf('GraphQL\Type\Definition\FieldDefinition', $writeMutation);
+        self::assertSame($this->blogArticle, $writeMutation->getType());
+        self::assertSame('Article', $writeMutation->getType()->name);
+        self::assertSame('writeArticle', $writeMutation->name);
     }
 
     /**
@@ -232,12 +232,12 @@ class DefinitionTest extends TestCase
             'subscription' => $this->blogSubscription,
         ]);
 
-        $this->assertEquals($this->blogSubscription, $schema->getSubscriptionType());
+        self::assertEquals($this->blogSubscription, $schema->getSubscriptionType());
 
         $sub = $this->blogSubscription->getField('articleSubscribe');
-        $this->assertEquals($sub->getType(), $this->blogArticle);
-        $this->assertEquals($sub->getType()->name, 'Article');
-        $this->assertEquals($sub->name, 'articleSubscribe');
+        self::assertEquals($sub->getType(), $this->blogArticle);
+        self::assertEquals($sub->getType()->name, 'Article');
+        self::assertEquals($sub->name, 'articleSubscribe');
     }
 
     /**
@@ -254,7 +254,7 @@ class DefinitionTest extends TestCase
 
         $value = $enumTypeWithDeprecatedValue->getValues()[0];
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'name'              => 'foo',
                 'description'       => null,
@@ -265,7 +265,7 @@ class DefinitionTest extends TestCase
             (array) $value
         );
 
-        $this->assertEquals(true, $value->isDeprecated());
+        self::assertEquals(true, $value->isDeprecated());
     }
 
     /**
@@ -300,9 +300,9 @@ class DefinitionTest extends TestCase
 
         $actual = $EnumTypeWithNullishValue->getValues();
 
-        $this->assertEquals(count($expected), count($actual));
-        $this->assertArraySubset($expected[0], (array) $actual[0]);
-        $this->assertArraySubset($expected[1], (array) $actual[1]);
+        self::assertEquals(count($expected), count($actual));
+        self::assertArraySubset($expected[0], (array) $actual[0]);
+        self::assertArraySubset($expected[1], (array) $actual[1]);
     }
 
     /**
@@ -322,11 +322,11 @@ class DefinitionTest extends TestCase
 
         $field = $TypeWithDeprecatedField->getField('bar');
 
-        $this->assertEquals(Type::string(), $field->getType());
-        $this->assertEquals(true, $field->isDeprecated());
-        $this->assertEquals('A terrible reason', $field->deprecationReason);
-        $this->assertEquals('bar', $field->name);
-        $this->assertEquals([], $field->args);
+        self::assertEquals(Type::string(), $field->getType());
+        self::assertEquals(true, $field->isDeprecated());
+        self::assertEquals('A terrible reason', $field->deprecationReason);
+        self::assertEquals('bar', $field->name);
+        self::assertEquals([], $field->args);
     }
 
     /**
@@ -356,7 +356,7 @@ class DefinitionTest extends TestCase
             'query'    => $this->blogQuery,
             'mutation' => $someMutation,
         ]);
-        $this->assertSame($nestedInputObject, $schema->getType('NestedInputObject'));
+        self::assertSame($nestedInputObject, $schema->getType('NestedInputObject'));
     }
 
     /**
@@ -388,7 +388,7 @@ class DefinitionTest extends TestCase
             ]),
             'types' => [$someSubtype],
         ]);
-        $this->assertSame($someSubtype, $schema->getType('SomeSubtype'));
+        self::assertSame($someSubtype, $schema->getType('SomeSubtype'));
     }
 
     /**
@@ -425,7 +425,7 @@ class DefinitionTest extends TestCase
             'types' => [$someSubtype],
         ]);
 
-        $this->assertSame($someSubtype, $schema->getType('SomeSubtype'));
+        self::assertSame($someSubtype, $schema->getType('SomeSubtype'));
     }
 
     /**
@@ -433,20 +433,20 @@ class DefinitionTest extends TestCase
      */
     public function testStringifiesSimpleTypes() : void
     {
-        $this->assertSame('Int', (string) Type::int());
-        $this->assertSame('Article', (string) $this->blogArticle);
+        self::assertSame('Int', (string) Type::int());
+        self::assertSame('Article', (string) $this->blogArticle);
 
-        $this->assertSame('Interface', (string) $this->interfaceType);
-        $this->assertSame('Union', (string) $this->unionType);
-        $this->assertSame('Enum', (string) $this->enumType);
-        $this->assertSame('InputObject', (string) $this->inputObjectType);
-        $this->assertSame('Object', (string) $this->objectType);
+        self::assertSame('Interface', (string) $this->interfaceType);
+        self::assertSame('Union', (string) $this->unionType);
+        self::assertSame('Enum', (string) $this->enumType);
+        self::assertSame('InputObject', (string) $this->inputObjectType);
+        self::assertSame('Object', (string) $this->objectType);
 
-        $this->assertSame('Int!', (string) new NonNull(Type::int()));
-        $this->assertSame('[Int]', (string) new ListOfType(Type::int()));
-        $this->assertSame('[Int]!', (string) new NonNull(new ListOfType(Type::int())));
-        $this->assertSame('[Int!]', (string) new ListOfType(new NonNull(Type::int())));
-        $this->assertSame('[[Int]]', (string) new ListOfType(new ListOfType(Type::int())));
+        self::assertSame('Int!', (string) new NonNull(Type::int()));
+        self::assertSame('[Int]', (string) new ListOfType(Type::int()));
+        self::assertSame('[Int]!', (string) new NonNull(new ListOfType(Type::int())));
+        self::assertSame('[Int!]', (string) new ListOfType(new NonNull(Type::int())));
+        self::assertSame('[[Int]]', (string) new ListOfType(new ListOfType(Type::int())));
     }
 
     /**
@@ -454,17 +454,17 @@ class DefinitionTest extends TestCase
      */
     public function testJSONStringifiesSimpleTypes() : void
     {
-        $this->assertEquals('"Int"', json_encode(Type::int()));
-        $this->assertEquals('"Article"', json_encode($this->blogArticle));
-        $this->assertEquals('"Interface"', json_encode($this->interfaceType));
-        $this->assertEquals('"Union"', json_encode($this->unionType));
-        $this->assertEquals('"Enum"', json_encode($this->enumType));
-        $this->assertEquals('"InputObject"', json_encode($this->inputObjectType));
-        $this->assertEquals('"Int!"', json_encode(Type::nonNull(Type::int())));
-        $this->assertEquals('"[Int]"', json_encode(Type::listOf(Type::int())));
-        $this->assertEquals('"[Int]!"', json_encode(Type::nonNull(Type::listOf(Type::int()))));
-        $this->assertEquals('"[Int!]"', json_encode(Type::listOf(Type::nonNull(Type::int()))));
-        $this->assertEquals('"[[Int]]"', json_encode(Type::listOf(Type::listOf(Type::int()))));
+        self::assertEquals('"Int"', json_encode(Type::int()));
+        self::assertEquals('"Article"', json_encode($this->blogArticle));
+        self::assertEquals('"Interface"', json_encode($this->interfaceType));
+        self::assertEquals('"Union"', json_encode($this->unionType));
+        self::assertEquals('"Enum"', json_encode($this->enumType));
+        self::assertEquals('"InputObject"', json_encode($this->inputObjectType));
+        self::assertEquals('"Int!"', json_encode(Type::nonNull(Type::int())));
+        self::assertEquals('"[Int]"', json_encode(Type::listOf(Type::int())));
+        self::assertEquals('"[Int]!"', json_encode(Type::nonNull(Type::listOf(Type::int()))));
+        self::assertEquals('"[Int!]"', json_encode(Type::listOf(Type::nonNull(Type::int()))));
+        self::assertEquals('"[[Int]]"', json_encode(Type::listOf(Type::listOf(Type::int()))));
     }
 
     /**
@@ -482,7 +482,7 @@ class DefinitionTest extends TestCase
         ];
 
         foreach ($expected as $index => $entry) {
-            $this->assertSame(
+            self::assertSame(
                 $entry[1],
                 Type::isInputType($entry[0]),
                 sprintf('Type %s was detected incorrectly', $entry[0])
@@ -505,7 +505,7 @@ class DefinitionTest extends TestCase
         ];
 
         foreach ($expected as $index => $entry) {
-            $this->assertSame(
+            self::assertSame(
                 $entry[1],
                 Type::isOutputType($entry[0]),
                 sprintf('Type %s was detected incorrectly', $entry[0])
@@ -538,8 +538,8 @@ class DefinitionTest extends TestCase
         ]);
 
         $types = $union->getTypes();
-        $this->assertEquals(1, count($types));
-        $this->assertSame($this->objectType, $types[0]);
+        self::assertEquals(1, count($types));
+        self::assertSame($this->objectType, $types[0]);
     }
 
     public function testAllowsRecursiveDefinitions() : void
@@ -558,7 +558,7 @@ class DefinitionTest extends TestCase
         $user = new ObjectType([
             'name'       => 'User',
             'fields'     => function () use (&$blog, &$called) {
-                $this->assertNotNull($blog, 'Blog type is expected to be defined at this point, but it is null');
+                self::assertNotNull($blog, 'Blog type is expected to be defined at this point, but it is null');
                 $called = true;
 
                 return [
@@ -594,17 +594,17 @@ class DefinitionTest extends TestCase
             'types' => [$user, $blog],
         ]);
 
-        $this->assertTrue($called);
+        self::assertTrue($called);
         $schema->getType('Blog');
 
-        $this->assertEquals([$node], $blog->getInterfaces());
-        $this->assertEquals([$node], $user->getInterfaces());
+        self::assertEquals([$node], $blog->getInterfaces());
+        self::assertEquals([$node], $user->getInterfaces());
 
-        $this->assertNotNull($user->getField('blogs'));
-        $this->assertSame($blog, $user->getField('blogs')->getType()->getWrappedType(true));
+        self::assertNotNull($user->getField('blogs'));
+        self::assertSame($blog, $user->getField('blogs')->getType()->getWrappedType(true));
 
-        $this->assertNotNull($blog->getField('owner'));
-        $this->assertSame($user, $blog->getField('owner')->getType()->getWrappedType(true));
+        self::assertNotNull($blog->getField('owner'));
+        self::assertSame($user, $blog->getField('owner')->getType()->getWrappedType(true));
     }
 
     public function testInputObjectTypeAllowsRecursiveDefinitions() : void
@@ -637,11 +637,11 @@ class DefinitionTest extends TestCase
             'mutation' => $someMutation,
         ]);
 
-        $this->assertSame($inputObject, $schema->getType('InputObject'));
-        $this->assertTrue($called);
-        $this->assertEquals(count($inputObject->getFields()), 2);
-        $this->assertSame($inputObject->getField('nested')->getType(), $inputObject);
-        $this->assertSame($someMutation->getField('mutateSomething')->getArg('input')->getType(), $inputObject);
+        self::assertSame($inputObject, $schema->getType('InputObject'));
+        self::assertTrue($called);
+        self::assertEquals(count($inputObject->getFields()), 2);
+        self::assertSame($inputObject->getField('nested')->getType(), $inputObject);
+        self::assertSame($someMutation->getField('mutateSomething')->getArg('input')->getType(), $inputObject);
     }
 
     public function testInterfaceTypeAllowsRecursiveDefinitions() : void
@@ -668,11 +668,11 @@ class DefinitionTest extends TestCase
 
         $schema = new Schema(['query' => $query]);
 
-        $this->assertSame($interface, $schema->getType('SomeInterface'));
-        $this->assertTrue($called);
-        $this->assertEquals(count($interface->getFields()), 2);
-        $this->assertSame($interface->getField('nested')->getType(), $interface);
-        $this->assertSame($interface->getField('value')->getType(), Type::string());
+        self::assertSame($interface, $schema->getType('SomeInterface'));
+        self::assertTrue($called);
+        self::assertEquals(count($interface->getFields()), 2);
+        self::assertSame($interface->getField('nested')->getType(), $interface);
+        self::assertSame($interface->getField('value')->getType(), Type::string());
     }
 
     public function testAllowsShorthandFieldDefinition() : void
@@ -703,27 +703,27 @@ class DefinitionTest extends TestCase
         $valueField  = $schema->getType('SomeInterface')->getField('value');
         $nestedField = $schema->getType('SomeInterface')->getField('nested');
 
-        $this->assertEquals(Type::string(), $valueField->getType());
-        $this->assertEquals($interface, $nestedField->getType());
+        self::assertEquals(Type::string(), $valueField->getType());
+        self::assertEquals($interface, $nestedField->getType());
 
         $withArg = $schema->getType('SomeInterface')->getField('withArg');
-        $this->assertEquals(Type::string(), $withArg->getType());
+        self::assertEquals(Type::string(), $withArg->getType());
 
-        $this->assertEquals('arg1', $withArg->args[0]->name);
-        $this->assertEquals(Type::int(), $withArg->args[0]->getType());
+        self::assertEquals('arg1', $withArg->args[0]->name);
+        self::assertEquals(Type::int(), $withArg->args[0]->getType());
 
         $testField = $schema->getType('Query')->getField('test');
-        $this->assertEquals($interface, $testField->getType());
-        $this->assertEquals('test', $testField->name);
+        self::assertEquals($interface, $testField->getType());
+        self::assertEquals('test', $testField->name);
     }
 
     public function testInfersNameFromClassname() : void
     {
         $myObj = new MyCustomType();
-        $this->assertEquals('MyCustom', $myObj->name);
+        self::assertEquals('MyCustom', $myObj->name);
 
         $otherCustom = new OtherCustom();
-        $this->assertEquals('OtherCustom', $otherCustom->name);
+        self::assertEquals('OtherCustom', $otherCustom->name);
     }
 
     public function testAllowsOverridingInternalTypes() : void
@@ -743,7 +743,7 @@ class DefinitionTest extends TestCase
             'types' => [$idType],
         ]);
 
-        $this->assertSame($idType, $schema->getType('ID'));
+        self::assertSame($idType, $schema->getType('ID'));
     }
 
     // Field config must be object
@@ -762,7 +762,7 @@ class DefinitionTest extends TestCase
             },
         ]);
         $objType->assertValid(true);
-        $this->assertSame(Type::string(), $objType->getField('f')->getType());
+        self::assertSame(Type::string(), $objType->getField('f')->getType());
     }
 
     /**
@@ -876,7 +876,7 @@ class DefinitionTest extends TestCase
             'interfaces' => [$this->interfaceType],
             'fields'     => ['f' => ['type' => Type::string()]],
         ]);
-        $this->assertSame($this->interfaceType, $objType->getInterfaces()[0]);
+        self::assertSame($this->interfaceType, $objType->getInterfaces()[0]);
     }
 
     /**
@@ -891,7 +891,7 @@ class DefinitionTest extends TestCase
             },
             'fields'     => ['f' => ['type' => Type::string()]],
         ]);
-        $this->assertSame($this->interfaceType, $objType->getInterfaces()[0]);
+        self::assertSame($this->interfaceType, $objType->getInterfaces()[0]);
     }
 
     /**
@@ -1399,7 +1399,7 @@ class DefinitionTest extends TestCase
             ],
         ]);
         $inputObjType->assertValid();
-        $this->assertSame(Type::string(), $inputObjType->getField('f')->getType());
+        self::assertSame(Type::string(), $inputObjType->getField('f')->getType());
     }
 
     // Type System: Input Objects must have fields
@@ -1418,7 +1418,7 @@ class DefinitionTest extends TestCase
             },
         ]);
         $inputObjType->assertValid();
-        $this->assertSame(Type::string(), $inputObjType->getField('f')->getType());
+        self::assertSame(Type::string(), $inputObjType->getField('f')->getType());
     }
 
     /**
@@ -1517,8 +1517,8 @@ class DefinitionTest extends TestCase
                 'BAR' => [],
             ],
         ]);
-        $this->assertEquals('FOO', $enumType->getValue('FOO')->value);
-        $this->assertEquals('BAR', $enumType->getValue('BAR')->value);
+        self::assertEquals('FOO', $enumType->getValue('FOO')->value);
+        self::assertEquals('BAR', $enumType->getValue('BAR')->value);
     }
 
     // Type System: Enum types must be well defined
@@ -1535,8 +1535,8 @@ class DefinitionTest extends TestCase
                 'BAR' => ['value' => 20],
             ],
         ]);
-        $this->assertEquals(10, $enumType->getValue('FOO')->value);
-        $this->assertEquals(20, $enumType->getValue('BAR')->value);
+        self::assertEquals(10, $enumType->getValue('FOO')->value);
+        self::assertEquals(20, $enumType->getValue('BAR')->value);
     }
 
     /**
@@ -1606,7 +1606,7 @@ class DefinitionTest extends TestCase
                 Type::listOf($badType);
                 $this->fail(sprintf('List should not accept %s', $typeStr));
             } catch (InvariantViolation $e) {
-                $this->assertEquals(sprintf('Expected %s to be a GraphQL type.', $typeStr), $e->getMessage());
+                self::assertEquals(sprintf('Expected %s to be a GraphQL type.', $typeStr), $e->getMessage());
             }
         }
     }
@@ -1647,7 +1647,7 @@ class DefinitionTest extends TestCase
                 Type::nonNull($badType);
                 $this->fail(sprintf('Nulls should not accept %s', $typeStr));
             } catch (InvariantViolation $e) {
-                $this->assertEquals(sprintf('Expected %s to be a GraphQL nullable type.', $typeStr), $e->getMessage());
+                self::assertEquals(sprintf('Expected %s to be a GraphQL nullable type.', $typeStr), $e->getMessage());
             }
         }
     }

--- a/tests/Type/EnumTypeTest.php
+++ b/tests/Type/EnumTypeTest.php
@@ -194,7 +194,7 @@ class EnumTypeTest extends TestCase
      */
     public function testAcceptsEnumLiteralsAsInput() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorInt' => 1]],
             GraphQL::executeQuery($this->schema, '{ colorInt(fromEnum: GREEN) }')->toArray()
         );
@@ -205,7 +205,7 @@ class EnumTypeTest extends TestCase
      */
     public function testEnumMayBeOutputType() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorEnum' => 'GREEN']],
             GraphQL::executeQuery($this->schema, '{ colorEnum(fromInt: 1) }')->toArray()
         );
@@ -216,7 +216,7 @@ class EnumTypeTest extends TestCase
      */
     public function testEnumMayBeBothInputAndOutputType() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorEnum' => 'GREEN']],
             GraphQL::executeQuery($this->schema, '{ colorEnum(fromEnum: GREEN) }')->toArray()
         );
@@ -240,19 +240,19 @@ class EnumTypeTest extends TestCase
     private function expectFailure($query, $vars, $err)
     {
         $result = GraphQL::executeQuery($this->schema, $query, null, null, $vars);
-        $this->assertEquals(1, count($result->errors));
+        self::assertEquals(1, count($result->errors));
 
         if (is_array($err)) {
-            $this->assertEquals(
+            self::assertEquals(
                 $err['message'],
                 $result->errors[0]->getMessage()
             );
-            $this->assertEquals(
+            self::assertEquals(
                 $err['locations'],
                 $result->errors[0]->getLocations()
             );
         } else {
-            $this->assertEquals(
+            self::assertEquals(
                 $err,
                 $result->errors[0]->getMessage()
             );
@@ -334,7 +334,7 @@ class EnumTypeTest extends TestCase
      */
     public function testAcceptsJSONStringAsEnumVariable() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorEnum' => 'BLUE']],
             GraphQL::executeQuery(
                 $this->schema,
@@ -351,7 +351,7 @@ class EnumTypeTest extends TestCase
      */
     public function testAcceptsEnumLiteralsAsInputArgumentsToMutations() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['favoriteEnum' => 'GREEN']],
             GraphQL::executeQuery(
                 $this->schema,
@@ -369,7 +369,7 @@ class EnumTypeTest extends TestCase
      */
     public function testAcceptsEnumLiteralsAsInputArgumentsToSubscriptions() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['subscribeToEnum' => 'GREEN']],
             GraphQL::executeQuery(
                 $this->schema,
@@ -422,7 +422,7 @@ class EnumTypeTest extends TestCase
      */
     public function testEnumValueMayHaveAnInternalValueOf0() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorEnum' => 'RED', 'colorInt' => 0]],
             GraphQL::executeQuery(
                 $this->schema,
@@ -439,7 +439,7 @@ class EnumTypeTest extends TestCase
      */
     public function testEnumInputsMayBeNullable() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             ['data' => ['colorEnum' => null, 'colorInt' => null]],
             GraphQL::executeQuery(
                 $this->schema,
@@ -459,11 +459,11 @@ class EnumTypeTest extends TestCase
         $ComplexEnum = $this->ComplexEnum;
         $values      = $ComplexEnum->getValues();
 
-        $this->assertEquals(2, count($values));
-        $this->assertEquals('ONE', $values[0]->name);
-        $this->assertEquals($this->Complex1, $values[0]->value);
-        $this->assertEquals('TWO', $values[1]->name);
-        $this->assertEquals($this->Complex2, $values[1]->value);
+        self::assertEquals(2, count($values));
+        self::assertEquals('ONE', $values[0]->name);
+        self::assertEquals($this->Complex1, $values[0]->value);
+        self::assertEquals('TWO', $values[1]->name);
+        self::assertEquals($this->Complex2, $values[1]->value);
     }
 
     /**
@@ -472,11 +472,11 @@ class EnumTypeTest extends TestCase
     public function testPresentsGetValueAPIForComplexEnums() : void
     {
         $oneValue = $this->ComplexEnum->getValue('ONE');
-        $this->assertEquals('ONE', $oneValue->name);
-        $this->assertEquals($this->Complex1, $oneValue->value);
+        self::assertEquals('ONE', $oneValue->name);
+        self::assertEquals($this->Complex1, $oneValue->value);
 
         $badUsage = $this->ComplexEnum->getValue($this->Complex1);
-        $this->assertEquals(null, $badUsage);
+        self::assertEquals(null, $badUsage);
     }
 
     /**
@@ -509,7 +509,7 @@ class EnumTypeTest extends TestCase
             ],
         ];
 
-        $this->assertArraySubset($expected, $result);
+        self::assertArraySubset($expected, $result);
     }
 
     /**
@@ -518,7 +518,7 @@ class EnumTypeTest extends TestCase
     public function testCanBeIntrospectedWithoutError() : void
     {
         $result = GraphQL::executeQuery($this->schema, Introspection::getIntrospectionQuery())->toArray();
-        $this->assertArrayNotHasKey('errors', $result);
+        self::assertArrayNotHasKey('errors', $result);
     }
 
     public function testAllowsSimpleArrayAsValues() : void
@@ -529,7 +529,7 @@ class EnumTypeTest extends TestCase
             third: simpleEnum(fromValue: "WRONG")
         }';
 
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'data'   => ['first' => 'ONE', 'second' => 'TWO', 'third' => null],
                 'errors' => [[

--- a/tests/Type/IntrospectionTest.php
+++ b/tests/Type/IntrospectionTest.php
@@ -1025,8 +1025,8 @@ class IntrospectionTest extends TestCase
 
         $actual = GraphQL::executeQuery($emptySchema, $request)->toArray();
 
-        // $this->assertEquals($expected, $actual);
-        $this->assertArraySubset($expected, $actual);
+        // self::assertEquals($expected, $actual);
+        self::assertArraySubset($expected, $actual);
     }
 
     /**
@@ -1124,7 +1124,7 @@ class IntrospectionTest extends TestCase
 
         $result = GraphQL::executeQuery($schema, $request)->toArray();
         $result = $result['data']['__type'];
-        $this->assertEquals($expectedFragment, $result);
+        self::assertEquals($expectedFragment, $result);
     }
 
     /**
@@ -1156,7 +1156,7 @@ class IntrospectionTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1210,7 +1210,7 @@ class IntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1267,7 +1267,7 @@ class IntrospectionTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1329,7 +1329,7 @@ class IntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1390,7 +1390,7 @@ class IntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1423,7 +1423,7 @@ class IntrospectionTest extends TestCase
                 ),
             ],
         ];
-        $this->assertArraySubset($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertArraySubset($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1483,7 +1483,7 @@ class IntrospectionTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 
     /**
@@ -1559,6 +1559,6 @@ class IntrospectionTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
+        self::assertEquals($expected, GraphQL::executeQuery($schema, $request)->toArray());
     }
 }

--- a/tests/Type/ResolutionTest.php
+++ b/tests/Type/ResolutionTest.php
@@ -272,7 +272,7 @@ class ResolutionTest extends TestCase
             'Int'     => Type::int(),
             'Boolean' => Type::boolean(),
         ];
-        $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
+        self::assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
 
         $expectedDescriptor = [
             'version'         => '1.0',
@@ -285,39 +285,39 @@ class ResolutionTest extends TestCase
             ],
             'possibleTypeMap' => [],
         ];
-        $this->assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
+        self::assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
 
-        $this->assertNull($eagerTypeResolution->resolveType('User'));
-        $this->assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->node));
-        $this->assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->content));
-        $this->assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->mention));
+        self::assertNull($eagerTypeResolution->resolveType('User'));
+        self::assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->node));
+        self::assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->content));
+        self::assertSame([], $eagerTypeResolution->resolvePossibleTypes($this->mention));
 
         $eagerTypeResolution = new EagerResolution([$this->query, $this->mutation]);
 
-        $this->assertSame($this->query, $eagerTypeResolution->resolveType('Query'));
-        $this->assertSame($this->mutation, $eagerTypeResolution->resolveType('Mutation'));
-        $this->assertSame($this->user, $eagerTypeResolution->resolveType('User'));
-        $this->assertSame($this->node, $eagerTypeResolution->resolveType('Node'));
-        $this->assertSame($this->node, $eagerTypeResolution->resolveType('Node'));
-        $this->assertSame($this->content, $eagerTypeResolution->resolveType('Content'));
-        $this->assertSame($this->comment, $eagerTypeResolution->resolveType('Comment'));
-        $this->assertSame($this->mention, $eagerTypeResolution->resolveType('Mention'));
-        $this->assertSame($this->blogStory, $eagerTypeResolution->resolveType('BlogStory'));
-        $this->assertSame($this->category, $eagerTypeResolution->resolveType('Category'));
-        $this->assertSame($this->postStoryMutation, $eagerTypeResolution->resolveType('PostStoryMutation'));
-        $this->assertSame($this->postStoryMutationInput, $eagerTypeResolution->resolveType('PostStoryMutationInput'));
-        $this->assertSame($this->postCommentMutation, $eagerTypeResolution->resolveType('PostCommentMutation'));
-        $this->assertSame(
+        self::assertSame($this->query, $eagerTypeResolution->resolveType('Query'));
+        self::assertSame($this->mutation, $eagerTypeResolution->resolveType('Mutation'));
+        self::assertSame($this->user, $eagerTypeResolution->resolveType('User'));
+        self::assertSame($this->node, $eagerTypeResolution->resolveType('Node'));
+        self::assertSame($this->node, $eagerTypeResolution->resolveType('Node'));
+        self::assertSame($this->content, $eagerTypeResolution->resolveType('Content'));
+        self::assertSame($this->comment, $eagerTypeResolution->resolveType('Comment'));
+        self::assertSame($this->mention, $eagerTypeResolution->resolveType('Mention'));
+        self::assertSame($this->blogStory, $eagerTypeResolution->resolveType('BlogStory'));
+        self::assertSame($this->category, $eagerTypeResolution->resolveType('Category'));
+        self::assertSame($this->postStoryMutation, $eagerTypeResolution->resolveType('PostStoryMutation'));
+        self::assertSame($this->postStoryMutationInput, $eagerTypeResolution->resolveType('PostStoryMutationInput'));
+        self::assertSame($this->postCommentMutation, $eagerTypeResolution->resolveType('PostCommentMutation'));
+        self::assertSame(
             $this->postCommentMutationInput,
             $eagerTypeResolution->resolveType('PostCommentMutationInput')
         );
 
-        $this->assertEquals([$this->blogStory], $eagerTypeResolution->resolvePossibleTypes($this->content));
-        $this->assertEquals(
+        self::assertEquals([$this->blogStory], $eagerTypeResolution->resolvePossibleTypes($this->content));
+        self::assertEquals(
             [$this->user, $this->comment, $this->category, $this->blogStory],
             $eagerTypeResolution->resolvePossibleTypes($this->node)
         );
-        $this->assertEquals([$this->user, $this->category], $eagerTypeResolution->resolvePossibleTypes($this->mention));
+        self::assertEquals([$this->user, $this->category], $eagerTypeResolution->resolvePossibleTypes($this->mention));
 
         $expectedTypeMap = [
             'Query'                    => $this->query,
@@ -340,7 +340,7 @@ class ResolutionTest extends TestCase
             'Boolean'                  => Type::boolean(),
         ];
 
-        $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
+        self::assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
 
         $expectedDescriptor = [
             'version'         => '1.0',
@@ -379,35 +379,35 @@ class ResolutionTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
+        self::assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
 
         // Ignores duplicates and nulls in initialTypes:
         $eagerTypeResolution = new EagerResolution([null, $this->query, null, $this->query, $this->mutation, null]);
-        $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
-        $this->assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
+        self::assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
+        self::assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
 
         // Those types are only part of interface
-        $this->assertEquals(null, $eagerTypeResolution->resolveType('Link'));
-        $this->assertEquals(null, $eagerTypeResolution->resolveType('Video'));
-        $this->assertEquals(null, $eagerTypeResolution->resolveType('VideoMetadata'));
+        self::assertEquals(null, $eagerTypeResolution->resolveType('Link'));
+        self::assertEquals(null, $eagerTypeResolution->resolveType('Video'));
+        self::assertEquals(null, $eagerTypeResolution->resolveType('VideoMetadata'));
 
-        $this->assertEquals([$this->blogStory], $eagerTypeResolution->resolvePossibleTypes($this->content));
-        $this->assertEquals(
+        self::assertEquals([$this->blogStory], $eagerTypeResolution->resolvePossibleTypes($this->content));
+        self::assertEquals(
             [$this->user, $this->comment, $this->category, $this->blogStory],
             $eagerTypeResolution->resolvePossibleTypes($this->node)
         );
-        $this->assertEquals([$this->user, $this->category], $eagerTypeResolution->resolvePossibleTypes($this->mention));
+        self::assertEquals([$this->user, $this->category], $eagerTypeResolution->resolvePossibleTypes($this->mention));
 
         $eagerTypeResolution = new EagerResolution([null, $this->video, null]);
-        $this->assertEquals($this->videoMetadata, $eagerTypeResolution->resolveType('VideoMetadata'));
-        $this->assertEquals($this->video, $eagerTypeResolution->resolveType('Video'));
+        self::assertEquals($this->videoMetadata, $eagerTypeResolution->resolveType('VideoMetadata'));
+        self::assertEquals($this->video, $eagerTypeResolution->resolveType('Video'));
 
-        $this->assertEquals([$this->video], $eagerTypeResolution->resolvePossibleTypes($this->content));
-        $this->assertEquals(
+        self::assertEquals([$this->video], $eagerTypeResolution->resolvePossibleTypes($this->content));
+        self::assertEquals(
             [$this->video, $this->user, $this->comment, $this->category],
             $eagerTypeResolution->resolvePossibleTypes($this->node)
         );
-        $this->assertEquals([], $eagerTypeResolution->resolvePossibleTypes($this->mention));
+        self::assertEquals([], $eagerTypeResolution->resolvePossibleTypes($this->mention));
 
         $expectedTypeMap = [
             'Video'         => $this->video,
@@ -423,7 +423,7 @@ class ResolutionTest extends TestCase
             'Int'           => Type::int(),
             'Boolean'       => Type::boolean(),
         ];
-        $this->assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
+        self::assertEquals($expectedTypeMap, $eagerTypeResolution->getTypeMap());
 
         $expectedDescriptor = [
             'version'         => '1.0',
@@ -451,7 +451,7 @@ class ResolutionTest extends TestCase
                 'Content' => ['Video' => 1],
             ],
         ];
-        $this->assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
+        self::assertEquals($expectedDescriptor, $eagerTypeResolution->getDescriptor());
     }
 
     public function testLazyResolutionFollowsEagerResolution() : void
@@ -465,10 +465,10 @@ class ResolutionTest extends TestCase
         };
 
         $lazy = new LazyResolution($emptyDescriptor, $typeLoader);
-        $this->assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
-        $this->assertSame($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
-        $this->assertSame($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
-        $this->assertSame($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
+        self::assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
+        self::assertSame($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
+        self::assertSame($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
+        self::assertSame($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
 
         $eager = new EagerResolution([$this->query, $this->mutation]);
 
@@ -483,46 +483,46 @@ class ResolutionTest extends TestCase
 
         $lazy = new LazyResolution($descriptor, $typeLoader);
 
-        $this->assertSame($eager->resolveType('Query'), $lazy->resolveType('Query'));
-        $this->assertSame(1, $called);
-        $this->assertSame($eager->resolveType('Mutation'), $lazy->resolveType('Mutation'));
-        $this->assertSame(2, $called);
-        $this->assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
-        $this->assertSame(3, $called);
-        $this->assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
-        $this->assertSame(3, $called);
-        $this->assertSame($eager->resolveType('Node'), $lazy->resolveType('Node'));
-        $this->assertSame($eager->resolveType('Node'), $lazy->resolveType('Node'));
-        $this->assertSame(4, $called);
-        $this->assertSame($eager->resolveType('Content'), $lazy->resolveType('Content'));
-        $this->assertSame($eager->resolveType('Comment'), $lazy->resolveType('Comment'));
-        $this->assertSame($eager->resolveType('Mention'), $lazy->resolveType('Mention'));
-        $this->assertSame($eager->resolveType('BlogStory'), $lazy->resolveType('BlogStory'));
-        $this->assertSame($eager->resolveType('Category'), $lazy->resolveType('Category'));
-        $this->assertSame($eager->resolveType('PostStoryMutation'), $lazy->resolveType('PostStoryMutation'));
-        $this->assertSame($eager->resolveType('PostStoryMutationInput'), $lazy->resolveType('PostStoryMutationInput'));
-        $this->assertSame($eager->resolveType('PostCommentMutation'), $lazy->resolveType('PostCommentMutation'));
-        $this->assertSame(
+        self::assertSame($eager->resolveType('Query'), $lazy->resolveType('Query'));
+        self::assertSame(1, $called);
+        self::assertSame($eager->resolveType('Mutation'), $lazy->resolveType('Mutation'));
+        self::assertSame(2, $called);
+        self::assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
+        self::assertSame(3, $called);
+        self::assertSame($eager->resolveType('User'), $lazy->resolveType('User'));
+        self::assertSame(3, $called);
+        self::assertSame($eager->resolveType('Node'), $lazy->resolveType('Node'));
+        self::assertSame($eager->resolveType('Node'), $lazy->resolveType('Node'));
+        self::assertSame(4, $called);
+        self::assertSame($eager->resolveType('Content'), $lazy->resolveType('Content'));
+        self::assertSame($eager->resolveType('Comment'), $lazy->resolveType('Comment'));
+        self::assertSame($eager->resolveType('Mention'), $lazy->resolveType('Mention'));
+        self::assertSame($eager->resolveType('BlogStory'), $lazy->resolveType('BlogStory'));
+        self::assertSame($eager->resolveType('Category'), $lazy->resolveType('Category'));
+        self::assertSame($eager->resolveType('PostStoryMutation'), $lazy->resolveType('PostStoryMutation'));
+        self::assertSame($eager->resolveType('PostStoryMutationInput'), $lazy->resolveType('PostStoryMutationInput'));
+        self::assertSame($eager->resolveType('PostCommentMutation'), $lazy->resolveType('PostCommentMutation'));
+        self::assertSame(
             $eager->resolveType('PostCommentMutationInput'),
             $lazy->resolveType('PostCommentMutationInput')
         );
-        $this->assertSame(13, $called);
+        self::assertSame(13, $called);
 
-        $this->assertEquals($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
-        $this->assertEquals($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
-        $this->assertEquals($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
+        self::assertEquals($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
+        self::assertEquals($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
+        self::assertEquals($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
 
         $called = 0;
         $eager  = new EagerResolution([$this->video]);
         $lazy   = new LazyResolution($eager->getDescriptor(), $typeLoader);
 
-        $this->assertEquals($eager->resolveType('VideoMetadata'), $lazy->resolveType('VideoMetadata'));
-        $this->assertEquals($eager->resolveType('Video'), $lazy->resolveType('Video'));
-        $this->assertEquals(2, $called);
+        self::assertEquals($eager->resolveType('VideoMetadata'), $lazy->resolveType('VideoMetadata'));
+        self::assertEquals($eager->resolveType('Video'), $lazy->resolveType('Video'));
+        self::assertEquals(2, $called);
 
-        $this->assertEquals($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
-        $this->assertEquals($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
-        $this->assertEquals($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
+        self::assertEquals($eager->resolvePossibleTypes($this->content), $lazy->resolvePossibleTypes($this->content));
+        self::assertEquals($eager->resolvePossibleTypes($this->node), $lazy->resolvePossibleTypes($this->node));
+        self::assertEquals($eager->resolvePossibleTypes($this->mention), $lazy->resolvePossibleTypes($this->mention));
     }
 
     public function testLazyThrowsOnInvalidLoadedType() : void
@@ -558,7 +558,7 @@ class ResolutionTest extends TestCase
 
         $lazy  = new LazyResolution($descriptor, $invalidTypeLoader);
         $value = $lazy->resolveType('null');
-        $this->assertEquals(null, $value);
+        self::assertEquals(null, $value);
 
         return $lazy;
     }

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -175,10 +175,10 @@ class ResolveInfoTest extends TestCase
         $schema = new Schema(['query' => $blogQuery]);
         $result = GraphQL::executeQuery($schema, $doc)->toArray();
 
-        $this->assertTrue($hasCalled);
-        $this->assertEquals(['data' => ['article' => null]], $result);
-        $this->assertEquals($expectedDefaultSelection, $actualDefaultSelection);
-        $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
+        self::assertTrue($hasCalled);
+        self::assertEquals(['data' => ['article' => null]], $result);
+        self::assertEquals($expectedDefaultSelection, $actualDefaultSelection);
+        self::assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
 
     public function testMergedFragmentsFieldSelection() : void
@@ -346,8 +346,8 @@ class ResolveInfoTest extends TestCase
         $schema = new Schema(['query' => $blogQuery]);
         $result = GraphQL::executeQuery($schema, $doc)->toArray();
 
-        $this->assertTrue($hasCalled);
-        $this->assertEquals(['data' => ['article' => null]], $result);
-        $this->assertEquals($expectedDeepSelection, $actualDeepSelection);
+        self::assertTrue($hasCalled);
+        self::assertEquals(['data' => ['article' => null]], $result);
+        self::assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
 }

--- a/tests/Type/ScalarSerializationTest.php
+++ b/tests/Type/ScalarSerializationTest.php
@@ -18,14 +18,14 @@ class ScalarSerializationTest extends TestCase
     {
         $intType = Type::int();
 
-        $this->assertSame(1, $intType->serialize(1));
-        $this->assertSame(123, $intType->serialize('123'));
-        $this->assertSame(0, $intType->serialize(0));
-        $this->assertSame(-1, $intType->serialize(-1));
-        $this->assertSame(100000, $intType->serialize(1e5));
-        $this->assertSame(0, $intType->serialize(0e5));
-        $this->assertSame(0, $intType->serialize(false));
-        $this->assertSame(1, $intType->serialize(true));
+        self::assertSame(1, $intType->serialize(1));
+        self::assertSame(123, $intType->serialize('123'));
+        self::assertSame(0, $intType->serialize(0));
+        self::assertSame(-1, $intType->serialize(-1));
+        self::assertSame(100000, $intType->serialize(1e5));
+        self::assertSame(0, $intType->serialize(0e5));
+        self::assertSame(0, $intType->serialize(false));
+        self::assertSame(1, $intType->serialize(true));
     }
 
     public function testSerializesOutputIntCannotRepresentFloat1() : void
@@ -119,16 +119,16 @@ class ScalarSerializationTest extends TestCase
     {
         $floatType = Type::float();
 
-        $this->assertSame(1.0, $floatType->serialize(1));
-        $this->assertSame(0.0, $floatType->serialize(0));
-        $this->assertSame(123.5, $floatType->serialize('123.5'));
-        $this->assertSame(-1.0, $floatType->serialize(-1));
-        $this->assertSame(0.1, $floatType->serialize(0.1));
-        $this->assertSame(1.1, $floatType->serialize(1.1));
-        $this->assertSame(-1.1, $floatType->serialize(-1.1));
-        $this->assertSame(-1.1, $floatType->serialize('-1.1'));
-        $this->assertSame(0.0, $floatType->serialize(false));
-        $this->assertSame(1.0, $floatType->serialize(true));
+        self::assertSame(1.0, $floatType->serialize(1));
+        self::assertSame(0.0, $floatType->serialize(0));
+        self::assertSame(123.5, $floatType->serialize('123.5'));
+        self::assertSame(-1.0, $floatType->serialize(-1));
+        self::assertSame(0.1, $floatType->serialize(0.1));
+        self::assertSame(1.1, $floatType->serialize(1.1));
+        self::assertSame(-1.1, $floatType->serialize(-1.1));
+        self::assertSame(-1.1, $floatType->serialize('-1.1'));
+        self::assertSame(0.0, $floatType->serialize(false));
+        self::assertSame(1.0, $floatType->serialize(true));
     }
 
     public function testSerializesOutputFloatCannotRepresentString() : void
@@ -154,13 +154,13 @@ class ScalarSerializationTest extends TestCase
     {
         $stringType = Type::string();
 
-        $this->assertSame('string', $stringType->serialize('string'));
-        $this->assertSame('1', $stringType->serialize(1));
-        $this->assertSame('-1.1', $stringType->serialize(-1.1));
-        $this->assertSame('true', $stringType->serialize(true));
-        $this->assertSame('false', $stringType->serialize(false));
-        $this->assertSame('null', $stringType->serialize(null));
-        $this->assertSame('2', $stringType->serialize(new ObjectIdStub(2)));
+        self::assertSame('string', $stringType->serialize('string'));
+        self::assertSame('1', $stringType->serialize(1));
+        self::assertSame('-1.1', $stringType->serialize(-1.1));
+        self::assertSame('true', $stringType->serialize(true));
+        self::assertSame('false', $stringType->serialize(false));
+        self::assertSame('null', $stringType->serialize(null));
+        self::assertSame('2', $stringType->serialize(new ObjectIdStub(2)));
     }
 
     public function testSerializesOutputStringsCannotRepresentArray() : void
@@ -186,13 +186,13 @@ class ScalarSerializationTest extends TestCase
     {
         $boolType = Type::boolean();
 
-        $this->assertTrue($boolType->serialize('string'));
-        $this->assertFalse($boolType->serialize(''));
-        $this->assertTrue($boolType->serialize('1'));
-        $this->assertTrue($boolType->serialize(1));
-        $this->assertFalse($boolType->serialize(0));
-        $this->assertTrue($boolType->serialize(true));
-        $this->assertFalse($boolType->serialize(false));
+        self::assertTrue($boolType->serialize('string'));
+        self::assertFalse($boolType->serialize(''));
+        self::assertTrue($boolType->serialize('1'));
+        self::assertTrue($boolType->serialize(1));
+        self::assertFalse($boolType->serialize(0));
+        self::assertTrue($boolType->serialize(true));
+        self::assertFalse($boolType->serialize(false));
         // TODO: how should it behave on '0'?
     }
 
@@ -200,14 +200,14 @@ class ScalarSerializationTest extends TestCase
     {
         $idType = Type::id();
 
-        $this->assertSame('string', $idType->serialize('string'));
-        $this->assertSame('', $idType->serialize(''));
-        $this->assertSame('1', $idType->serialize('1'));
-        $this->assertSame('1', $idType->serialize(1));
-        $this->assertSame('0', $idType->serialize(0));
-        $this->assertSame('true', $idType->serialize(true));
-        $this->assertSame('false', $idType->serialize(false));
-        $this->assertSame('2', $idType->serialize(new ObjectIdStub(2)));
+        self::assertSame('string', $idType->serialize('string'));
+        self::assertSame('', $idType->serialize(''));
+        self::assertSame('1', $idType->serialize('1'));
+        self::assertSame('1', $idType->serialize(1));
+        self::assertSame('0', $idType->serialize(0));
+        self::assertSame('true', $idType->serialize(true));
+        self::assertSame('false', $idType->serialize(false));
+        self::assertSame('2', $idType->serialize(new ObjectIdStub(2)));
     }
 
     public function testSerializesOutputIDCannotRepresentObject() : void

--- a/tests/Type/SchemaTest.php
+++ b/tests/Type/SchemaTest.php
@@ -127,7 +127,7 @@ class SchemaTest extends TestCase
     public function testIncludesInputTypesOnlyUsedInDirectives() : void
     {
         $typeMap = $this->schema->getTypeMap();
-        $this->assertArrayHasKey('DirInput', $typeMap);
-        $this->assertArrayHasKey('WrappedDirInput', $typeMap);
+        self::assertArrayHasKey('DirInput', $typeMap);
+        self::assertArrayHasKey('WrappedDirInput', $typeMap);
     }
 }

--- a/tests/Type/TypeLoaderTest.php
+++ b/tests/Type/TypeLoaderTest.php
@@ -186,15 +186,15 @@ class TypeLoaderTest extends TestCase
             'Mutation.fields',
             'BlogStory.fields',
         ];
-        $this->assertEquals($expected, $this->calls);
+        self::assertEquals($expected, $this->calls);
 
-        $this->assertSame($this->query, $schema->getType('Query'));
-        $this->assertSame($this->mutation, $schema->getType('Mutation'));
-        $this->assertSame($this->node, $schema->getType('Node'));
-        $this->assertSame($this->content, $schema->getType('Content'));
-        $this->assertSame($this->blogStory, $schema->getType('BlogStory'));
-        $this->assertSame($this->postStoryMutation, $schema->getType('PostStoryMutation'));
-        $this->assertSame($this->postStoryMutationInput, $schema->getType('PostStoryMutationInput'));
+        self::assertSame($this->query, $schema->getType('Query'));
+        self::assertSame($this->mutation, $schema->getType('Mutation'));
+        self::assertSame($this->node, $schema->getType('Node'));
+        self::assertSame($this->content, $schema->getType('Content'));
+        self::assertSame($this->blogStory, $schema->getType('BlogStory'));
+        self::assertSame($this->postStoryMutation, $schema->getType('PostStoryMutation'));
+        self::assertSame($this->postStoryMutationInput, $schema->getType('PostStoryMutationInput'));
 
         $expectedTypeMap = [
             'Query'                  => $this->query,
@@ -206,7 +206,7 @@ class TypeLoaderTest extends TestCase
             'PostStoryMutationInput' => $this->postStoryMutationInput,
         ];
 
-        $this->assertArraySubset($expectedTypeMap, $schema->getTypeMap());
+        self::assertArraySubset($expectedTypeMap, $schema->getTypeMap());
     }
 
     public function testWorksWithTypeLoader() : void
@@ -216,23 +216,23 @@ class TypeLoaderTest extends TestCase
             'mutation'   => $this->mutation,
             'typeLoader' => $this->typeLoader,
         ]);
-        $this->assertEquals([], $this->calls);
+        self::assertEquals([], $this->calls);
 
         $node = $schema->getType('Node');
-        $this->assertSame($this->node, $node);
-        $this->assertEquals(['Node'], $this->calls);
+        self::assertSame($this->node, $node);
+        self::assertEquals(['Node'], $this->calls);
 
         $content = $schema->getType('Content');
-        $this->assertSame($this->content, $content);
-        $this->assertEquals(['Node', 'Content'], $this->calls);
+        self::assertSame($this->content, $content);
+        self::assertEquals(['Node', 'Content'], $this->calls);
 
         $input = $schema->getType('PostStoryMutationInput');
-        $this->assertSame($this->postStoryMutationInput, $input);
-        $this->assertEquals(['Node', 'Content', 'PostStoryMutationInput'], $this->calls);
+        self::assertSame($this->postStoryMutationInput, $input);
+        self::assertEquals(['Node', 'Content', 'PostStoryMutationInput'], $this->calls);
 
         $result = $schema->isPossibleType($this->node, $this->blogStory);
-        $this->assertTrue($result);
-        $this->assertEquals(['Node', 'Content', 'PostStoryMutationInput'], $this->calls);
+        self::assertTrue($result);
+        self::assertEquals(['Node', 'Content', 'PostStoryMutationInput'], $this->calls);
     }
 
     public function testOnlyCallsLoaderOnce() : void
@@ -243,10 +243,10 @@ class TypeLoaderTest extends TestCase
         ]);
 
         $schema->getType('Node');
-        $this->assertEquals(['Node'], $this->calls);
+        self::assertEquals(['Node'], $this->calls);
 
         $schema->getType('Node');
-        $this->assertEquals(['Node'], $this->calls);
+        self::assertEquals(['Node'], $this->calls);
     }
 
     public function testFailsOnNonExistentType() : void
@@ -321,10 +321,10 @@ class TypeLoaderTest extends TestCase
             'typeLoader' => $this->typeLoader,
         ]);
 
-        $this->assertSame($withoutLoader->getQueryType(), $withLoader->getQueryType());
-        $this->assertSame($withoutLoader->getMutationType(), $withLoader->getMutationType());
-        $this->assertSame($withoutLoader->getType('BlogStory'), $withLoader->getType('BlogStory'));
-        $this->assertSame($withoutLoader->getDirectives(), $withLoader->getDirectives());
+        self::assertSame($withoutLoader->getQueryType(), $withLoader->getQueryType());
+        self::assertSame($withoutLoader->getMutationType(), $withLoader->getMutationType());
+        self::assertSame($withoutLoader->getType('BlogStory'), $withLoader->getType('BlogStory'));
+        self::assertSame($withoutLoader->getDirectives(), $withLoader->getDirectives());
     }
 
     public function testSkipsLoaderForInternalTypes() : void
@@ -336,7 +336,7 @@ class TypeLoaderTest extends TestCase
         ]);
 
         $type = $schema->getType('ID');
-        $this->assertSame(Type::id(), $type);
-        $this->assertEquals([], $this->calls);
+        self::assertSame(Type::id(), $type);
+        self::assertEquals([], $this->calls);
     }
 }

--- a/tests/Type/ValidationTest.php
+++ b/tests/Type/ValidationTest.php
@@ -203,7 +203,7 @@ class ValidationTest extends TestCase
                 $factory();
                 $this->fail('Expected exception not thrown for entry ' . $index);
             } catch (InvariantViolation $e) {
-                $this->assertEquals($expectedError, $e->getMessage(), 'Error in callable #' . $index);
+                self::assertEquals($expectedError, $e->getMessage(), 'Error in callable #' . $index);
             }
         }
     }
@@ -218,7 +218,7 @@ class ValidationTest extends TestCase
         test: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
 
         $schemaWithDef = BuildSchema::build('
       schema {
@@ -228,7 +228,7 @@ class ValidationTest extends TestCase
         test: String
       }
     ');
-        $this->assertEquals([], $schemaWithDef->validate());
+        self::assertEquals([], $schemaWithDef->validate());
     }
 
     /**
@@ -245,7 +245,7 @@ class ValidationTest extends TestCase
         test: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
 
         $schema = BuildSchema::build('
       schema {
@@ -261,7 +261,7 @@ class ValidationTest extends TestCase
         test: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -278,7 +278,7 @@ class ValidationTest extends TestCase
         test: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
 
         $schema = BuildSchema::build('
       schema {
@@ -294,7 +294,7 @@ class ValidationTest extends TestCase
         test: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -339,7 +339,7 @@ class ValidationTest extends TestCase
      */
     private function assertContainsValidationMessage($array, $messages)
     {
-        $this->assertCount(
+        self::assertCount(
             count($messages),
             $array,
             sprintf('For messages: %s', $messages[0]['message']) . "\n" .
@@ -358,12 +358,12 @@ class ValidationTest extends TestCase
             if (! isset($messages[$index]) || ! $error instanceof Error) {
                 $this->fail('Received unexpected error: ' . $error->getMessage());
             }
-            $this->assertEquals($messages[$index]['message'], $error->getMessage());
+            self::assertEquals($messages[$index]['message'], $error->getMessage());
             $errorLocations = [];
             foreach ($error->getLocations() as $location) {
                 $errorLocations[] = $location->toArray();
             }
-            $this->assertEquals(
+            self::assertEquals(
                 $messages[$index]['locations'] ?? [],
                 $errorLocations
             );
@@ -541,7 +541,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -664,7 +664,7 @@ class ValidationTest extends TestCase
                 ],
             ],
         ]));
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -714,7 +714,7 @@ class ValidationTest extends TestCase
         | TypeB
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     // DESCRIBE: Type System: Input Objects must have fields
@@ -848,7 +848,7 @@ class ValidationTest extends TestCase
         field: String
       }
         ');
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -1021,7 +1021,7 @@ class ValidationTest extends TestCase
     {
         foreach ($this->outputTypes as $type) {
             $schema = $this->schemaWithObjectFieldOfType($type);
-            $this->assertEquals([], $schema->validate());
+            self::assertEquals([], $schema->validate());
         }
     }
 
@@ -1223,7 +1223,7 @@ class ValidationTest extends TestCase
     {
         foreach ($this->outputTypes as $type) {
             $schema = $this->schemaWithInterfaceFieldOfType($type);
-            $this->assertEquals([], $schema->validate());
+            self::assertEquals([], $schema->validate());
         }
     }
 
@@ -1314,7 +1314,7 @@ class ValidationTest extends TestCase
     {
         foreach ($this->inputTypes as $type) {
             $schema = $this->schemaWithArgOfType($type);
-            $this->assertEquals([], $schema->validate());
+            self::assertEquals([], $schema->validate());
         }
     }
 
@@ -1405,7 +1405,7 @@ class ValidationTest extends TestCase
     {
         foreach ($this->inputTypes as $type) {
             $schema = $this->schemaWithInputFieldOfType($type);
-            $this->assertEquals([], $schema->validate());
+            self::assertEquals([], $schema->validate());
         }
     }
 
@@ -1510,7 +1510,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals(
+        self::assertEquals(
             [],
             $schema->validate()
         );
@@ -1536,7 +1536,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals(
+        self::assertEquals(
             [],
             $schema->validate()
         );
@@ -1561,7 +1561,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals(
+        self::assertEquals(
             [],
             $schema->validate()
         );
@@ -1679,7 +1679,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -1707,7 +1707,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -1856,7 +1856,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**
@@ -1938,7 +1938,7 @@ class ValidationTest extends TestCase
       }
         ');
 
-        $this->assertEquals([], $schema->validate());
+        self::assertEquals([], $schema->validate());
     }
 
     /**

--- a/tests/Utils/AstFromValueTest.php
+++ b/tests/Utils/AstFromValueTest.php
@@ -31,16 +31,16 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsBooleanValueToASTs() : void
     {
-        $this->assertEquals(new BooleanValueNode(['value' => true]), AST::astFromValue(true, Type::boolean()));
-        $this->assertEquals(new BooleanValueNode(['value' => false]), AST::astFromValue(false, Type::boolean()));
-        $this->assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::boolean()));
-        $this->assertEquals(new BooleanValueNode(['value' => false]), AST::astFromValue(0, Type::boolean()));
-        $this->assertEquals(new BooleanValueNode(['value' => true]), AST::astFromValue(1, Type::boolean()));
-        $this->assertEquals(
+        self::assertEquals(new BooleanValueNode(['value' => true]), AST::astFromValue(true, Type::boolean()));
+        self::assertEquals(new BooleanValueNode(['value' => false]), AST::astFromValue(false, Type::boolean()));
+        self::assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::boolean()));
+        self::assertEquals(new BooleanValueNode(['value' => false]), AST::astFromValue(0, Type::boolean()));
+        self::assertEquals(new BooleanValueNode(['value' => true]), AST::astFromValue(1, Type::boolean()));
+        self::assertEquals(
             new BooleanValueNode(['value' => false]),
             AST::astFromValue(0, Type::nonNull(Type::boolean()))
         );
-        $this->assertEquals(
+        self::assertEquals(
             null,
             AST::astFromValue(null, Type::nonNull(Type::boolean()))
         ); // Note: null means that AST cannot
@@ -51,10 +51,10 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsIntValuesToASTs() : void
     {
-        $this->assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::int()));
-        $this->assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123.0, Type::int()));
-        $this->assertEquals(new IntValueNode(['value' => '10000']), AST::astFromValue(1e4, Type::int()));
-        $this->assertEquals(new IntValueNode(['value' => '0']), AST::astFromValue(0e4, Type::int()));
+        self::assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::int()));
+        self::assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123.0, Type::int()));
+        self::assertEquals(new IntValueNode(['value' => '10000']), AST::astFromValue(1e4, Type::int()));
+        self::assertEquals(new IntValueNode(['value' => '0']), AST::astFromValue(0e4, Type::int()));
     }
 
     public function testConvertsIntValuesToASTsCannotRepresentNonInteger() : void
@@ -81,13 +81,13 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsFloatValuesToIntOrFloatASTs() : void
     {
-        $this->assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::float()));
-        $this->assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123, Type::float()));
-        $this->assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123.0, Type::float()));
-        $this->assertEquals(new FloatValueNode(['value' => '123.5']), AST::astFromValue(123.5, Type::float()));
-        $this->assertEquals(new IntValueNode(['value' => '10000']), AST::astFromValue(1e4, Type::float()));
-        $this->assertEquals(new FloatValueNode(['value' => '1e+40']), AST::astFromValue(1e40, Type::float()));
-        $this->assertEquals(new IntValueNode(['value' => '0']), AST::astFromValue(0e40, Type::float()));
+        self::assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::float()));
+        self::assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123, Type::float()));
+        self::assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123.0, Type::float()));
+        self::assertEquals(new FloatValueNode(['value' => '123.5']), AST::astFromValue(123.5, Type::float()));
+        self::assertEquals(new IntValueNode(['value' => '10000']), AST::astFromValue(1e4, Type::float()));
+        self::assertEquals(new FloatValueNode(['value' => '1e+40']), AST::astFromValue(1e40, Type::float()));
+        self::assertEquals(new IntValueNode(['value' => '0']), AST::astFromValue(0e40, Type::float()));
     }
 
     /**
@@ -95,13 +95,13 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsStringValuesToASTs() : void
     {
-        $this->assertEquals(new StringValueNode(['value' => 'hello']), AST::astFromValue('hello', Type::string()));
-        $this->assertEquals(new StringValueNode(['value' => 'VALUE']), AST::astFromValue('VALUE', Type::string()));
-        $this->assertEquals(new StringValueNode(['value' => "VA\nLUE"]), AST::astFromValue("VA\nLUE", Type::string()));
-        $this->assertEquals(new StringValueNode(['value' => '123']), AST::astFromValue(123, Type::string()));
-        $this->assertEquals(new StringValueNode(['value' => 'false']), AST::astFromValue(false, Type::string()));
-        $this->assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::string()));
-        $this->assertEquals(null, AST::astFromValue(null, Type::nonNull(Type::string())));
+        self::assertEquals(new StringValueNode(['value' => 'hello']), AST::astFromValue('hello', Type::string()));
+        self::assertEquals(new StringValueNode(['value' => 'VALUE']), AST::astFromValue('VALUE', Type::string()));
+        self::assertEquals(new StringValueNode(['value' => "VA\nLUE"]), AST::astFromValue("VA\nLUE", Type::string()));
+        self::assertEquals(new StringValueNode(['value' => '123']), AST::astFromValue(123, Type::string()));
+        self::assertEquals(new StringValueNode(['value' => 'false']), AST::astFromValue(false, Type::string()));
+        self::assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::string()));
+        self::assertEquals(null, AST::astFromValue(null, Type::nonNull(Type::string())));
     }
 
     /**
@@ -109,16 +109,16 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertIdValuesToIntOrStringASTs() : void
     {
-        $this->assertEquals(new StringValueNode(['value' => 'hello']), AST::astFromValue('hello', Type::id()));
-        $this->assertEquals(new StringValueNode(['value' => 'VALUE']), AST::astFromValue('VALUE', Type::id()));
-        $this->assertEquals(new StringValueNode(['value' => "VA\nLUE"]), AST::astFromValue("VA\nLUE", Type::id()));
-        $this->assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::id()));
-        $this->assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123, Type::id()));
-        $this->assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue('123', Type::id()));
-        $this->assertEquals(new StringValueNode(['value' => '01']), AST::astFromValue('01', Type::id()));
-        $this->assertEquals(new StringValueNode(['value' => 'false']), AST::astFromValue(false, Type::id()));
-        $this->assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::id()));
-        $this->assertEquals(null, AST::astFromValue(null, Type::nonNull(Type::id())));
+        self::assertEquals(new StringValueNode(['value' => 'hello']), AST::astFromValue('hello', Type::id()));
+        self::assertEquals(new StringValueNode(['value' => 'VALUE']), AST::astFromValue('VALUE', Type::id()));
+        self::assertEquals(new StringValueNode(['value' => "VA\nLUE"]), AST::astFromValue("VA\nLUE", Type::id()));
+        self::assertEquals(new IntValueNode(['value' => '-1']), AST::astFromValue(-1, Type::id()));
+        self::assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue(123, Type::id()));
+        self::assertEquals(new IntValueNode(['value' => '123']), AST::astFromValue('123', Type::id()));
+        self::assertEquals(new StringValueNode(['value' => '01']), AST::astFromValue('01', Type::id()));
+        self::assertEquals(new StringValueNode(['value' => 'false']), AST::astFromValue(false, Type::id()));
+        self::assertEquals(new NullValueNode([]), AST::astFromValue(null, Type::id()));
+        self::assertEquals(null, AST::astFromValue(null, Type::nonNull(Type::id())));
     }
 
     /**
@@ -126,7 +126,7 @@ class AstFromValueTest extends TestCase
      */
     public function testDoesNotConvertsNonNullValuestoNullValue() : void
     {
-        $this->assertNull(AST::astFromValue(null, Type::nonNull(Type::boolean())));
+        self::assertNull(AST::astFromValue(null, Type::nonNull(Type::boolean())));
     }
 
     /**
@@ -134,17 +134,17 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsStringValuesToEnumASTsIfPossible() : void
     {
-        $this->assertEquals(new EnumValueNode(['value' => 'HELLO']), AST::astFromValue('HELLO', $this->myEnum()));
-        $this->assertEquals(
+        self::assertEquals(new EnumValueNode(['value' => 'HELLO']), AST::astFromValue('HELLO', $this->myEnum()));
+        self::assertEquals(
             new EnumValueNode(['value' => 'COMPLEX']),
             AST::astFromValue($this->complexValue(), $this->myEnum())
         );
 
         // Note: case sensitive
-        $this->assertNull(AST::astFromValue('hello', $this->myEnum()));
+        self::assertNull(AST::astFromValue('hello', $this->myEnum()));
 
         // Note: Not a valid enum value
-        $this->assertNull(AST::astFromValue('VALUE', $this->myEnum()));
+        self::assertNull(AST::astFromValue('VALUE', $this->myEnum()));
     }
 
     /**
@@ -183,7 +183,7 @@ class AstFromValueTest extends TestCase
                 new StringValueNode(['value' => 'BAR']),
             ],
         ]);
-        $this->assertEquals($value1, AST::astFromValue(['FOO', 'BAR'], Type::listOf(Type::string())));
+        self::assertEquals($value1, AST::astFromValue(['FOO', 'BAR'], Type::listOf(Type::string())));
 
         $value2 = new ListValueNode([
             'values' => [
@@ -191,7 +191,7 @@ class AstFromValueTest extends TestCase
                 new EnumValueNode(['value' => 'GOODBYE']),
             ],
         ]);
-        $this->assertEquals($value2, AST::astFromValue(['HELLO', 'GOODBYE'], Type::listOf($this->myEnum())));
+        self::assertEquals($value2, AST::astFromValue(['HELLO', 'GOODBYE'], Type::listOf($this->myEnum())));
     }
 
     /**
@@ -199,7 +199,7 @@ class AstFromValueTest extends TestCase
      */
     public function testConvertsListSingletons() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             new StringValueNode(['value' => 'FOO']),
             AST::astFromValue('FOO', Type::listOf(Type::string()))
         );
@@ -226,8 +226,8 @@ class AstFromValueTest extends TestCase
         ]);
 
         $data = ['foo' => 3, 'bar' => 'HELLO'];
-        $this->assertEquals($expected, AST::astFromValue($data, $inputObj));
-        $this->assertEquals($expected, AST::astFromValue((object) $data, $inputObj));
+        self::assertEquals($expected, AST::astFromValue($data, $inputObj));
+        self::assertEquals($expected, AST::astFromValue((object) $data, $inputObj));
     }
 
     /**
@@ -255,7 +255,7 @@ class AstFromValueTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             new ObjectValueNode([
             'fields' => [
                 $this->objectField('foo', new NullValueNode([])),

--- a/tests/Utils/AstFromValueUntypedTest.php
+++ b/tests/Utils/AstFromValueUntypedTest.php
@@ -16,20 +16,20 @@ class AstFromValueUntypedTest extends TestCase
      */
     public function testParsesSimpleValues() : void
     {
-        $this->assertTestCase('null', null);
-        $this->assertTestCase('true', true);
-        $this->assertTestCase('false', false);
-        $this->assertTestCase('123', 123);
-        $this->assertTestCase('123.456', 123.456);
-        $this->assertTestCase('abc123', 'abc123');
+        self::assertTestCase('null', null);
+        self::assertTestCase('true', true);
+        self::assertTestCase('false', false);
+        self::assertTestCase('123', 123);
+        self::assertTestCase('123.456', 123.456);
+        self::assertTestCase('abc123', 'abc123');
     }
 
     /**
      * @param mixed[]|null $variables
      */
-    private function assertTestCase($valueText, $expected, ?array $variables = null) : void
+    private static function assertTestCase($valueText, $expected, ?array $variables = null) : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             AST::valueFromASTUntyped(Parser::parseValue($valueText), $variables)
         );
@@ -40,10 +40,10 @@ class AstFromValueUntypedTest extends TestCase
      */
     public function testParsesListsOfValues() : void
     {
-        $this->assertTestCase('[true, false]', [true, false]);
-        $this->assertTestCase('[true, 123.45]', [true, 123.45]);
-        $this->assertTestCase('[true, null]', [true, null]);
-        $this->assertTestCase('[true, ["foo", 1.2]]', [true, ['foo', 1.2]]);
+        self::assertTestCase('[true, false]', [true, false]);
+        self::assertTestCase('[true, 123.45]', [true, 123.45]);
+        self::assertTestCase('[true, null]', [true, null]);
+        self::assertTestCase('[true, ["foo", 1.2]]', [true, ['foo', 1.2]]);
     }
 
     /**
@@ -51,12 +51,12 @@ class AstFromValueUntypedTest extends TestCase
      */
     public function testParsesInputObjects() : void
     {
-        $this->assertTestCase(
+        self::assertTestCase(
             '{ int: 123, bool: false }',
             ['int' => 123, 'bool' => false]
         );
 
-        $this->assertTestCase(
+        self::assertTestCase(
             '{ foo: [ { bar: "baz"} ] }',
             ['foo' => [['bar' => 'baz']]]
         );
@@ -67,12 +67,12 @@ class AstFromValueUntypedTest extends TestCase
      */
     public function testParsesEnumValuesAsPlainStrings() : void
     {
-        $this->assertTestCase(
+        self::assertTestCase(
             'TEST_ENUM_VALUE',
             'TEST_ENUM_VALUE'
         );
 
-        $this->assertTestCase(
+        self::assertTestCase(
             '[TEST_ENUM_VALUE]',
             ['TEST_ENUM_VALUE']
         );
@@ -83,32 +83,32 @@ class AstFromValueUntypedTest extends TestCase
      */
     public function testParsesVariables() : void
     {
-        $this->assertTestCase(
+        self::assertTestCase(
             '$testVariable',
             'foo',
             ['testVariable' => 'foo']
         );
-        $this->assertTestCase(
+        self::assertTestCase(
             '[$testVariable]',
             ['foo'],
             ['testVariable' => 'foo']
         );
-        $this->assertTestCase(
+        self::assertTestCase(
             '{a:[$testVariable]}',
             ['a' => ['foo']],
             ['testVariable' => 'foo']
         );
-        $this->assertTestCase(
+        self::assertTestCase(
             '$testVariable',
             null,
             ['testVariable' => null]
         );
-        $this->assertTestCase(
+        self::assertTestCase(
             '$testVariable',
             null,
             []
         );
-        $this->assertTestCase(
+        self::assertTestCase(
             '$testVariable',
             null,
             null

--- a/tests/Utils/BreakingChangesFinderTest.php
+++ b/tests/Utils/BreakingChangesFinderTest.php
@@ -70,12 +70,12 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findRemovedTypes($oldSchema, $newSchema)
         );
 
-        $this->assertEquals([], BreakingChangesFinder::findRemovedTypes($oldSchema, $oldSchema));
+        self::assertEquals([], BreakingChangesFinder::findRemovedTypes($oldSchema, $oldSchema));
     }
 
     /**
@@ -119,7 +119,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findTypesThatChangedKind($oldSchema, $newSchema)
         );
@@ -268,7 +268,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedFieldChanges,
             BreakingChangesFinder::findFieldsThatChangedTypeOnObjectOrInterfaceTypes($oldSchema, $newSchema)
         );
@@ -435,7 +435,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedFieldChanges,
             BreakingChangesFinder::findFieldsThatChangedTypeOnInputObjectTypes(
                 $oldSchema,
@@ -482,7 +482,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findFieldsThatChangedTypeOnInputObjectTypes(
                 $oldSchema,
@@ -548,7 +548,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findTypesRemovedFromUnions($oldSchema, $newSchema)
         );
@@ -593,7 +593,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findValuesRemovedFromEnums($oldSchema, $newSchema)
         );
@@ -678,7 +678,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedChanges,
             BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']
         );
@@ -802,7 +802,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedChanges,
             BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']
         );
@@ -853,7 +853,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']
         );
@@ -913,7 +913,7 @@ class BreakingChangesFinderTest extends TestCase
             'types' => [$newType],
         ]);
 
-        $this->assertEquals([], BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']);
+        self::assertEquals([], BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']);
     }
 
     /**
@@ -953,7 +953,7 @@ class BreakingChangesFinderTest extends TestCase
             'types' => [$newType],
         ]);
 
-        $this->assertEquals([], BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']);
+        self::assertEquals([], BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']);
     }
 
     /**
@@ -997,7 +997,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findInterfacesRemovedFromObjectTypes($oldSchema, $newSchema)
         );
@@ -1264,7 +1264,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findBreakingChanges($oldSchema, $newSchema)
         );
@@ -1292,7 +1292,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findRemovedDirectives($oldSchema, $newSchema)
         );
@@ -1318,7 +1318,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findRemovedDirectives($oldSchema, $newSchema)
         );
@@ -1357,7 +1357,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findRemovedDirectiveArgs($oldSchema, $newSchema)
         );
@@ -1399,7 +1399,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findAddedNonNullDirectiveArgs($oldSchema, $newSchema)
         );
@@ -1420,7 +1420,7 @@ class BreakingChangesFinderTest extends TestCase
             'locations' => [DirectiveLocation::FIELD_DEFINITION],
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             [DirectiveLocation::QUERY],
             BreakingChangesFinder::findRemovedLocationsForDirective($d1, $d2)
         );
@@ -1459,7 +1459,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedBreakingChanges,
             BreakingChangesFinder::findRemovedDirectiveLocations($oldSchema, $newSchema)
         );
@@ -1520,7 +1520,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['dangerousChanges']
         );
@@ -1564,7 +1564,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findValuesAddedToEnums($oldSchema, $newSchema)
         );
@@ -1613,7 +1613,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findInterfacesAddedToObjectTypes($oldSchema, $newSchema)
         );
@@ -1671,7 +1671,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             BreakingChangesFinder::findTypesAddedToUnions($oldSchema, $newSchema)
         );
@@ -1719,7 +1719,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedFieldChanges,
             BreakingChangesFinder::findFieldsThatChangedTypeOnInputObjectTypes(
                 $oldSchema,
@@ -1861,7 +1861,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedDangerousChanges,
             BreakingChangesFinder::findDangerousChanges($oldSchema, $newSchema)
         );
@@ -1920,7 +1920,7 @@ class BreakingChangesFinderTest extends TestCase
             ],
         ];
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedFieldChanges,
             BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['dangerousChanges']
         );

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -36,7 +36,7 @@ class BuildSchemaTest extends TestCase
         '));
 
         $result = GraphQL::executeQuery($schema, '{ str }', ['str' => 123]);
-        $this->assertEquals(['str' => 123], $result->toArray(true)['data']);
+        self::assertEquals(['str' => 123], $result->toArray(true)['data']);
     }
 
     /**
@@ -61,7 +61,7 @@ class BuildSchemaTest extends TestCase
             '{ add(x: 34, y: 55) }',
             $root
         );
-        $this->assertEquals(['data' => ['add' => 89]], $result->toArray(true));
+        self::assertEquals(['data' => ['add' => 89]], $result->toArray(true));
     }
 
     /**
@@ -79,7 +79,7 @@ type HelloScalars {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     private function cycleOutput($body, $options = [])
@@ -103,7 +103,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -135,7 +135,7 @@ type Query {
 ';
 
         $output = $this->cycleOutput($body);
-        $this->assertEquals($body, $output);
+        self::assertEquals($body, $output);
     }
 
     /**
@@ -166,7 +166,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body, ['commentDescriptions' => true]);
-        $this->assertEquals($body, $output);
+        self::assertEquals($body, $output);
     }
 
     /**
@@ -180,10 +180,10 @@ type Query {
 }
 ';
         $schema = BuildSchema::buildAST(Parser::parse($body));
-        $this->assertEquals(count($schema->getDirectives()), 3);
-        $this->assertEquals($schema->getDirective('skip'), Directive::skipDirective());
-        $this->assertEquals($schema->getDirective('include'), Directive::includeDirective());
-        $this->assertEquals($schema->getDirective('deprecated'), Directive::deprecatedDirective());
+        self::assertEquals(count($schema->getDirectives()), 3);
+        self::assertEquals($schema->getDirective('skip'), Directive::skipDirective());
+        self::assertEquals($schema->getDirective('include'), Directive::includeDirective());
+        self::assertEquals($schema->getDirective('deprecated'), Directive::deprecatedDirective());
     }
 
     /**
@@ -201,10 +201,10 @@ type Query {
 }
     ';
         $schema = BuildSchema::buildAST(Parser::parse($body));
-        $this->assertEquals(count($schema->getDirectives()), 3);
-        $this->assertNotEquals($schema->getDirective('skip'), Directive::skipDirective());
-        $this->assertNotEquals($schema->getDirective('include'), Directive::includeDirective());
-        $this->assertNotEquals($schema->getDirective('deprecated'), Directive::deprecatedDirective());
+        self::assertEquals(count($schema->getDirectives()), 3);
+        self::assertNotEquals($schema->getDirective('skip'), Directive::skipDirective());
+        self::assertNotEquals($schema->getDirective('include'), Directive::includeDirective());
+        self::assertNotEquals($schema->getDirective('deprecated'), Directive::deprecatedDirective());
     }
 
     /**
@@ -220,10 +220,10 @@ type Query {
       }
     ';
         $schema = BuildSchema::buildAST(Parser::parse($body));
-        $this->assertCount(4, $schema->getDirectives());
-        $this->assertNotEquals(null, $schema->getDirective('skip'));
-        $this->assertNotEquals(null, $schema->getDirective('include'));
-        $this->assertNotEquals(null, $schema->getDirective('deprecated'));
+        self::assertCount(4, $schema->getDirectives());
+        self::assertNotEquals(null, $schema->getDirective('skip'));
+        self::assertNotEquals(null, $schema->getDirective('include'));
+        self::assertNotEquals(null, $schema->getDirective('deprecated'));
     }
 
     /**
@@ -241,7 +241,7 @@ type HelloScalars {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -256,7 +256,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -280,7 +280,7 @@ type TypeTwo {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -298,7 +298,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -312,7 +312,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -330,7 +330,7 @@ interface WorldInterface {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -348,7 +348,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -366,7 +366,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($body, $output);
+        self::assertEquals($body, $output);
     }
 
     /**
@@ -385,7 +385,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -405,7 +405,7 @@ type World {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -429,7 +429,7 @@ type WorldTwo {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -486,7 +486,7 @@ type WorldTwo {
         ];
 
         $result = GraphQL::executeQuery($schema, $query, $root);
-        $this->assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expected, $result->toArray(true));
     }
 
     /**
@@ -550,7 +550,7 @@ type WorldTwo {
         ];
 
         $result = GraphQL::executeQuery($schema, $query, $root);
-        $this->assertEquals($expected, $result->toArray(true));
+        self::assertEquals($expected, $result->toArray(true));
     }
 
     /**
@@ -566,7 +566,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -584,7 +584,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -598,7 +598,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -614,7 +614,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -639,7 +639,7 @@ type Mutation {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -664,7 +664,7 @@ type Subscription {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -686,7 +686,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -706,7 +706,7 @@ type Query {
 union Union = Concrete
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
     }
 
     /**
@@ -728,7 +728,7 @@ type Query {
 }
 ';
         $output = $this->cycleOutput($body);
-        $this->assertEquals($output, $body);
+        self::assertEquals($output, $body);
 
         $ast    = Parser::parse($body);
         $schema = BuildSchema::buildAST($ast);
@@ -737,22 +737,22 @@ type Query {
         $myEnum = $schema->getType('MyEnum');
 
         $value = $myEnum->getValue('VALUE');
-        $this->assertFalse($value->isDeprecated());
+        self::assertFalse($value->isDeprecated());
 
         $oldValue = $myEnum->getValue('OLD_VALUE');
-        $this->assertTrue($oldValue->isDeprecated());
-        $this->assertEquals('No longer supported', $oldValue->deprecationReason);
+        self::assertTrue($oldValue->isDeprecated());
+        self::assertEquals('No longer supported', $oldValue->deprecationReason);
 
         $otherValue = $myEnum->getValue('OTHER_VALUE');
-        $this->assertTrue($otherValue->isDeprecated());
-        $this->assertEquals('Terrible reasons', $otherValue->deprecationReason);
+        self::assertTrue($otherValue->isDeprecated());
+        self::assertEquals('Terrible reasons', $otherValue->deprecationReason);
 
         $rootFields = $schema->getType('Query')->getFields();
-        $this->assertEquals($rootFields['field1']->isDeprecated(), true);
-        $this->assertEquals($rootFields['field1']->deprecationReason, 'No longer supported');
+        self::assertEquals($rootFields['field1']->isDeprecated(), true);
+        self::assertEquals($rootFields['field1']->deprecationReason, 'No longer supported');
 
-        $this->assertEquals($rootFields['field2']->isDeprecated(), true);
-        $this->assertEquals($rootFields['field2']->deprecationReason, 'Because I said so');
+        self::assertEquals($rootFields['field2']->isDeprecated(), true);
+        self::assertEquals($rootFields['field2']->deprecationReason, 'Because I said so');
     }
 
     /**
@@ -814,22 +814,22 @@ type Query {
             Printer::doPrint($testDirective->astNode)
         ));
 
-        $this->assertEquals($restoredIDL, SchemaPrinter::doPrint($schema));
+        self::assertEquals($restoredIDL, SchemaPrinter::doPrint($schema));
 
         $testField = $query->getField('testField');
-        $this->assertEquals('testField(testArg: TestInput): TestUnion', Printer::doPrint($testField->astNode));
-        $this->assertEquals('testArg: TestInput', Printer::doPrint($testField->args[0]->astNode));
-        $this->assertEquals(
+        self::assertEquals('testField(testArg: TestInput): TestUnion', Printer::doPrint($testField->astNode));
+        self::assertEquals('testArg: TestInput', Printer::doPrint($testField->args[0]->astNode));
+        self::assertEquals(
             'testInputField: TestEnum',
             Printer::doPrint($testInput->getField('testInputField')->astNode)
         );
-        $this->assertEquals('TEST_VALUE', Printer::doPrint($testEnum->getValue('TEST_VALUE')->astNode));
-        $this->assertEquals(
+        self::assertEquals('TEST_VALUE', Printer::doPrint($testEnum->getValue('TEST_VALUE')->astNode));
+        self::assertEquals(
             'interfaceField: String',
             Printer::doPrint($testInterface->getField('interfaceField')->astNode)
         );
-        $this->assertEquals('interfaceField: String', Printer::doPrint($testType->getField('interfaceField')->astNode));
-        $this->assertEquals('arg: TestScalar', Printer::doPrint($testDirective->args[0]->astNode));
+        self::assertEquals('interfaceField: String', Printer::doPrint($testType->getField('interfaceField')->astNode));
+        self::assertEquals('arg: TestScalar', Printer::doPrint($testDirective->args[0]->astNode));
     }
 
     /**
@@ -848,9 +848,9 @@ type Query {
           type SomeSubscription { str: String }
         ');
 
-        $this->assertEquals('SomeQuery', $schema->getQueryType()->name);
-        $this->assertEquals('SomeMutation', $schema->getMutationType()->name);
-        $this->assertEquals('SomeSubscription', $schema->getSubscriptionType()->name);
+        self::assertEquals('SomeQuery', $schema->getQueryType()->name);
+        self::assertEquals('SomeMutation', $schema->getMutationType()->name);
+        self::assertEquals('SomeSubscription', $schema->getSubscriptionType()->name);
     }
 
     /**
@@ -863,9 +863,9 @@ type Query {
           type Mutation { str: String }
           type Subscription { str: String }
         ');
-        $this->assertEquals('Query', $schema->getQueryType()->name);
-        $this->assertEquals('Mutation', $schema->getMutationType()->name);
-        $this->assertEquals('Subscription', $schema->getSubscriptionType()->name);
+        self::assertEquals('Query', $schema->getQueryType()->name);
+        self::assertEquals('Mutation', $schema->getMutationType()->name);
+        self::assertEquals('Subscription', $schema->getSubscriptionType()->name);
     }
 
     /**
@@ -880,7 +880,7 @@ type Query {
           }
         ');
         $errors = $schema->validate();
-        $this->assertGreaterThan(0, $errors);
+        self::assertGreaterThan(0, $errors);
     }
 
     // Describe: Failures
@@ -1205,26 +1205,26 @@ interface Hello {
 
         $schema = BuildSchema::buildAST($doc, $typeConfigDecorator);
         $schema->getTypeMap();
-        $this->assertEquals(['Query', 'Color', 'Hello'], $decorated);
+        self::assertEquals(['Query', 'Color', 'Hello'], $decorated);
 
         list($defaultConfig, $node, $allNodesMap) = $calls[0];
-        $this->assertInstanceOf(ObjectTypeDefinitionNode::class, $node);
-        $this->assertEquals('Query', $defaultConfig['name']);
-        $this->assertInstanceOf(\Closure::class, $defaultConfig['fields']);
-        $this->assertInstanceOf(\Closure::class, $defaultConfig['interfaces']);
-        $this->assertArrayHasKey('description', $defaultConfig);
-        $this->assertCount(5, $defaultConfig);
-        $this->assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
-        $this->assertEquals('My description of Query', $schema->getType('Query')->description);
+        self::assertInstanceOf(ObjectTypeDefinitionNode::class, $node);
+        self::assertEquals('Query', $defaultConfig['name']);
+        self::assertInstanceOf(\Closure::class, $defaultConfig['fields']);
+        self::assertInstanceOf(\Closure::class, $defaultConfig['interfaces']);
+        self::assertArrayHasKey('description', $defaultConfig);
+        self::assertCount(5, $defaultConfig);
+        self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
+        self::assertEquals('My description of Query', $schema->getType('Query')->description);
 
         list($defaultConfig, $node, $allNodesMap) = $calls[1];
-        $this->assertInstanceOf(EnumTypeDefinitionNode::class, $node);
-        $this->assertEquals('Color', $defaultConfig['name']);
+        self::assertInstanceOf(EnumTypeDefinitionNode::class, $node);
+        self::assertEquals('Color', $defaultConfig['name']);
         $enumValue = [
             'description'       => '',
             'deprecationReason' => '',
         ];
-        $this->assertArraySubset(
+        self::assertArraySubset(
             [
                 'RED'   => $enumValue,
                 'GREEN' => $enumValue,
@@ -1232,18 +1232,18 @@ interface Hello {
             ],
             $defaultConfig['values']
         );
-        $this->assertCount(4, $defaultConfig); // 3 + astNode
-        $this->assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
-        $this->assertEquals('My description of Color', $schema->getType('Color')->description);
+        self::assertCount(4, $defaultConfig); // 3 + astNode
+        self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
+        self::assertEquals('My description of Color', $schema->getType('Color')->description);
 
         list($defaultConfig, $node, $allNodesMap) = $calls[2];
-        $this->assertInstanceOf(InterfaceTypeDefinitionNode::class, $node);
-        $this->assertEquals('Hello', $defaultConfig['name']);
-        $this->assertInstanceOf(\Closure::class, $defaultConfig['fields']);
-        $this->assertArrayHasKey('description', $defaultConfig);
-        $this->assertCount(4, $defaultConfig);
-        $this->assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
-        $this->assertEquals('My description of Hello', $schema->getType('Hello')->description);
+        self::assertInstanceOf(InterfaceTypeDefinitionNode::class, $node);
+        self::assertEquals('Hello', $defaultConfig['name']);
+        self::assertInstanceOf(\Closure::class, $defaultConfig['fields']);
+        self::assertArrayHasKey('description', $defaultConfig);
+        self::assertCount(4, $defaultConfig);
+        self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
+        self::assertEquals('My description of Hello', $schema->getType('Hello')->description);
     }
 
     public function testCreatesTypesLazily() : void
@@ -1283,19 +1283,19 @@ type World implements Hello {
         };
 
         $schema = BuildSchema::buildAST($doc, $typeConfigDecorator);
-        $this->assertEquals(['Query'], $created);
+        self::assertEquals(['Query'], $created);
 
         $schema->getType('Color');
-        $this->assertEquals(['Query', 'Color'], $created);
+        self::assertEquals(['Query', 'Color'], $created);
 
         $schema->getType('Hello');
-        $this->assertEquals(['Query', 'Color', 'Hello'], $created);
+        self::assertEquals(['Query', 'Color', 'Hello'], $created);
 
         $types = $schema->getTypeMap();
-        $this->assertEquals(['Query', 'Color', 'Hello', 'World'], $created);
-        $this->assertArrayHasKey('Query', $types);
-        $this->assertArrayHasKey('Color', $types);
-        $this->assertArrayHasKey('Hello', $types);
-        $this->assertArrayHasKey('World', $types);
+        self::assertEquals(['Query', 'Color', 'Hello', 'World'], $created);
+        self::assertArrayHasKey('Query', $types);
+        self::assertArrayHasKey('Color', $types);
+        self::assertArrayHasKey('Hello', $types);
+        self::assertArrayHasKey('World', $types);
     }
 }

--- a/tests/Utils/CoerceValueTest.php
+++ b/tests/Utils/CoerceValueTest.php
@@ -51,7 +51,7 @@ class CoerceValueTest extends TestCase
             'Expected type String; String cannot represent an array value: [1,2,3]'
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'String cannot represent an array value: [1,2,3]',
             $result['errors'][0]->getPrevious()->getMessage()
         );
@@ -62,11 +62,11 @@ class CoerceValueTest extends TestCase
      */
     private function expectError($result, $expected)
     {
-        $this->assertInternalType('array', $result);
-        $this->assertInternalType('array', $result['errors']);
-        $this->assertCount(1, $result['errors']);
-        $this->assertEquals($expected, $result['errors'][0]->getMessage());
-        $this->assertEquals(Utils::undefined(), $result['value']);
+        self::assertInternalType('array', $result);
+        self::assertInternalType('array', $result['errors']);
+        self::assertCount(1, $result['errors']);
+        self::assertEquals($expected, $result['errors'][0]->getMessage());
+        self::assertEquals(Utils::undefined(), $result['value']);
     }
 
     /**
@@ -80,9 +80,9 @@ class CoerceValueTest extends TestCase
 
     private function expectNoErrors($result)
     {
-        $this->assertInternalType('array', $result);
-        $this->assertNull($result['errors']);
-        $this->assertNotEquals(Utils::undefined(), $result['value']);
+        self::assertInternalType('array', $result);
+        self::assertNull($result['errors']);
+        self::assertNotEquals(Utils::undefined(), $result['value']);
     }
 
     /**
@@ -243,11 +243,11 @@ class CoerceValueTest extends TestCase
     {
         $fooResult = Value::coerceValue('FOO', $this->testEnum);
         $this->expectNoErrors($fooResult);
-        $this->assertEquals('InternalFoo', $fooResult['value']);
+        self::assertEquals('InternalFoo', $fooResult['value']);
 
         $barResult = Value::coerceValue('BAR', $this->testEnum);
         $this->expectNoErrors($barResult);
-        $this->assertEquals(123456789, $barResult['value']);
+        self::assertEquals(123456789, $barResult['value']);
     }
 
     // DESCRIBE: for GraphQLInputObject
@@ -280,7 +280,7 @@ class CoerceValueTest extends TestCase
     {
         $result = Value::coerceValue(['foo' => 123], $this->testInputObject);
         $this->expectNoErrors($result);
-        $this->assertEquals(['foo' => 123], $result['value']);
+        self::assertEquals(['foo' => 123], $result['value']);
     }
 
     /**
@@ -310,7 +310,7 @@ class CoerceValueTest extends TestCase
     public function testReturnsMultipleErrorsForMultipleInvalidFields() : void
     {
         $result = Value::coerceValue(['foo' => 'abc', 'bar' => 'def'], $this->testInputObject);
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'Expected type Int at value.foo; Int cannot represent non 32-bit signed integer value: abc',
                 'Expected type Int at value.bar; Int cannot represent non 32-bit signed integer value: def',

--- a/tests/Utils/ExtractTypesTest.php
+++ b/tests/Utils/ExtractTypesTest.php
@@ -264,7 +264,7 @@ class ExtractTypesTest extends TestCase
         ];
 
         $actualTypeMap = TypeInfo::extractTypes($this->query);
-        $this->assertEquals($expectedTypeMap, $actualTypeMap);
+        self::assertEquals($expectedTypeMap, $actualTypeMap);
     }
 
     public function testExtractTypesFromMutation() : void
@@ -286,7 +286,7 @@ class ExtractTypesTest extends TestCase
         ];
 
         $actualTypeMap = TypeInfo::extractTypes($this->mutation);
-        $this->assertEquals($expectedTypeMap, $actualTypeMap);
+        self::assertEquals($expectedTypeMap, $actualTypeMap);
     }
 
     public function testThrowsOnMultipleTypesWithSameName() : void

--- a/tests/Utils/IsValidLiteralValueTest.php
+++ b/tests/Utils/IsValidLiteralValueTest.php
@@ -18,7 +18,7 @@ class IsValidLiteralValueTest extends TestCase
      */
     public function testReturnsNoErrorsForAValidValue() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [],
             DocumentValidator::isValidLiteralValue(Type::int(), Parser::parseValue('123'))
         );
@@ -31,9 +31,9 @@ class IsValidLiteralValueTest extends TestCase
     {
         $errors = DocumentValidator::isValidLiteralValue(Type::int(), Parser::parseValue('"abc"'));
 
-        $this->assertCount(1, $errors);
-        $this->assertEquals('Expected type Int, found "abc".', $errors[0]->getMessage());
-        $this->assertEquals([new SourceLocation(1, 1)], $errors[0]->getLocations());
-        $this->assertEquals(null, $errors[0]->getPath());
+        self::assertCount(1, $errors);
+        self::assertEquals('Expected type Int, found "abc".', $errors[0]->getMessage());
+        self::assertEquals([new SourceLocation(1, 1)], $errors[0]->getLocations());
+        self::assertEquals(null, $errors[0]->getPath());
     }
 }

--- a/tests/Utils/MixedStoreTest.php
+++ b/tests/Utils/MixedStoreTest.php
@@ -48,12 +48,12 @@ class MixedStoreTest extends TestCase
         $err = 'Failed assertion that MixedStore accepts key ' .
             Utils::printSafe($key) . ' with value ' . Utils::printSafe($value);
 
-        $this->assertFalse($this->mixedStore->offsetExists($key), $err);
+        self::assertFalse($this->mixedStore->offsetExists($key), $err);
         $this->mixedStore->offsetSet($key, $value);
-        $this->assertTrue($this->mixedStore->offsetExists($key), $err);
-        $this->assertSame($value, $this->mixedStore->offsetGet($key), $err);
+        self::assertTrue($this->mixedStore->offsetExists($key), $err);
+        self::assertSame($value, $this->mixedStore->offsetGet($key), $err);
         $this->mixedStore->offsetUnset($key);
-        $this->assertFalse($this->mixedStore->offsetExists($key), $err);
+        self::assertFalse($this->mixedStore->offsetExists($key), $err);
         $this->assertProvidesArrayAccess($key, $value);
     }
 
@@ -62,13 +62,13 @@ class MixedStoreTest extends TestCase
         $err = 'Failed assertion that MixedStore provides array access for key ' .
             Utils::printSafe($key) . ' with value ' . Utils::printSafe($value);
 
-        $this->assertFalse(isset($this->mixedStore[$key]), $err);
+        self::assertFalse(isset($this->mixedStore[$key]), $err);
         $this->mixedStore[$key] = $value;
-        $this->assertTrue(isset($this->mixedStore[$key]), $err);
-        $this->assertEquals(! empty($value), ! empty($this->mixedStore[$key]), $err);
-        $this->assertSame($value, $this->mixedStore[$key], $err);
+        self::assertTrue(isset($this->mixedStore[$key]), $err);
+        self::assertEquals(! empty($value), ! empty($this->mixedStore[$key]), $err);
+        self::assertSame($value, $this->mixedStore[$key], $err);
         unset($this->mixedStore[$key]);
-        $this->assertFalse(isset($this->mixedStore[$key]), $err);
+        self::assertFalse(isset($this->mixedStore[$key]), $err);
     }
 
     public function testAcceptsBoolKeys() : void

--- a/tests/Utils/QuotedOrListTest.php
+++ b/tests/Utils/QuotedOrListTest.php
@@ -24,7 +24,7 @@ class QuotedOrListTest extends TestCase
      */
     public function testReturnsSingleQuotedItem() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             '"A"',
             Utils::quotedOrList(['A'])
         );
@@ -35,7 +35,7 @@ class QuotedOrListTest extends TestCase
      */
     public function testReturnsTwoItemList() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             '"A" or "B"',
             Utils::quotedOrList(['A', 'B'])
         );
@@ -46,7 +46,7 @@ class QuotedOrListTest extends TestCase
      */
     public function testReturnsCommaSeparatedManyItemList() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             '"A", "B", or "C"',
             Utils::quotedOrList(['A', 'B', 'C'])
         );
@@ -57,7 +57,7 @@ class QuotedOrListTest extends TestCase
      */
     public function testLimitsToFiveItems() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             '"A", "B", "C", "D", or "E"',
             Utils::quotedOrList(['A', 'B', 'C', 'D', 'E', 'F'])
         );

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -30,7 +30,7 @@ class SchemaPrinterTest extends TestCase
         $output = $this->printSingleFieldSchema([
             'type' => Type::string(),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: String
@@ -53,7 +53,7 @@ type Query {
     private function printForTest($schema)
     {
         $schemaText = SchemaPrinter::doPrint($schema);
-        $this->assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
+        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
 
         return "\n" . $schemaText;
     }
@@ -66,7 +66,7 @@ type Query {
         $output = $this->printSingleFieldSchema([
             'type' => Type::listOf(Type::string()),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: [String]
@@ -84,7 +84,7 @@ type Query {
         $output = $this->printSingleFieldSchema([
             'type' => Type::nonNull(Type::string()),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: String!
@@ -102,7 +102,7 @@ type Query {
         $output = $this->printSingleFieldSchema([
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: [String]!
@@ -120,7 +120,7 @@ type Query {
         $output = $this->printSingleFieldSchema([
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: [String!]
@@ -138,7 +138,7 @@ type Query {
         $output = $this->printSingleFieldSchema([
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField: [String!]!
@@ -165,7 +165,7 @@ type Query {
 
         $schema = new Schema(['query' => $root]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Foo {
   str: String
@@ -188,7 +188,7 @@ type Query {
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int): String
@@ -207,7 +207,7 @@ type Query {
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int = 2): String
@@ -226,7 +226,7 @@ type Query {
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: String = "tes\t de\fault"): String
@@ -245,7 +245,7 @@ type Query {
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int = null): String
@@ -264,7 +264,7 @@ type Query {
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int!): String
@@ -286,7 +286,7 @@ type Query {
                 'argTwo' => ['type' => Type::string()],
             ],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int, argTwo: String): String
@@ -309,7 +309,7 @@ type Query {
                 'argThree' => ['type' => Type::boolean()],
             ],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
@@ -332,7 +332,7 @@ type Query {
                 'argThree' => ['type' => Type::boolean()],
             ],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
@@ -355,7 +355,7 @@ type Query {
                 'argThree' => ['type' => Type::boolean(), 'defaultValue' => false],
             ],
         ]);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
@@ -386,7 +386,7 @@ type CustomQueryType {
   bar: String
 }
 ';
-        $this->assertEquals($expected, $output);
+        self::assertEquals($expected, $output);
     }
 
     /**
@@ -415,7 +415,7 @@ type CustomQueryType {
             'types' => [$barType],
         ]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Bar implements Foo {
   str: String
@@ -467,7 +467,7 @@ type Query {
             'types' => [$barType],
         ]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 interface Baaz {
   int: Int
@@ -525,7 +525,7 @@ type Query {
 
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Bar {
   str: String
@@ -570,7 +570,7 @@ union SingleUnion = Foo
 
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 input InputType {
   int: Int
@@ -605,7 +605,7 @@ type Query {
 
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 scalar Odd
 
@@ -640,7 +640,7 @@ type Query {
 
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   rgb: RGB
@@ -681,7 +681,7 @@ enum RGB {
         ]);
 
         $output = $this->printForTest($schema);
-        $this->assertEquals(
+        self::assertEquals(
             '
 directive @customDirective on FIELD
 
@@ -704,7 +704,7 @@ type Query {
             'description' => $description,
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   """This field is awesome"""
@@ -716,7 +716,7 @@ type Query {
 
         $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
         $recreatedField = $recreatedRoot->getFields()['singleField'];
-        $this->assertEquals($description, $recreatedField->description);
+        self::assertEquals($description, $recreatedField->description);
     }
 
     /**
@@ -730,7 +730,7 @@ type Query {
             'description' => $description,
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   """
@@ -744,7 +744,7 @@ type Query {
 
         $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
         $recreatedField = $recreatedRoot->getFields()['singleField'];
-        $this->assertEquals($description, $recreatedField->description);
+        self::assertEquals($description, $recreatedField->description);
     }
 
     /**
@@ -758,7 +758,7 @@ type Query {
             'description' => $description,
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             '
 type Query {
   """    This field is "awesome"
@@ -771,7 +771,7 @@ type Query {
 
         $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
         $recreatedField = $recreatedRoot->getFields()['singleField'];
-        $this->assertEquals($description, $recreatedField->description);
+        self::assertEquals($description, $recreatedField->description);
     }
 
     /**
@@ -1016,7 +1016,7 @@ enum __TypeKind {
 }
 
 EOT;
-        $this->assertEquals($introspectionSchema, $output);
+        self::assertEquals($introspectionSchema, $output);
     }
 
     /**
@@ -1232,6 +1232,6 @@ enum __TypeKind {
 }
 
 EOT;
-        $this->assertEquals($introspectionSchema, $output);
+        self::assertEquals($introspectionSchema, $output);
     }
 }

--- a/tests/Utils/SuggestionListTest.php
+++ b/tests/Utils/SuggestionListTest.php
@@ -15,7 +15,7 @@ class SuggestionListTest extends TestCase
      */
     public function testResturnsResultsWhenInputIsEmpty() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             Utils::suggestionList('', ['a']),
             ['a']
         );
@@ -26,7 +26,7 @@ class SuggestionListTest extends TestCase
      */
     public function testReturnsEmptyArrayWhenThereAreNoOptions() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             Utils::suggestionList('input', []),
             []
         );
@@ -37,7 +37,7 @@ class SuggestionListTest extends TestCase
      */
     public function testReturnsOptionsSortedBasedOnSimilarity() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             Utils::suggestionList('abc', ['a', 'ab', 'abc']),
             ['abc', 'ab']
         );

--- a/tests/Utils/ValueFromAstTest.php
+++ b/tests/Utils/ValueFromAstTest.php
@@ -22,7 +22,7 @@ class ValueFromAstTest extends TestCase
      */
     public function testRejectsEmptyInput() : void
     {
-        $this->assertEquals(Utils::undefined(), AST::valueFromAST(null, Type::boolean()));
+        self::assertEquals(Utils::undefined(), AST::valueFromAST(null, Type::boolean()));
     }
 
     /**
@@ -42,7 +42,7 @@ class ValueFromAstTest extends TestCase
 
     private function runTestCase($type, $valueText, $expected)
     {
-        $this->assertEquals($expected, AST::valueFromAST(Parser::parseValue($valueText), $type));
+        self::assertEquals($expected, AST::valueFromAST(Parser::parseValue($valueText), $type));
     }
 
     /**
@@ -205,7 +205,7 @@ class ValueFromAstTest extends TestCase
 
     private function runTestCaseWithVars($variables, $type, $valueText, $expected)
     {
-        $this->assertEquals($expected, AST::valueFromAST(Parser::parseValue($valueText), $type, $variables));
+        self::assertEquals($expected, AST::valueFromAST(Parser::parseValue($valueText), $type, $variables));
     }
 
     /**

--- a/tests/Validator/FieldsOnCorrectTypeTest.php
+++ b/tests/Validator/FieldsOnCorrectTypeTest.php
@@ -336,7 +336,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
      */
     public function testWorksWithNoSuggestions() : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             'Cannot query field "f" on type "T".',
             FieldsOnCorrectType::undefinedFieldMessage('f', 'T', [], [])
         );
@@ -350,7 +350,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
         $expected = 'Cannot query field "f" on type "T". ' .
             'Did you mean to use an inline fragment on "A" or "B"?';
 
-        $this->assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', ['A', 'B'], []));
+        self::assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', ['A', 'B'], []));
     }
 
     /**
@@ -361,7 +361,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
         $expected = 'Cannot query field "f" on type "T". ' .
             'Did you mean "z" or "y"?';
 
-        $this->assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', [], ['z', 'y']));
+        self::assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', [], ['z', 'y']));
     }
 
     /**
@@ -372,7 +372,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
         $expected = 'Cannot query field "f" on type "T". ' .
             'Did you mean to use an inline fragment on "A" or "B"?';
 
-        $this->assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', ['A', 'B'], ['z', 'y']));
+        self::assertEquals($expected, FieldsOnCorrectType::undefinedFieldMessage('f', 'T', ['A', 'B'], ['z', 'y']));
     }
 
     /**
@@ -383,7 +383,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
         $expected = 'Cannot query field "f" on type "T". ' .
             'Did you mean to use an inline fragment on "A", "B", "C", "D", or "E"?';
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             FieldsOnCorrectType::undefinedFieldMessage(
                 'f',
@@ -402,7 +402,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
         $expected = 'Cannot query field "f" on type "T". ' .
             'Did you mean "z", "y", "x", "w", or "v"?';
 
-        $this->assertEquals(
+        self::assertEquals(
             $expected,
             FieldsOnCorrectType::undefinedFieldMessage(
                 'f',

--- a/tests/Validator/OverlappingFieldsCanBeMergedTest.php
+++ b/tests/Validator/OverlappingFieldsCanBeMergedTest.php
@@ -1276,7 +1276,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         $error = OverlappingFieldsCanBeMerged::fieldsConflictMessage('x', 'a and b are different fields');
         $hint  = 'Use different aliases on the fields to fetch both if this was intentional.';
 
-        $this->assertStringEndsWith($hint, $error);
+        self::assertStringEndsWith($hint, $error);
     }
 
     /**

--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -185,8 +185,8 @@ class QueryComplexityTest extends QuerySecurityTestCase
             [$otherRule, $this->getRule(1)]
         );
 
-        $this->assertEquals(1, count($errors));
-        $this->assertSame($reportedError, $errors[0]);
+        self::assertEquals(1, count($errors));
+        self::assertSame($reportedError, $errors[0]);
 
         $this->expectException(Error::class);
         DocumentValidator::validate(

--- a/tests/Validator/QuerySecurityTestCase.php
+++ b/tests/Validator/QuerySecurityTestCase.php
@@ -62,7 +62,7 @@ abstract class QuerySecurityTestCase extends TestCase
             [$this->getRule($max)]
         );
 
-        $this->assertEquals($expectedErrors, array_map([Error::class, 'formatError'], $errors), $queryString);
+        self::assertEquals($expectedErrors, array_map([Error::class, 'formatError'], $errors), $queryString);
 
         return $errors;
     }

--- a/tests/Validator/ValidatorTestCase.php
+++ b/tests/Validator/ValidatorTestCase.php
@@ -27,7 +27,7 @@ abstract class ValidatorTestCase extends TestCase
 
     protected function expectValid($schema, $rules, $queryString) : void
     {
-        $this->assertEquals(
+        self::assertEquals(
             [],
             DocumentValidator::validate($schema, Parser::parse($queryString), $rules),
             'Should validate'
@@ -433,8 +433,8 @@ abstract class ValidatorTestCase extends TestCase
     {
         $errors = DocumentValidator::validate($schema, Parser::parse($queryString), $rules);
 
-        $this->assertNotEmpty($errors, 'GraphQL should not validate');
-        $this->assertEquals($expectedErrors, array_map(['GraphQL\Error\Error', 'formatError'], $errors));
+        self::assertNotEmpty($errors, 'GraphQL should not validate');
+        self::assertEquals($expectedErrors, array_map(['GraphQL\Error\Error', 'formatError'], $errors));
 
         return $errors;
     }

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -1349,7 +1349,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
             ]
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'Invalid scalar is always invalid: 123',
             $errors[0]->getPrevious()->getMessage()
         );


### PR DESCRIPTION
Those methods are declared static so should be called that way. They do not contain any instance-specific behaviour, they're rather wrappers for throwing exceptions.