### PR TITLE
Lazy loading for arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 phpcs.xml
 phpstan.neon
 vendor/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ composer.phar
 phpcs.xml
 phpstan.neon
 vendor/
-.idea/

--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -70,6 +70,7 @@ class FieldArgument
      * @param mixed[]|callable $config
      *
      * @return FieldArgument[]
+     * @throws \InvalidArgumentException
      */
     public static function createMap($config)
     {

--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -8,6 +8,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Utils\Utils;
 use function is_array;
+use function is_callable;
 use function is_string;
 use function sprintf;
 
@@ -66,12 +67,20 @@ class FieldArgument
     }
 
     /**
-     * @param mixed[] $config
+     * @param mixed[]|callable $config
      *
      * @return FieldArgument[]
      */
-    public static function createMap(array $config)
+    public static function createMap($config)
     {
+        if (is_callable($config)) {
+            $config = $config();
+        }
+
+        if (! is_array($config)) {
+            throw new \InvalidArgumentException('$config must be an array or a callable which returns such an array.');
+        }
+
         $map = [];
         foreach ($config as $name => $argConfig) {
             if (! is_array($argConfig)) {

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -109,9 +109,9 @@ class FieldDefinition
 
                     $field['name'] = $name;
                 }
-                if (isset($field['args']) && ! is_array($field['args'])) {
+                if (isset($field['args']) && ! is_array($field['args']) && ! is_callable($field['args'])) {
                     throw new InvariantViolation(
-                        sprintf('%s.%s args must be an array.', $type->name, $name)
+                        sprintf('%s.%s args must be an array or a callable which returns such an array.', $type->name, $name)
                     );
                 }
                 $fieldDef = self::create($field);


### PR DESCRIPTION
Hi!

This pull request ensures that field arguments can be lazy loaded in the same manner as fields, which should improve performance quite a bit. I've ran a majorly tiny benchmark on the performance impact and found out that this change decreased our schema build time from 28ms to 3ms.

I'd like to get some help on testing this feature as I'm not familiar with maintaining automated tests and got lost trying to find the right place to add them.

And, of course, a big thank you for the amazing library!