### PR TITLE
Fix return annotation of resolveType() in InterfaceType

### DIFF
--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -107,7 +107,7 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
      * @param object  $objectValue
      * @param mixed[] $context
      *
-     * @return callable|null
+     * @return Type|null
      */
     public function resolveType($objectValue, $context, ResolveInfo $info)
     {


### PR DESCRIPTION
Hi,
When I run phpstan on my project I found out about wrong return type on InterfaceType::resolveType(). It should return _resolved_ Type | null, not callable, as the resolving is done inside that method.

I'm not sure if you want to be more specific about the returned type.