### PR TITLE
BUGFIX: ExtendSchema should be able to introduce new types

### DIFF
--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -513,7 +513,14 @@ class SchemaExtender
                 $schemaExtensions[] = $def;
             } elseif ($def instanceof TypeDefinitionNode) {
                 $typeName = isset($def->name) ? $def->name->value : null;
-                if ($schema->getType($typeName)) {
+
+                try {
+                    $type = $schema->getType($typeName);
+                } catch (Error $error) {
+                    $type = null;
+                }
+
+                if ($type) {
                     throw new Error('Type "' . $typeName . '" already exists in the schema. It cannot also be defined in this type definition.', [$def]);
                 }
                 $typeDefinitionMap[$typeName] = $def;

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -1980,7 +1980,7 @@ extend type Query {
         ';
 
         $documentNode = Parser::parse($sdl);
-        $schema = BuildSchema::build($documentNode);
+        $schema       = BuildSchema::build($documentNode);
 
         $extensionSdl = '
           type Bar {
@@ -1989,7 +1989,7 @@ extend type Query {
         ';
 
         $extendedDocumentNode = Parser::parse($extensionSdl);
-        $extendedSchema = SchemaExtender::extend($schema, $extendedDocumentNode);
+        $extendedSchema       = SchemaExtender::extend($schema, $extendedDocumentNode);
 
         $expected = '
             type Bar {


### PR DESCRIPTION
Currently ExtendSchema throws if the new document node has types that are not present in the base schema. 

Described in this issue: https://github.com/webonyx/graphql-php/issues/180#issuecomment-444478026