### PR TITLE
Preserve array indices when computing path for ListOf type

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -917,11 +917,11 @@ class ReferenceExecutor implements ExecutorImplementation
             'User Error: expected iterable, but did not find one for field ' . $info->parentType . '.' . $info->fieldName . '.'
         );
         $containsPromise = false;
-        $i               = 0;
+
         $completedItems  = [];
-        foreach ($result as $item) {
+        foreach ($result as $idx => $item) {
             $fieldPath     = $path;
-            $fieldPath[]   = $i++;
+            $fieldPath[]   = $idx;
             $completedItem = $this->completeValueCatchingError($itemType, $fieldNodes, $info, $fieldPath, $item);
             if (! $containsPromise && $this->getPromise($completedItem)) {
                 $containsPromise = true;


### PR DESCRIPTION
I noticed that the behavior of `ReferenceExecutor.completeListValue` is slightly different than the equivalent method in the reference library. The reference library doesn't alter the array keys as it builds up `path`. It uses `forEach` from Lee Byron's own "iterall" library, which preserves the original array indices. 

Here's the relevant section of code from your `completeListValue`:

```php
        $i               = 0;
        $completedItems  = [];
        foreach ($result as $item) {
            $fieldPath     = $path;
            $fieldPath[]   = $i++;
```

You can see that any existing array indices are ignored, and they are renumbered starting from 0.

This is causing some issues with my dynamically generated user error types (I expose the array position of the error for `ListOf` types to the client). Please let me know if you would like to see some sample code or further analysis. 