### PR TITLE
Let's a bit wait more for coverage in Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,7 +20,7 @@ build:
 
 tools:
     external_code_coverage:
-        timeout: 900
+        timeout: 3600
 
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/327717/62366226-9e41ae00-b526-11e9-9aaf-511c41fd768a.png)

sometimes travis runs more builds and the timeout is not enough