### PR TITLE
Error handling improvements

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -182,12 +182,16 @@ class Error extends \Exception implements \JsonSerializable, ClientAware
         if ($previous instanceof ClientAware) {
             $this->isClientSafe = $previous->isClientSafe();
             $this->category = $previous->getCategory() ?: static::CATEGORY_INTERNAL;
-        } else if ($previous) {
-            $this->isClientSafe = false;
-            $this->category = static::CATEGORY_INTERNAL;
         } else {
             $this->isClientSafe = true;
-            $this->category = static::CATEGORY_GRAPHQL;
+            while ($previous) {
+                if (!preg_match('#/webonyx/graphql-php/#u', $previous->getFile())) {
+                    $this->isClientSafe = false;
+                    break;
+                }
+                $previous = $previous->getPrevious();
+            }
+            $this->category = $this->isClientSafe ? self::CATEGORY_GRAPHQL : self::CATEGORY_INTERNAL;
         }
     }
 

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -182,16 +182,12 @@ class Error extends \Exception implements \JsonSerializable, ClientAware
         if ($previous instanceof ClientAware) {
             $this->isClientSafe = $previous->isClientSafe();
             $this->category = $previous->getCategory() ?: static::CATEGORY_INTERNAL;
+        } else if ($previous) {
+            $this->isClientSafe = false;
+            $this->category = static::CATEGORY_INTERNAL;
         } else {
             $this->isClientSafe = true;
-            while ($previous) {
-                if (!preg_match('#/webonyx/graphql-php/#u', $previous->getFile())) {
-                    $this->isClientSafe = false;
-                    break;
-                }
-                $previous = $previous->getPrevious();
-            }
-            $this->category = $this->isClientSafe ? self::CATEGORY_GRAPHQL : self::CATEGORY_INTERNAL;
+            $this->category = static::CATEGORY_GRAPHQL;
         }
     }
 

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -20,6 +20,7 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\WrappingType;

--- a/tests/Type/EnumTypeTest.php
+++ b/tests/Type/EnumTypeTest.php
@@ -292,7 +292,7 @@ class EnumTypeTest extends \PHPUnit_Framework_TestCase
         $this->expectFailure(
             '{ colorEnum(fromInt: GREEN) }',
             null,
-            "Expected type Int, found GREEN."
+            "Field \"colorEnum\" argument \"fromInt\" requires type Int, found GREEN."
         );
     }
 

--- a/tests/Type/EnumTypeTest.php
+++ b/tests/Type/EnumTypeTest.php
@@ -220,7 +220,7 @@ class EnumTypeTest extends \PHPUnit_Framework_TestCase
             '{ colorEnum(fromEnum: "GREEN") }',
             null,
             [
-                'message' => "Expected type Color, found \"GREEN\"; Did you mean the enum value GREEN?",
+                'message' => "Field \"colorEnum\" argument \"fromEnum\" requires type Color, found \"GREEN\"; Did you mean the enum value GREEN?",
                 'locations' => [new SourceLocation(1, 23)]
             ]
         );
@@ -235,7 +235,7 @@ class EnumTypeTest extends \PHPUnit_Framework_TestCase
             '{ colorEnum(fromEnum: GREENISH) }',
             null,
             [
-                'message' => "Expected type Color, found GREENISH; Did you mean the enum value GREEN?",
+                'message' => "Field \"colorEnum\" argument \"fromEnum\" requires type Color, found GREENISH; Did you mean the enum value GREEN?",
                 'locations' => [new SourceLocation(1, 23)]
             ]
         );
@@ -250,7 +250,7 @@ class EnumTypeTest extends \PHPUnit_Framework_TestCase
             '{ colorEnum(fromEnum: green) }',
             null,
             [
-                'message' => "Expected type Color, found green; Did you mean the enum value GREEN?",
+                'message' => "Field \"colorEnum\" argument \"fromEnum\" requires type Color, found green; Did you mean the enum value GREEN?",
                 'locations' => [new SourceLocation(1, 23)]
             ]
         );
@@ -280,7 +280,7 @@ class EnumTypeTest extends \PHPUnit_Framework_TestCase
         $this->expectFailure(
             '{ colorEnum(fromEnum: 1) }',
             null,
-            "Expected type Color, found 1."
+            "Field \"colorEnum\" argument \"fromEnum\" requires type Color, found 1."
         );
     }
 

--- a/tests/Validator/ValidationTest.php
+++ b/tests/Validator/ValidationTest.php
@@ -36,7 +36,7 @@ class ValidationTest extends TestCase
         ';
 
         $expectedError = [
-            'message' => "Expected type Invalid, found \"bad value\"; Invalid scalar is always invalid: bad value",
+            'message' => "Field \"invalidArg\" argument \"arg\" requires type Invalid, found \"bad value\"; Invalid scalar is always invalid: bad value",
             'locations' => [ ['line' => 3, 'column' => 25] ]
         ];
 

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -19,9 +19,9 @@ class ValuesOfCorrectTypeTest extends TestCase
         );
     }
 
-    private function badValue2($error, $line, $column)
+    private function badValueWithMessage($message, $line, $column)
     {
-        return FormattedError::create($error, [new SourceLocation($line, $column)]);
+        return FormattedError::create($message, [new SourceLocation($line, $column)]);
     }
 
     private function requiredField($typeName, $fieldName, $fieldTypeName, $line, $column) {
@@ -236,7 +236,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.", 4, 39)
+            $this->badValueWithMessage("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.", 4, 39)
         ]);
     }
 
@@ -252,7 +252,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.0.", 4, 39)
+            $this->badValueWithMessage("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.0.", 4, 39)
         ]);
     }
 
@@ -268,7 +268,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found true.", 4, 39)
+            $this->badValueWithMessage("Field \"stringArgField\" argument \"stringArg\" requires type String, found true.", 4, 39)
         ]);
     }
 
@@ -284,7 +284,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found BAR.", 4, 39)
+            $this->badValueWithMessage("Field \"stringArgField\" argument \"stringArg\" requires type String, found BAR.", 4, 39)
         ]);
     }
 
@@ -302,7 +302,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found \"3\".", 4, 33)
+            $this->badValueWithMessage("Field \"intArgField\" argument \"intArg\" requires type Int, found \"3\".", 4, 33)
         ]);
     }
 
@@ -318,7 +318,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 829384293849283498239482938.", 4, 33)
+            $this->badValueWithMessage("Field \"intArgField\" argument \"intArg\" requires type Int, found 829384293849283498239482938.", 4, 33)
         ]);
     }
 
@@ -334,7 +334,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found FOO.", 4, 33)
+            $this->badValueWithMessage("Field \"intArgField\" argument \"intArg\" requires type Int, found FOO.", 4, 33)
         ]);
     }
 
@@ -350,7 +350,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.0.", 4, 33)
+            $this->badValueWithMessage("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.0.", 4, 33)
         ]);
     }
 
@@ -366,7 +366,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.333.", 4, 33)
+            $this->badValueWithMessage("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.333.", 4, 33)
         ]);
     }
 
@@ -384,7 +384,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found \"3.333\".", 4, 37)
+            $this->badValueWithMessage("Field \"floatArgField\" argument \"floatArg\" requires type Float, found \"3.333\".", 4, 37)
         ]);
     }
 
@@ -400,7 +400,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found true.", 4, 37)
+            $this->badValueWithMessage("Field \"floatArgField\" argument \"floatArg\" requires type Float, found true.", 4, 37)
         ]);
     }
 
@@ -416,7 +416,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found FOO.", 4, 37)
+            $this->badValueWithMessage("Field \"floatArgField\" argument \"floatArg\" requires type Float, found FOO.", 4, 37)
         ]);
     }
 
@@ -434,7 +434,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 2.", 4, 41)
+            $this->badValueWithMessage("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 2.", 4, 41)
         ]);
     }
 
@@ -450,7 +450,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 1.0.", 4, 41)
+            $this->badValueWithMessage("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 1.0.", 4, 41)
         ]);
     }
 
@@ -466,7 +466,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found \"true\".", 4, 41)
+            $this->badValueWithMessage("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found \"true\".", 4, 41)
         ]);
     }
 
@@ -482,7 +482,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found TRUE.", 4, 41)
+            $this->badValueWithMessage("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found TRUE.", 4, 41)
         ]);
     }
 
@@ -500,7 +500,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found 1.0.", 4, 31)
+            $this->badValueWithMessage("Field \"idArgField\" argument \"idArg\" requires type ID, found 1.0.", 4, 31)
         ]);
     }
 
@@ -516,7 +516,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found true.", 4, 31)
+            $this->badValueWithMessage("Field \"idArgField\" argument \"idArg\" requires type ID, found true.", 4, 31)
         ]);
     }
 
@@ -532,7 +532,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found SOMETHING.", 4, 31)
+            $this->badValueWithMessage("Field \"idArgField\" argument \"idArg\" requires type ID, found SOMETHING.", 4, 31)
         ]);
     }
 
@@ -550,7 +550,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('DogCommand', '2', 4, 41)
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found 2.", 4, 41)
         ]);
     }
 
@@ -566,7 +566,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('DogCommand', '1.0', 4, 41)
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found 1.0.", 4, 41)
         ]);
     }
 
@@ -582,13 +582,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue(
-                'DogCommand',
-                '"SIT"',
-                4,
-                41,
-                'Did you mean the enum value SIT?'
-            )
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found \"SIT\"; Did you mean the enum value SIT?", 4, 41)
         ]);
     }
 
@@ -604,7 +598,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('DogCommand', 'true', 4, 41)
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found true.", 4, 41)
         ]);
     }
 
@@ -620,7 +614,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('DogCommand', 'JUGGLE', 4, 41)
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found JUGGLE.", 4, 41)
         ]);
     }
 
@@ -636,13 +630,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue(
-                'DogCommand',
-                'sit',
-                4,
-                41,
-                'Did you mean the enum value SIT?'
-            )
+            $this->badValueWithMessage("Field \"doesKnowCommand\" argument \"dogCommand\" requires type DogCommand, found sit; Did you mean the enum value SIT?", 4, 41)
         ]);
     }
 
@@ -718,7 +706,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringListArgField\" argument \"stringListArg\" requires type String, found 2.", 4, 55),
+            $this->badValueWithMessage("Field \"stringListArgField\" argument \"stringListArg\" requires type String, found 2.", 4, 55),
         ]);
     }
 
@@ -734,7 +722,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"stringListArgField\" argument \"stringListArg\" requires type [String], found 1.", 4, 47),
+            $this->badValueWithMessage("Field \"stringListArgField\" argument \"stringListArg\" requires type [String], found 1.", 4, 47),
         ]);
     }
 
@@ -894,8 +882,8 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"multipleReqs\" argument \"req2\" requires type Int!, found \"two\".", 4, 32),
-            $this->badValue2("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 45),
+            $this->badValueWithMessage("Field \"multipleReqs\" argument \"req2\" requires type Int!, found \"two\".", 4, 32),
+            $this->badValueWithMessage("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 45),
         ]);
     }
 
@@ -911,7 +899,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 32),
+            $this->badValueWithMessage("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 32),
         ]);
     }
 
@@ -927,7 +915,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int!', 'null', 4, 32),
+            $this->badValueWithMessage("Field \"multipleReqs\" argument \"req1\" requires type Int!, found null.", 4, 32),
         ]);
     }
 
@@ -1063,7 +1051,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"complexArgField\" argument \"complexArg\" requires type String, found 2.", 5, 40),
+            $this->badValueWithMessage("Field \"complexArgField\" argument \"complexArg\" requires type String, found 2.", 5, 40),
         ]);
     }
 
@@ -1107,12 +1095,12 @@ class ValuesOfCorrectTypeTest extends TestCase
           invalidArg(arg: 123)
         }
         ', [
-            $this->badValue2("Field \"invalidArg\" argument \"arg\" requires type Invalid, found 123; Invalid scalar is always invalid: 123", 3, 27),
+            $this->badValueWithMessage("Field \"invalidArg\" argument \"arg\" requires type Invalid, found 123; Invalid scalar is always invalid: 123", 3, 27),
         ]);
 
         $this->assertEquals(
-            'Invalid scalar is always invalid: 123',
-            $errors[0]->getPrevious()->getMessage()
+            "Field \"invalidArg\" argument \"arg\" requires type Invalid, found 123; Invalid scalar is always invalid: 123",
+            $errors[0]->getMessage()
         );
     }
 
@@ -1162,8 +1150,8 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue2("Field \"dog\" argument \"if\" requires type Boolean!, found \"yes\".", 3, 28),
-            $this->badValue2("Field \"name\" argument \"if\" requires type Boolean!, found ENUM.", 4, 28),
+            $this->badValueWithMessage("Field \"dog\" argument \"if\" requires type Boolean!, found \"yes\".", 3, 28),
+            $this->badValueWithMessage("Field \"name\" argument \"if\" requires type Boolean!, found ENUM.", 4, 28),
         ]);
     }
 

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -19,6 +19,11 @@ class ValuesOfCorrectTypeTest extends TestCase
         );
     }
 
+    private function badValue2($error, $line, $column)
+    {
+        return FormattedError::create($error, [new SourceLocation($line, $column)]);
+    }
+
     private function requiredField($typeName, $fieldName, $fieldTypeName, $line, $column) {
         return FormattedError::create(
             ValuesOfCorrectType::requiredFieldMessage(
@@ -231,7 +236,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', '1', 4, 39)
+            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.", 4, 39)
         ]);
     }
 
@@ -247,7 +252,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', '1.0', 4, 39)
+            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found 1.0.", 4, 39)
         ]);
     }
 
@@ -263,7 +268,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', 'true', 4, 39)
+            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found true.", 4, 39)
         ]);
     }
 
@@ -279,7 +284,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', 'BAR', 4, 39)
+            $this->badValue2("Field \"stringArgField\" argument \"stringArg\" requires type String, found BAR.", 4, 39)
         ]);
     }
 
@@ -297,7 +302,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int', '"3"', 4, 33)
+            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found \"3\".", 4, 33)
         ]);
     }
 
@@ -313,7 +318,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int', '829384293849283498239482938', 4, 33)
+            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 829384293849283498239482938.", 4, 33)
         ]);
     }
 
@@ -329,7 +334,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int', 'FOO', 4, 33)
+            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found FOO.", 4, 33)
         ]);
     }
 
@@ -345,7 +350,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int', '3.0', 4, 33)
+            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.0.", 4, 33)
         ]);
     }
 
@@ -361,7 +366,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int', '3.333', 4, 33)
+            $this->badValue2("Field \"intArgField\" argument \"intArg\" requires type Int, found 3.333.", 4, 33)
         ]);
     }
 
@@ -379,7 +384,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Float', '"3.333"', 4, 37)
+            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found \"3.333\".", 4, 37)
         ]);
     }
 
@@ -395,7 +400,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Float', 'true', 4, 37)
+            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found true.", 4, 37)
         ]);
     }
 
@@ -411,7 +416,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Float', 'FOO', 4, 37)
+            $this->badValue2("Field \"floatArgField\" argument \"floatArg\" requires type Float, found FOO.", 4, 37)
         ]);
     }
 
@@ -429,7 +434,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Boolean', '2', 4, 41)
+            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 2.", 4, 41)
         ]);
     }
 
@@ -445,7 +450,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Boolean', '1.0', 4, 41)
+            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found 1.0.", 4, 41)
         ]);
     }
 
@@ -461,7 +466,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Boolean', '"true"', 4, 41)
+            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found \"true\".", 4, 41)
         ]);
     }
 
@@ -477,7 +482,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Boolean', 'TRUE', 4, 41)
+            $this->badValue2("Field \"booleanArgField\" argument \"booleanArg\" requires type Boolean, found TRUE.", 4, 41)
         ]);
     }
 
@@ -495,7 +500,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('ID', '1.0', 4, 31)
+            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found 1.0.", 4, 31)
         ]);
     }
 
@@ -511,7 +516,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('ID', 'true', 4, 31)
+            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found true.", 4, 31)
         ]);
     }
 
@@ -527,7 +532,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('ID', 'SOMETHING', 4, 31)
+            $this->badValue2("Field \"idArgField\" argument \"idArg\" requires type ID, found SOMETHING.", 4, 31)
         ]);
     }
 
@@ -713,7 +718,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', '2', 4, 55),
+            $this->badValue2("Field \"stringListArgField\" argument \"stringListArg\" requires type String, found 2.", 4, 55),
         ]);
     }
 
@@ -729,7 +734,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('[String]', '1', 4, 47),
+            $this->badValue2("Field \"stringListArgField\" argument \"stringListArg\" requires type [String], found 1.", 4, 47),
         ]);
     }
 
@@ -889,8 +894,8 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int!', '"two"', 4, 32),
-            $this->badValue('Int!', '"one"', 4, 45),
+            $this->badValue2("Field \"multipleReqs\" argument \"req2\" requires type Int!, found \"two\".", 4, 32),
+            $this->badValue2("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 45),
         ]);
     }
 
@@ -906,7 +911,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Int!', '"one"', 4, 32),
+            $this->badValue2("Field \"multipleReqs\" argument \"req1\" requires type Int!, found \"one\".", 4, 32),
         ]);
     }
 
@@ -1058,7 +1063,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('String', '2', 5, 40),
+            $this->badValue2("Field \"complexArgField\" argument \"complexArg\" requires type String, found 2.", 5, 40),
         ]);
     }
 
@@ -1102,13 +1107,7 @@ class ValuesOfCorrectTypeTest extends TestCase
           invalidArg(arg: 123)
         }
         ', [
-            $this->badValue(
-                'Invalid',
-                '123',
-                3,
-                27,
-                'Invalid scalar is always invalid: 123'
-            ),
+            $this->badValue2("Field \"invalidArg\" argument \"arg\" requires type Invalid, found 123; Invalid scalar is always invalid: 123", 3, 27),
         ]);
 
         $this->assertEquals(
@@ -1163,8 +1162,8 @@ class ValuesOfCorrectTypeTest extends TestCase
           }
         }
         ', [
-            $this->badValue('Boolean!', '"yes"', 3, 28),
-            $this->badValue('Boolean!', 'ENUM', 4, 28),
+            $this->badValue2("Field \"dog\" argument \"if\" requires type Boolean!, found \"yes\".", 3, 28),
+            $this->badValue2("Field \"name\" argument \"if\" requires type Boolean!, found ENUM.", 4, 28),
         ]);
     }
 


### PR DESCRIPTION
**graphql-php** shows incorrect error when we pass a field argument value of incorrect type.

How to reproduce:

1. Create field in **QueryType** that takes a non-null argument of **StringType**. This step is described in [Hello world example](https://github.com/webonyx/graphql-php/blob/0.12.x/docs/getting-started.md#hello-world)
2. Query this field, but put a **ListOfType** value to the argument (simply []) instead of **StringType** value.

For this query **graphql-php** returns an exception of category "internal", so we get "Internal server error" string at the output (in "message" field). Based on this information, it's unobvious to get field caused the error (we must count query lines and columns) and we haven't the reason of the error:
![image](https://user-images.githubusercontent.com/10958696/47381523-e8307480-d708-11e8-952f-4366e65268c8.png)

But let's query the field without the argument. Because it's non-null, we get an exception of category "graphql" and very detailed "message" field, that contains field name, argument name and required type of value:
![image](https://user-images.githubusercontent.com/10958696/47382280-9b4d9d80-d70a-11e8-8f16-d1ed580597e5.png)

I think the situation with incorrect value type should cause similar detailed error, so in this pull request I did the next output:
![image](https://user-images.githubusercontent.com/10958696/47382377-d4860d80-d70a-11e8-9929-d6ab118444d5.png)
