### PR TITLE
Fix incorrect array type of contextValue in PHPDocs

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -161,9 +161,9 @@ class Executor
      * and returns it as the result, or if it's a function, returns the result
      * of calling that function while passing along args and context.
      *
-     * @param mixed        $source
-     * @param mixed[]      $args
-     * @param mixed|null   $context
+     * @param mixed      $source
+     * @param mixed[]    $args
+     * @param mixed|null $context
      *
      * @return mixed|null
      */

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -119,7 +119,7 @@ class Executor
      *
      * Useful for async PHP platforms.
      *
-     * @param mixed[]|null $rootValue
+     * @param mixed|null   $rootValue
      * @param mixed|null   $contextValue
      * @param mixed[]|null $variableValues
      * @param string|null  $operationName

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -74,7 +74,7 @@ class Executor
      * execution are collected in `$result->errors`.
      *
      * @param mixed|null               $rootValue
-     * @param mixed[]|null             $contextValue
+     * @param mixed|null               $contextValue
      * @param mixed[]|ArrayAccess|null $variableValues
      * @param string|null              $operationName
      *
@@ -120,7 +120,7 @@ class Executor
      * Useful for async PHP platforms.
      *
      * @param mixed[]|null $rootValue
-     * @param mixed[]|null $contextValue
+     * @param mixed|null   $contextValue
      * @param mixed[]|null $variableValues
      * @param string|null  $operationName
      *
@@ -163,7 +163,7 @@ class Executor
      *
      * @param mixed        $source
      * @param mixed[]      $args
-     * @param mixed[]|null $context
+     * @param mixed|null   $context
      *
      * @return mixed|null
      */

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -116,7 +116,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * execute, which we will pass throughout the other execution methods.
      *
      * @param mixed[]             $rootValue
-     * @param mixed[]             $contextValue
+     * @param mixed               $contextValue
      * @param mixed[]|Traversable $rawVariableValues
      * @param string|null         $operationName
      *

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -115,7 +115,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * Constructs an ExecutionContext object from the arguments passed to
      * execute, which we will pass throughout the other execution methods.
      *
-     * @param mixed[]             $rootValue
+     * @param mixed               $rootValue
      * @param mixed               $contextValue
      * @param mixed[]|Traversable $rawVariableValues
      * @param string|null         $operationName


### PR DESCRIPTION
Hi guys,

I was playing with GraphQL to learn more about it and I got to point where I ended up calling default field resolver but my IDE told me I have incorrect parameter for context. So I looked at the PHPDocs and some classes say context is "mixed|NULL" and others "mixed[]|NULL".

Here is a patch that marks the execution context parameter as "mixed|NULL" everywhere, I hope that is what was intended.

Cheers,
Petr