### PR TITLE
Allow extensions to be provided in GET request.

### DIFF
--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -89,11 +89,18 @@ class OperationParams
             $params['variables'] = null;
         }
 
-        if (is_string($params['variables'])) {
-            $tmp = json_decode($params['variables'], true);
-            if (! json_last_error()) {
-                $params['variables'] = $tmp;
+        // Some parameters could be provided as serialized JSON.
+        foreach (['extensions', 'variables'] as $param) {
+            if (! is_string($params[$param])) {
+                continue;
             }
+
+            $tmp = json_decode($params[$param], true);
+            if (json_last_error()) {
+                continue;
+            }
+
+            $params[$param] = $tmp;
         }
 
         $instance->query      = $params['query'];

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -293,14 +293,16 @@ class RequestParsingTest extends TestCase
         }
     }
 
-    public function testParsesVariablesAsJSON() : void
+    public function testParsesParamsAsJSON() : void
     {
-        $query     = '{my query}';
-        $variables = ['test' => 1, 'test2' => 2];
-        $operation = 'op';
+        $query      = '{my query}';
+        $variables  = ['test1' => 1, 'test2' => 2];
+        $extensions = ['test3' => 3, 'test4' => 4];
+        $operation  = 'op';
 
         $body   = [
             'query'         => $query,
+            'extensions'    => json_encode($extensions),
             'variables'     => json_encode($variables),
             'operationName' => $operation,
         ];
@@ -309,7 +311,7 @@ class RequestParsingTest extends TestCase
             'psr' => $this->parsePsrRequest('application/json', json_encode($body)),
         ];
         foreach ($parsed as $method => $parsedBody) {
-            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, null, $method);
+            self::assertValidOperationParams($parsedBody, $query, null, $variables, $operation, $extensions, $method);
             self::assertFalse($parsedBody->isReadOnly(), $method);
         }
     }


### PR DESCRIPTION
With apologies, my [previous PR](https://github.com/webonyx/graphql-php/pull/413) did not account for possible JSON encoding of extensions when passed as GET query string parameter. Leveraging GET requests is one of the primary benefits of using persisted queries.