### PR TITLE
Drop PHP 7.1 support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
         env: [
           'EXECUTOR= DEPENDENCIES=--prefer-lowest',
           'EXECUTOR=coroutine DEPENDENCIES=--prefer-lowest',
@@ -68,7 +68,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.9.0
       with:
-        php-version: 7.1
+        php-version: 7.2
         coverage: none
         extensions: json, mbstring
 
@@ -99,7 +99,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.9.0
       with:
-        php-version: 7.1
+        php-version: 7.2
         coverage: none
         extensions: json, mbstring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Unreleased
 
+- PHP version required: 7.2+
+
 #### 14.4.1
 
 Fix:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "API"
   ],
   "require": {
-    "php": "^7.1||^8.0",
+    "php": "^7.2||^8.0",
     "ext-json": "*",
     "ext-mbstring": "*"
   },


### PR DESCRIPTION
Sounds like bold move but support for [PHP 7.1 ended almost half year ago](https://www.php.net/supported-versions.php). Let's move forward. No issue here for legacy systems can continue using this lib as composer won't install platform-unsupported versions for them.