### PR TITLE
Remove composer.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .phpcs-cache
-composer.lock
 composer.phar
 phpcs.xml
 phpstan.neon

--- a/src/Type/Definition/Directive.php
+++ b/src/Type/Definition/Directive.php
@@ -20,8 +20,8 @@ class Directive
     public const DEPRECATED_NAME      = 'deprecated';
     public const REASON_ARGUMENT_NAME = 'reason';
 
-    /** @var Directive[] */
-    public static $internalDirectives = [];
+    /** @var Directive[]|null */
+    public static $internalDirectives;
 
     // Schema Definitions
 


### PR DESCRIPTION
I think we need to remove `composer.lock` from `.gitignore` because it makes reproducible builds impossible. Even [composer documentation](https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control) states it.

I created this PR because today I fall in indicative situation. I cloned my fork of this repo on local machine, typed `composer install` and got the build that can't pass the tests. But I know that this build passed the tests a week before. The reason is phpstan library, that was updated from 0.11.8 to 0.11.12, and this update introduced breaking change.
We had (a week ago) ^0.11.8 version constraint for phpstan in `composer.json` and it allows any available version of 0.11.x (where x >= 8). If we would have `composer.lock` in repository, I would get the right version of phpstan, which was used to prepare the build. But without it I got the last available version of phpstan, which meets the version constraint, but wasn't tested with the build and broke it.

This PR also includes #518 to pass the tests (current master branch is broken).