### PR TITLE
QueryPlan can now be used on interfaces not only objects.

### DIFF
--- a/src/Type/Definition/QueryPlan.php
+++ b/src/Type/Definition/QueryPlan.php
@@ -140,9 +140,11 @@ class QueryPlan
     /**
      * @return mixed[]
      *
+     * $parentType InterfaceType|ObjectType.
+     *
      * @throws Error
      */
-    private function analyzeSelectionSet(SelectionSetNode $selectionSet, ObjectType $parentType) : array
+    private function analyzeSelectionSet(SelectionSetNode $selectionSet, Type $parentType) : array
     {
         $fields = [];
         foreach ($selectionSet->selections as $selectionNode) {


### PR DESCRIPTION
It's often the case to use interfaces in queries:

```
interface Pet { name: String! }

Query {
 pets: [Pet]
}
```