### PR TITLE
Updated default field resolver code in documentation.

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -118,7 +118,7 @@ function defaultFieldResolver($source, $args, $context, \GraphQL\Type\Definition
         }
     }
 
-    return $property instanceof \Closure ? $property($source, $args, $context) : $property;
+    return $property instanceof Closure ? $property($source, $args, $context, $info) : $property;
 }
 ```
 


### PR DESCRIPTION
Updated code to match definition in GraphQL\Executor\Executor::defaultFieldResolver. Change is notable because previous version did not indicate that the callable receives the $info variable.