### PR TITLE
Ignore examples directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 * text eol=lf
 /benchmarks export-ignore
 /tests export-ignore
+/examples export-ignore
 /tools export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
With some graphQL plugins, the graphQL schemas declared in the examples mess things up.

You could argue you want to keep doc & example in the installed package, but I would then argue you should also keep tests since tests are part of the documentation as well.