### PR TITLE
Add WP-GraphQL to complementary tools.

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -7,6 +7,7 @@
   - [laravel-graphql-relay](https://github.com/nuwave/laravel-graphql-relay) – Relay Helpers for Laravel
   - [Lighthouse](https://github.com/nuwave/lighthouse) – GraphQL Server for Laravel
 * [OverblogGraphQLBundle](https://github.com/overblog/GraphQLBundle) – Bundle for Symfony
+* [WP-GraphQL](https://github.com/wp-graphql/wp-graphql) - GraphQL API for WordPress
 
 # GraphQL PHP Tools
 


### PR DESCRIPTION
We utilized this repo for our work in WP GraphQL and wanted to let WP users know that it's available for use.