### PR TITLE
Use foreach for iterating over NodeList

### DIFF
--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -114,9 +114,8 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
      */
     public function getIterator()
     {
-        $count = count($this->nodes);
-        for ($i = 0; $i < $count; $i++) {
-            yield $this->offsetGet($i);
+        foreach (array_keys($this->nodes) as $key) {
+            yield $this->offsetGet($key);
         }
     }
 

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -114,7 +114,7 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
      */
     public function getIterator()
     {
-        foreach (array_keys($this->nodes) as $key) {
+        foreach ($this->nodes as $key => $_) {
             yield $this->offsetGet($key);
         }
     }


### PR DESCRIPTION
Closes https://github.com/webonyx/graphql-php/pull/251
Resolves https://github.com/webonyx/graphql-php/issues/252

Ran into this again, as i am utilizing the NodeList for performance gains in Lighthouse.

We embed the AST into lazy type-loading, so we store the AST in an associative array, keyed by type names. The NodeList class serves this purpose well, but does not handle non-numeric keys right now.