### PR TITLE
Support no field selection

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -178,10 +178,12 @@ class ResolveInfo
 
         /** @var FieldNode $fieldNode */
         foreach ($this->fieldNodes as $fieldNode) {
-            $fields = array_merge_recursive(
-                $fields,
-                $this->foldSelectionSet($fieldNode->selectionSet, $depth)
-            );
+            if ($fieldNode->selectionSet) {
+                $fields = array_merge_recursive(
+                    $fields,
+                    $this->foldSelectionSet($fieldNode->selectionSet, $depth)
+                );
+            }
         }
 
         return $fields;


### PR DESCRIPTION
I am getting this error on my query that accepts no args and returns a string:

```
Argument 1 passed to GraphQL\\Type\\Definition\\ResolveInfo::foldSelectionSet() must be an instance of GraphQL\\Language\\AST\\SelectionSetNode, null given
```

Here's the query:

```
query Nonce {
  nonce: Nonce
}
```

This should work? Right? This change fixes it.