### PR TITLE
Apollo persisted query compatibility: Look for queryId in extensions.

### DIFF
--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -95,6 +95,11 @@ class OperationParams
         $instance->variables = $params['variables'];
         $instance->readOnly  = (bool) $readonly;
 
+        // Apollo server/client compatibility: look for the queryid in extensions
+        if (isset($params['extensions']['persistedQuery']['sha256Hash']) && empty($instance->query) && empty($instance->queryid)) {
+          $instance->queryId = $params['extensions']['persistedQuery']['sha256Hash'];
+        }
+
         return $instance;
     }
 

--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -96,8 +96,8 @@ class OperationParams
         $instance->readOnly  = (bool) $readonly;
 
         // Apollo server/client compatibility: look for the queryid in extensions
-        if (isset($params['extensions']['persistedQuery']['sha256Hash']) && empty($instance->query) && empty($instance->queryid)) {
-          $instance->queryId = $params['extensions']['persistedQuery']['sha256Hash'];
+        if (isset($params['extensions']['persistedQuery']['sha256Hash']) && empty($instance->query) && empty($instance->queryId)) {
+            $instance->queryId = $params['extensions']['persistedQuery']['sha256Hash'];
         }
 
         return $instance;

--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -46,6 +46,12 @@ class OperationParams
      */
     public $variables;
 
+    /**
+     * @api
+     * @var mixed[]|null
+     */
+    public $extensions;
+
     /** @var mixed[] */
     private $originalInput;
 
@@ -76,6 +82,7 @@ class OperationParams
             'id' => null, // alias to queryid
             'operationname' => null,
             'variables' => null,
+            'extensions' => null,
         ];
 
         if ($params['variables'] === '') {
@@ -89,15 +96,16 @@ class OperationParams
             }
         }
 
-        $instance->query     = $params['query'];
-        $instance->queryId   = $params['queryid'] ?: $params['documentid'] ?: $params['id'];
-        $instance->operation = $params['operationname'];
-        $instance->variables = $params['variables'];
-        $instance->readOnly  = (bool) $readonly;
+        $instance->query      = $params['query'];
+        $instance->queryId    = $params['queryid'] ?: $params['documentid'] ?: $params['id'];
+        $instance->operation  = $params['operationname'];
+        $instance->variables  = $params['variables'];
+        $instance->extensions = $params['extensions'];
+        $instance->readOnly   = (bool) $readonly;
 
         // Apollo server/client compatibility: look for the queryid in extensions
-        if (isset($params['extensions']['persistedQuery']['sha256Hash']) && empty($instance->query) && empty($instance->queryId)) {
-            $instance->queryId = $params['extensions']['persistedQuery']['sha256Hash'];
+        if (isset($instance->extensions['persistedQuery']['sha256Hash']) && empty($instance->query) && empty($instance->queryId)) {
+            $instance->queryId = $instance->extensions['persistedQuery']['sha256Hash'];
         }
 
         return $instance;

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -335,12 +335,8 @@ class RequestParsingTest extends TestCase
 
     public function testParsesApolloPersistedQueryJSONRequest() : void
     {
-        $queryId = 'my-query-id';
-        $extensions = [
-            'persistedQuery' => [
-                'sha256Hash' => $queryId,
-            ],
-        ];
+        $queryId    = 'my-query-id';
+        $extensions = ['persistedQuery' => ['sha256Hash' => $queryId]];
         $variables  = ['test' => 1, 'test2' => 2];
         $operation  = 'op';
 

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -25,7 +25,7 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $source => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, null, null, $source);
+            self::assertValidOperationParams($parsedBody, $query, null, null, null, null, $source);
             self::assertFalse($parsedBody->isReadOnly(), $source);
         }
     }
@@ -91,6 +91,7 @@ class RequestParsingTest extends TestCase
         $queryId = null,
         $variables = null,
         $operation = null,
+        $extensions = null,
         $message = ''
     ) {
         self::assertInstanceOf(OperationParams::class, $params, $message);
@@ -99,6 +100,7 @@ class RequestParsingTest extends TestCase
         self::assertSame($queryId, $params->queryId, $message);
         self::assertSame($variables, $params->variables, $message);
         self::assertSame($operation, $params->operation, $message);
+        self::assertSame($extensions, $params->extensions, $message);
     }
 
     public function testParsesUrlencodedRequest() : void
@@ -118,7 +120,7 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -175,7 +177,7 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertTrue($parsedBody->isReadonly(), $method);
         }
     }
@@ -230,7 +232,7 @@ class RequestParsingTest extends TestCase
         ];
 
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -286,7 +288,7 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -307,7 +309,7 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -328,7 +330,7 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -350,7 +352,7 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, null, $queryId, $variables, $operation, $method);
+            self::assertValidOperationParams($parsedBody, null, $queryId, $variables, $operation, $extensions, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }
@@ -382,6 +384,7 @@ class RequestParsingTest extends TestCase
                 null,
                 $body[0]['variables'],
                 $body[0]['operationName'],
+                null,
                 $method
             );
             self::assertValidOperationParams(
@@ -390,6 +393,7 @@ class RequestParsingTest extends TestCase
                 $body[1]['queryId'],
                 $body[1]['variables'],
                 $body[1]['operationName'],
+                null,
                 $method
             );
         }

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -333,6 +333,32 @@ class RequestParsingTest extends TestCase
         }
     }
 
+    public function testParsesApolloPersistedQueryJSONRequest() : void
+    {
+        $queryId = 'my-query-id';
+        $extensions = [
+            'persistedQuery' => [
+                'sha256Hash' => $queryId,
+            ],
+        ];
+        $variables  = ['test' => 1, 'test2' => 2];
+        $operation  = 'op';
+
+        $body   = [
+            'extensions'    => $extensions,
+            'variables'     => $variables,
+            'operationName' => $operation,
+        ];
+        $parsed = [
+            'raw' => $this->parseRawRequest('application/json', json_encode($body)),
+            'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
+        ];
+        foreach ($parsed as $method => $parsedBody) {
+            self::assertValidOperationParams($parsedBody, null, $queryId, $variables, $operation, $method);
+            self::assertFalse($parsedBody->isReadOnly(), $method);
+        }
+    }
+
     public function testParsesBatchJSONRequest() : void
     {
         $body   = [


### PR DESCRIPTION
Apollo Engine's implementation of [automatic persisted queries](https://blog.apollographql.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea) expects the query hash in the operation's `extensions`. In JSON request body terms, it looks like this:

```
{
  "operationName": "MyQuery",
  "variables": null,
  "extensions": {
    "persistedQuery": {
      "sha256Hash": "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
      "version": 1
    }
}
```

Naturally, [Apollo client](https://github.com/apollographql/apollo-link-persisted-queries#protocol) follows this protocol. Considering Apollo's popularity and the large number of users likely to use Apollo client to query `graphql-php`-powered servers, it seems useful to provide out-of-the-box compatibility for this protocol.

This PR looks for the query hash in the operation's extensions and copies it to the `queryId` (if neither a `query` nor `queryId` were separately provided). Implementors are then able to implement `persistentQueryLoader` for Apollo clients.

----

After some more thought, I think it makes sense to add `extensions` to the public API of `OperationParams`. This would allow easier implementation of other and future extensions. And if you disagreed that we should support Apollo's protocol out-of-the-box, this would still provide an easy implementation path for persisted queries since the operation params are passed to `persistentQueryLoader`.