### PR TITLE
Fix annotation

### DIFF
--- a/src/Language/AST/BooleanValueNode.php
+++ b/src/Language/AST/BooleanValueNode.php
@@ -9,6 +9,6 @@ class BooleanValueNode extends Node implements ValueNode
     /** @var string */
     public $kind = NodeKind::BOOLEAN;
 
-    /** @var string */
+    /** @var bool */
     public $value;
 }


### PR DESCRIPTION
[Parser](https://github.com/webonyx/graphql-php/blob/v0.12.6/src/Language/Parser.php#L739) creates BooleanValueNode with boolean, not string.

BooleanType and Printer also both expect it to be boolean.