### PR TITLE
Documentation fix: add missing semicolon in generated cache file

### DIFF
--- a/docs/type-system/type-language.md
+++ b/docs/type-system/type-language.md
@@ -81,7 +81,7 @@ $cacheFilename = 'cached_schema.php';
 
 if (!file_exists($cacheFilename)) {
     $document = Parser::parse(file_get_contents('./schema.graphql'));
-    file_put_contents($cacheFilename, "<?php\nreturn " . var_export(AST::toArray($document), true));
+    file_put_contents($cacheFilename, "<?php\nreturn " . var_export(AST::toArray($document), true) . ";\n");
 } else {
     $document = AST::fromArray(require $cacheFilename); // fromArray() is a lazy operation as well
 }


### PR DESCRIPTION
The `require $cacheFilename` statement in the provided code example about caching the Schema file leads to a PHP error due to a missing semicolon in the generated cache file.