### PR TITLE
Error handling improvements

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -182,12 +182,16 @@ class Error extends \Exception implements \JsonSerializable, ClientAware
         if ($previous instanceof ClientAware) {
             $this->isClientSafe = $previous->isClientSafe();
             $this->category = $previous->getCategory() ?: static::CATEGORY_INTERNAL;
-        } else if ($previous) {
-            $this->isClientSafe = false;
-            $this->category = static::CATEGORY_INTERNAL;
         } else {
             $this->isClientSafe = true;
-            $this->category = static::CATEGORY_GRAPHQL;
+			while ($previous) {
+				if (!preg_match('#/webonyx/graphql-php/#u', $previous->getFile())) {
+					$this->isClientSafe = false;
+					break;
+				}
+				$previous = $previous->getPrevious();
+			}
+            $this->category = $this->isClientSafe ? self::CATEGORY_GRAPHQL : self::CATEGORY_INTERNAL;
         }
     }
 


### PR DESCRIPTION
**graphql-php** shows incorrect error when we pass field argument with incorrect value type.

How to reproduce:

1. Create field in **QueryType** that takes non-null argument of **StringType**.
2. Query this field, but put a **ListOfType** argument (simply []) instead of **StringType**.

For this query **graphql-php** returns an exception with category "internal", so we get "Internal server error" string at the output (in "message" field). Based on this information, we can't detect, what field caused the error (in situations when we have many fields/arguments in query):
![image](https://user-images.githubusercontent.com/10958696/47381523-e8307480-d708-11e8-952f-4366e65268c8.png)


But let's query the field without the argument. Because it's non-null, we get exception with category "graphql" and very detailed "message" field, that contains field name, argument name and required type of value:
![image](https://user-images.githubusercontent.com/10958696/47382280-9b4d9d80-d70a-11e8-8f16-d1ed580597e5.png)

I think the situation with incorrect value type should cause similar detailed error, so in this pull request I did the next output:
![image](https://user-images.githubusercontent.com/10958696/47382377-d4860d80-d70a-11e8-9929-d6ab118444d5.png)
