### PR TITLE
Enum default values

### DIFF
--- a/docs/type-system/input-types.md
+++ b/docs/type-system/input-types.md
@@ -114,7 +114,7 @@ Option | Type | Notes
 name | `string` | **Required.** Name of the input field. When not set - inferred from **fields** array key
 type | `Type` | **Required.** Instance of one of [Input Types](input-types.md) (**Scalar**, **Enum**, **InputObjectType** + any combination of those with **nonNull** and **listOf** modifiers)
 description | `string` | Plain-text description of this input field for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
-defaultValue | `scalar` | Default value of this input field
+defaultValue | `scalar` | Default value of this input field. Use the internal value if specifying a default for an **enum** type
 
 # Using Input Object Type
 In the example above we defined our InputObjectType. Now let's use it in one of field arguments:

--- a/docs/type-system/object-types.md
+++ b/docs/type-system/object-types.md
@@ -94,7 +94,7 @@ Option | Type | Notes
 name | `string` | **Required.** Name of the argument. When not set - inferred from **args** array key
 type | `Type` | **Required.** Instance of one of [Input Types](input-types.md) (**scalar**, **enum**, **InputObjectType** + any combination of those with **nonNull** and **listOf** modifiers)
 description | `string` | Plain-text description of this argument for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
-defaultValue | `scalar` | Default value for this argument
+defaultValue | `scalar` | Default value for this argument. Use the internal value if specifying a default for an **enum** type
 
 # Shorthand field definitions
 Fields can be also defined in **shorthand** notation (with only **name** and **type** options):

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1101,13 +1101,14 @@ class ExecutorTest extends TestCase
                             'f' => ['type' => Type::int(), 'defaultValue' => 'some-string'],
                             'g' => ['type' => Type::boolean()],
                             'h' => [
-                                'type'             => new InputObjectType([
+                                'type' => new InputObjectType([
                                     'name'   => 'ComplexType',
                                     'fields' => [
                                         'a' => ['type' => Type::int()],
                                         'b' => ['type' => Type::string()],
                                     ],
-                                ]), 'defaultValue' => ['a' => 1, 'b' => 'test'],
+                                ]),
+                                'defaultValue' => ['a' => 1, 'b' => 'test'],
                             ],
                             'i' => [
                                 'type' => new EnumType([
@@ -1115,10 +1116,10 @@ class ExecutorTest extends TestCase
                                     'values' => [
                                         'VALUE1' => 1,
                                         'VALUE2' => 2,
-                                    ]
+                                    ],
                                 ]),
-                                'defaultValue' => 1
-                            ]
+                                'defaultValue' => 1,
+                            ],
                         ],
                     ],
                 ],

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -11,6 +11,7 @@ use GraphQL\Executor\Executor;
 use GraphQL\Language\Parser;
 use GraphQL\Tests\Executor\TestClasses\NotSpecial;
 use GraphQL\Tests\Executor\TestClasses\Special;
+use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
@@ -1108,6 +1109,16 @@ class ExecutorTest extends TestCase
                                     ],
                                 ]), 'defaultValue' => ['a' => 1, 'b' => 'test'],
                             ],
+                            'i' => [
+                                'type' => new EnumType([
+                                    'name' => 'EnumType',
+                                    'values' => [
+                                        'VALUE1' => 1,
+                                        'VALUE2' => 2,
+                                    ]
+                                ]),
+                                'defaultValue' => 1
+                            ]
                         ],
                     ],
                 ],
@@ -1117,7 +1128,7 @@ class ExecutorTest extends TestCase
         $query    = Parser::parse('{ field }');
         $result   = Executor::execute($schema, $query);
         $expected = [
-            'data' => ['field' => '{"a":1,"b":null,"c":0,"d":false,"e":"0","f":"some-string","h":{"a":1,"b":"test"}}'],
+            'data' => ['field' => '{"a":1,"b":null,"c":0,"d":false,"e":"0","f":"some-string","h":{"a":1,"b":"test"},"i":1}'],
         ];
 
         self::assertEquals($expected, $result->toArray());


### PR DESCRIPTION
This behaviour is consistent with the reference implementation https://github.com/graphql/graphql-js/issues/1604

Just wanted to emphasize that point in the docs and add a test to ensure the behaviour is well defined.