### PR TITLE
fix query complexity validator on directives

### DIFF
--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -206,7 +206,7 @@ class QueryComplexity extends QuerySecurityRule
 
                 return ! $directiveArgsIf;
             }
-            if ($directiveNode->name->value === 'skip') {
+            if (Directive::SKIP_NAME === $directiveNode->name->value) {
                 $directive = Directive::skipDirective();
                 /** @var bool $directiveArgsIf */
                 $directiveArgsIf = Values::getArgumentValues($directive, $directiveNode, $variableValues)['if'];

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -206,7 +206,7 @@ class QueryComplexity extends QuerySecurityRule
 
                 return ! $directiveArgsIf;
             }
-            if (Directive::SKIP_NAME === $directiveNode->name->value) {
+            if ($directiveNode->name->value === Directive::SKIP_NAME) {
                 $directive = Directive::skipDirective();
                 /** @var bool $directiveArgsIf */
                 $directiveArgsIf = Values::getArgumentValues($directive, $directiveNode, $variableValues)['if'];

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -206,11 +206,16 @@ class QueryComplexity extends QuerySecurityRule
 
                 return ! $directiveArgsIf;
             }
-            $directive       = Directive::skipDirective();
-            $directiveArgsIf = Values::getArgumentValues($directive, $directiveNode, $variableValues);
+            if ($directiveNode->name->value === 'skip') {
+                $directive = Directive::skipDirective();
+                /** @var bool $directiveArgsIf */
+                $directiveArgsIf = Values::getArgumentValues($directive, $directiveNode, $variableValues)['if'];
 
-            return $directiveArgsIf['if'];
+                return $directiveArgsIf;
+            }
         }
+
+        return false;
     }
 
     public function getRawVariableValues()

--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -146,6 +146,22 @@ class QueryComplexityTest extends QuerySecurityTestCase
         $this->assertDocumentValidators($query, 2, 3);
     }
 
+    public function testQueryWithCustomDirective() : void
+    {
+        $query = 'query MyQuery { human { ... on Human { firstName @foo(bar: false) } } }';
+
+        $this->assertDocumentValidators($query, 2, 3);
+    }
+
+    public function testQueryWithCustomAndSkipDirective() : void
+    {
+        $query = 'query MyQuery($withoutDogs: Boolean!) { human { dogs(name: "Root") @skip(if:$withoutDogs) { name @foo(bar: true) } } }';
+
+        $this->getRule()->setRawVariableValues(['withoutDogs' => true]);
+
+        $this->assertDocumentValidators($query, 1, 2);
+    }
+
     public function testComplexityIntrospectionQuery() : void
     {
         $this->assertIntrospectionQuery(181);

--- a/tests/Validator/QuerySecuritySchema.php
+++ b/tests/Validator/QuerySecuritySchema.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
+use GraphQL\GraphQL;
+use GraphQL\Language\DirectiveLocation;
+use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+use function array_merge;
 
 class QuerySecuritySchema
 {
     /** @var Schema */
     private static $schema;
+
+    /** @var Directive */
+    private static $fooDirective;
 
     /** @var ObjectType */
     private static $dogType;
@@ -32,7 +40,8 @@ class QuerySecuritySchema
         }
 
         self::$schema = new Schema([
-            'query' => static::buildQueryRootType(),
+            'query'      => static::buildQueryRootType(),
+            'directives' => array_merge(GraphQL::getStandardDirectives(), [static::buildFooDirective()]),
         ]);
 
         return self::$schema;
@@ -109,5 +118,25 @@ class QuerySecuritySchema
         );
 
         return self::$dogType;
+    }
+
+    public static function buildFooDirective()
+    {
+        if (self::$fooDirective !== null) {
+            return self::$fooDirective;
+        }
+
+        self::$fooDirective = new Directive([
+            'name'      => 'foo',
+            'locations' => [DirectiveLocation::FIELD],
+            'args'      => [new FieldArgument([
+                'name'         => 'bar',
+                'type'         => Type::nonNull(Type::boolean()),
+                'defaultValue' => ' ',
+            ]),
+            ],
+        ]);
+
+        return self::$fooDirective;
     }
 }

--- a/tests/Validator/QuerySecuritySchema.php
+++ b/tests/Validator/QuerySecuritySchema.php
@@ -120,7 +120,7 @@ class QuerySecuritySchema
         return self::$dogType;
     }
 
-    public static function buildFooDirective()
+    public static function buildFooDirective() : Directive
     {
         if (self::$fooDirective !== null) {
             return self::$fooDirective;


### PR DESCRIPTION
During query complexity validation, the directive "skip" is always check and failed when using a custom directive.

```
query {
  currencies @lang(code: "en") {
    id
    iso
    symbol
    name
  }
}
```
In my exemple, the validator searching the argument `if` who doesn't exist in the directive `lang` and return the error : `Argument "if" of required type "Boolean!" was not provided`.