### PR TITLE
Adding GraphQLite to the list of PHP Tools

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -10,6 +10,7 @@
 
 # GraphQL PHP Tools
 
+* [GraphQLite](https://graphqlite.thecodingmachine.io) – Define your complete schema with annotations
 * [GraphQL Doctrine](https://github.com/Ecodev/graphql-doctrine) – Define types with Doctrine ORM annotations
 * [DataLoaderPHP](https://github.com/overblog/dataloader-php) – as a ready implementation for [deferred resolvers](data-fetching.md#solving-n1-problem)
 * [GraphQL Uploads](https://github.com/Ecodev/graphql-upload) – A PSR-15 middleware to support file uploads in GraphQL.


### PR DESCRIPTION
Hey!

I just wrote GraphQLite, a library on top of Webonyx/GraphQL-PHP that can create a complete schema using annotations (queries, mutations, and types).

This PR adds a link to GraphQLite in the documentation.

You can have a look at it here: https://graphqlite.thecodingmachine.io

Also, here is an article introducing the library: https://thecodingmachine.io/graphqlite-graphql-in-php-easy

Hope you will enjoy it.
Keep on the great work on Webonyx/GraphQL-PHP!