### PR TITLE
Remove deprecated tools and improve Lighthouse description

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -2,10 +2,7 @@
 
 * [Standard Server](executing-queries.md/#using-server) – Out of the box integration with any PSR-7 compatible framework (like [Slim](http://slimframework.com) or [Zend Expressive](http://zendframework.github.io/zend-expressive/)).
 * [Relay Library for graphql-php](https://github.com/ivome/graphql-relay-php) – Helps construct Relay related schema definitions.
-* Laravel 
-  - [Laravel GraphQL](https://github.com/Folkloreatelier/laravel-graphql) – Integration with Laravel 5
-  - [laravel-graphql-relay](https://github.com/nuwave/laravel-graphql-relay) – Relay Helpers for Laravel
-  - [Lighthouse](https://github.com/nuwave/lighthouse) – GraphQL Server for Laravel
+* [Lighthouse](https://github.com/nuwave/lighthouse) – Laravel based, uses Schema Definition Language
 * [OverblogGraphQLBundle](https://github.com/overblog/GraphQLBundle) – Bundle for Symfony
 * [WP-GraphQL](https://github.com/wp-graphql/wp-graphql) - GraphQL API for WordPress
 


### PR DESCRIPTION
- The folklore package was archived by the owner.
- The lighthouse relay tools were integrated with the core