### PR TITLE
Added all possible scalar types to Node constructor

### DIFF
--- a/src/Language/AST/Node.php
+++ b/src/Language/AST/Node.php
@@ -40,7 +40,7 @@ abstract class Node
     public $loc;
 
     /**
-     * @param (string|NameNode|NodeList|SelectionSetNode|Location|null)[] $vars
+     * @param (NameNode|NodeList|SelectionSetNode|Location|string|int|bool|float|null)[] $vars
      */
     public function __construct(array $vars)
     {


### PR DESCRIPTION
When constructing BooleanValueNode

```php
new BooleanValueNode(['value' => false]))
```

This error occured

> Parameter #1 $vars of class GraphQL\Language\AST\BooleanValueNode constructor expects array<GraphQL\Language\AST\Location|GraphQL\Language\AST\NameNode|GraphQL\Language\AST\NodeList|GraphQL\Language\AST\SelectionSetNode|string|null>, array<string, false> given. 