### PR TITLE
Fix new executor is removing associative array when using custom scalar

### DIFF
--- a/src/Experimental/Executor/CoroutineExecutor.php
+++ b/src/Experimental/Executor/CoroutineExecutor.php
@@ -34,11 +34,8 @@ use GraphQL\Utils\Utils;
 use SplQueue;
 use stdClass;
 use Throwable;
-use function array_keys;
-use function count;
 use function is_array;
 use function is_string;
-use function range;
 use function sprintf;
 
 class CoroutineExecutor implements Runtime, ExecutorImplementation
@@ -154,14 +151,9 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
         }
 
         if (is_array($value)) {
-            $array   = [];
-            $isAssoc = array_keys($value) !== range(0, count($value) - 1);
+            $array = [];
             foreach ($value as $key => $item) {
-                if ($isAssoc) {
-                    $array[$key] = self::resultToArray($item);
-                } else {
-                    $array[] = self::resultToArray($item);
-                }
+                $array[$key] = self::resultToArray($item);
             }
             return $array;
         }

--- a/src/Experimental/Executor/CoroutineExecutor.php
+++ b/src/Experimental/Executor/CoroutineExecutor.php
@@ -34,8 +34,11 @@ use GraphQL\Utils\Utils;
 use SplQueue;
 use stdClass;
 use Throwable;
+use function array_keys;
+use function count;
 use function is_array;
 use function is_string;
+use function range;
 use function sprintf;
 
 class CoroutineExecutor implements Runtime, ExecutorImplementation
@@ -151,9 +154,14 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
         }
 
         if (is_array($value)) {
-            $array = [];
-            foreach ($value as $item) {
-                $array[] = self::resultToArray($item);
+            $array   = [];
+            $isAssoc = array_keys($value) !== range(0, count($value) - 1);
+            foreach ($value as $key => $item) {
+                if ($isAssoc) {
+                    $array[$key] = self::resultToArray($item);
+                } else {
+                    $array[] = self::resultToArray($item);
+                }
             }
             return $array;
         }

--- a/tests/Executor/ExecutorSchemaTest.php
+++ b/tests/Executor/ExecutorSchemaTest.php
@@ -6,6 +6,7 @@ namespace GraphQL\Tests\Executor;
 
 use GraphQL\Executor\Executor;
 use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -20,6 +21,13 @@ class ExecutorSchemaTest extends TestCase
      */
     public function testExecutesUsingASchema() : void
     {
+        $BlogSerializableValueType = new CustomScalarType([
+            'name'         => 'JsonSerializableValueScalar',
+            'serialize'    => static function ($value) { return $value; },
+            'parseValue'   => static function ($value) { return $value; },
+            'parseLiteral' => static function ($value) { return $value; },
+        ]);
+
         $BlogArticle = null;
         $BlogImage   = new ObjectType([
             'name'   => 'Image',
@@ -57,6 +65,7 @@ class ExecutorSchemaTest extends TestCase
                 'title'       => ['type' => Type::string()],
                 'body'        => ['type' => Type::string()],
                 'keywords'    => ['type' => Type::listOf(Type::string())],
+                'meta'        => ['type' => $BlogSerializableValueType],
             ],
         ]);
 
@@ -113,6 +122,7 @@ class ExecutorSchemaTest extends TestCase
               keywords
             }
           }
+          meta
         }
       }
 
@@ -191,6 +201,9 @@ class ExecutorSchemaTest extends TestCase
                             'keywords'    => ['foo', 'bar', '1', 'true', null],
                         ],
                     ],
+                    'meta' => [
+                        'title' => 'My Article 1 | My Blog'
+                    ]
                 ],
             ],
         ];
@@ -210,6 +223,9 @@ class ExecutorSchemaTest extends TestCase
                 'body'        => 'This is a post',
                 'hidden'      => 'This data is not exposed in the schema',
                 'keywords'    => ['foo', 'bar', 1, true, null],
+                'meta'        => [
+                    'title'   => 'My Article 1 | My Blog',
+                ],
             ];
         };
 

--- a/tests/Executor/ExecutorSchemaTest.php
+++ b/tests/Executor/ExecutorSchemaTest.php
@@ -23,9 +23,9 @@ class ExecutorSchemaTest extends TestCase
     {
         $BlogSerializableValueType = new CustomScalarType([
             'name'         => 'JsonSerializableValueScalar',
-            'serialize'    => static function ($value) { return $value; },
-            'parseValue'   => static function ($value) { return $value; },
-            'parseLiteral' => static function ($value) { return $value; },
+            'serialize'    => static function ($value) {
+                return $value;
+            },
         ]);
 
         $BlogArticle = null;
@@ -201,9 +201,7 @@ class ExecutorSchemaTest extends TestCase
                             'keywords'    => ['foo', 'bar', '1', 'true', null],
                         ],
                     ],
-                    'meta' => [
-                        'title' => 'My Article 1 | My Blog'
-                    ]
+                    'meta' => [ 'title' => 'My Article 1 | My Blog' ],
                 ],
             ],
         ];
@@ -223,9 +221,7 @@ class ExecutorSchemaTest extends TestCase
                 'body'        => 'This is a post',
                 'hidden'      => 'This data is not exposed in the schema',
                 'keywords'    => ['foo', 'bar', 1, true, null],
-                'meta'        => [
-                    'title'   => 'My Article 1 | My Blog',
-                ],
+                'meta'        => ['title' => 'My Article 1 | My Blog'],
             ];
         };
 


### PR DESCRIPTION
Hi, I just came across that the new CoroutineExecutor is converting associative arrays to simple array, if such array would ever happen in your schema. The ReferenceExecutor is keeping the associative array.

**Failing test**
```
1) GraphQL\Tests\Executor\ExecutorSchemaTest::testExecutesUsingASchema
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
             'body' => 'This is a post'
             'author' => Array (...)
             'meta' => Array (
-                'title' => 'My Article 1 | My Blog'
+                0 => 'My Article 1 | My Blog'
             )
         )
     )
 )
```

**Example data / my use case:**
In my side project I wanted to pass cropped image URLs for my js component, but the list is dynamic (some images have only 1 configuration, some can have 20 different ones).

```json
{
  "id": "4574BB",
  "variantUrls": {
    "00": "/uploads/00/16029619-136d-4110-a31c-3e00c06cb482",
    "cb": "/uploads/cb/16029619-136d-4110-a31c-3e00c06cb482",
    "og": "/uploads/og/aa6f99d0-4710-4cf1-8e30-604d47be5cf4",
  }
}
```

When I created simple Scalar type, that was just passing variable out (as I trust the associative array from backend) the new Coroutine Executor is changing associative array to simple array without keys.

I probably should have created an ObjectType for that, but this way is slightly simpler to foreach, not having to check for nulls.

---

After I made all of this I noticed, that if I wrap the associative array in some kind of stdClass, this problem disappears. But at least I found out about this difference between executors.
