### PR TITLE
Add schema validation: Input Objects must not contain non-nullable circular references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## Unreleased
+- Add schema validation: Input Objects must not contain non-nullable circular references (#492)
+
 ## v0.13.0
 This release brings several breaking changes. Please refer to [UPGRADE](UPGRADE.md) document for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,4 @@
 # Changelog
-
-## Unreleased
-- Add schema validation: Input Objects must not contain non-nullable circular references (https://github.com/webonyx/graphql-php/pull/492)
-
-#### v0.13.4
-- Force int when setting max query depth (https://github.com/webonyx/graphql-php/pull/477)
-
-#### v0.13.3
-- Reverted minor possible breaking change (https://github.com/webonyx/graphql-php/pull/476)
-
-#### v0.13.2
-- Added QueryPlan support (https://github.com/webonyx/graphql-php/pull/436)
-- Fixed an issue with NodeList iteration over missing keys (https://github.com/webonyx/graphql-php/pull/475)
-
-#### v0.13.1
-- Better validation of field/directive arguments
-- Support for Apollo-style client/server persisted queries
-- Minor tweaks and fixes
-
 ## v0.13.0
 This release brings several breaking changes. Please refer to [UPGRADE](UPGRADE.md) document for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+
+## Unreleased
+- Add schema validation: Input Objects must not contain non-nullable circular references (https://github.com/webonyx/graphql-php/pull/492)
+
+#### v0.13.4
+- Force int when setting max query depth (https://github.com/webonyx/graphql-php/pull/477)
+
+#### v0.13.3
+- Reverted minor possible breaking change (https://github.com/webonyx/graphql-php/pull/476)
+
+#### v0.13.2
+- Added QueryPlan support (https://github.com/webonyx/graphql-php/pull/436)
+- Fixed an issue with NodeList iteration over missing keys (https://github.com/webonyx/graphql-php/pull/475)
+
+#### v0.13.1
+- Better validation of field/directive arguments
+- Support for Apollo-style client/server persisted queries
+- Minor tweaks and fixes
+
 ## v0.13.0
 This release brings several breaking changes. Please refer to [UPGRADE](UPGRADE.md) document for details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ For smaller contributions just use this workflow:
 * Fork the project.
 * Add your features and or bug fixes.
 * Add tests. Tests are important for us.
-* Check your changes using `composer check-all`
-* Send a pull request
+* Check your changes using `composer check-all`.
+* Add an entry to the [Changelog's Unreleases section](CHANGELOG.md#unreleased).
+* Send a pull request.
 
 ## Setup the Development Environment
 First, copy the URL of your fork and `git clone` it to your local machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,8 @@ For smaller contributions just use this workflow:
 * Fork the project.
 * Add your features and or bug fixes.
 * Add tests. Tests are important for us.
-* Check your changes using `composer check-all`.
-* Add an entry to the [Changelog](CHANGELOG.md).
-* Send a pull request.
+* Check your changes using `composer check-all`
+* Send a pull request
 
 ## Setup the Development Environment
 First, copy the URL of your fork and `git clone` it to your local machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ For smaller contributions just use this workflow:
 * Fork the project.
 * Add your features and or bug fixes.
 * Add tests. Tests are important for us.
-* Check your changes using `composer check-all`
-* Send a pull request
+* Check your changes using `composer check-all`.
+* Add an entry to the [Changelog](CHANGELOG.md).
+* Send a pull request.
 
 ## Setup the Development Environment
 First, copy the URL of your fork and `git clone` it to your local machine.

--- a/src/Type/Validation/InputObjectCircularRefs.php
+++ b/src/Type/Validation/InputObjectCircularRefs.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Type\Validation;
+
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Type\Definition\InputObjectField;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\SchemaValidationContext;
+use function array_map;
+use function array_pop;
+use function array_slice;
+use function count;
+use function implode;
+
+class InputObjectCircularRefs
+{
+    /** @var SchemaValidationContext */
+    private $schemaValidationContext;
+
+    /**
+     * Tracks already visited types to maintain O(N) and to ensure that cycles
+     * are not redundantly reported.
+     *
+     * @var InputObjectType[]
+     */
+    private $visitedTypes = [];
+
+    /** @var InputObjectField[] */
+    private $fieldPath = [];
+
+    /**
+     * Position in the type path.
+     *
+     * [string $typeName => int $index]
+     *
+     * @var int[]
+     */
+    private $fieldPathIndexByTypeName = [];
+
+    public function __construct(SchemaValidationContext $schemaValidationContext)
+    {
+        $this->schemaValidationContext = $schemaValidationContext;
+    }
+
+    /**
+     * This does a straight-forward DFS to find cycles.
+     * It does not terminate when a cycle was found but continues to explore
+     * the graph to find all possible cycles.
+     */
+    public function validate(InputObjectType $inputObj) : void
+    {
+        if (isset($this->visitedTypes[$inputObj->name])) {
+            return;
+        }
+
+        $this->visitedTypes[$inputObj->name]             = true;
+        $this->fieldPathIndexByTypeName[$inputObj->name] = count($this->fieldPath);
+
+        $fieldMap = $inputObj->getFields();
+        foreach ($fieldMap as $fieldName => $field) {
+            $type = $field->getType();
+
+            if ($type instanceof NonNull) {
+                $fieldType = $type->getWrappedType();
+
+                // If the type of the field is anything else then a non-nullable input object,
+                // there is no chance of an unbreakable cycle
+                if ($fieldType instanceof InputObjectType) {
+                    $this->fieldPath[] = $field;
+
+                    if (! isset($this->fieldPathIndexByTypeName[$fieldType->name])) {
+                        $this->validate($fieldType);
+                    } else {
+                        $cycleIndex = $this->fieldPathIndexByTypeName[$fieldType->name];
+                        $cyclePath  = array_slice($this->fieldPath, $cycleIndex);
+                        $fieldNames = array_map(
+                            static function (InputObjectField $field) : string {
+                                return $field->name;
+                            },
+                            $cyclePath
+                        );
+
+                        $this->schemaValidationContext->reportError(
+                            'Cannot reference Input Object "' . $fieldType->name . '" within itself '
+                            . 'through a series of non-null fields: "' . implode('.', $fieldNames) . '".',
+                            array_map(
+                                static function (InputObjectField $field) : ?InputValueDefinitionNode {
+                                    return $field->astNode;
+                                },
+                                $cyclePath
+                            )
+                        );
+                    }
+                }
+            }
+
+            array_pop($this->fieldPath);
+        }
+
+        unset($this->fieldPathIndexByTypeName[$inputObj->name]);
+    }
+}


### PR DESCRIPTION
Input Objects are allowed to reference other Input Objects. A circular reference occurs
when an Input Object references itself either directly or through subordinated Input Objects.

Circular references are generally allowed, however they may not be defined as an
unbroken chain of Non-Null fields. Such Input Objects are invalid, because there
is no way to provide a legal value for them.

The following examples are allowed:

```graphql example
input Example {
  self: Example
  value: String
}
```

This is fine because a value for `self` may simply be omitted from the arguments.

```graphql example
input Example {
  self: [Example!]!
  value: String
}
```

This also works as `self` can just contain an empty list.

The following examples are invalid:

```graphql counter-example
input Example {
  value: String
  self: Example!
}
```

```graphql counter-example
input First {
  second: Second!
  value: String
}

input Second {
  first: First!
  value: String
}
```

Spec change: https://github.com/graphql/graphql-spec/pull/445
Reference implementation: https://github.com/graphql/graphql-js/pull/1359

I think this might be added to a `0.13` release, since the relevant spec change is just a clarification.