### PR TITLE
Scalar type ResolverInfo::getFieldSelection support

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -178,6 +178,10 @@ class ResolveInfo
 
         /** @var FieldNode $fieldNode */
         foreach ($this->fieldNodes as $fieldNode) {
+            if ($fieldNode->selectionSet === null) {
+                continue;
+            }
+
             $fields = array_merge_recursive(
                 $fields,
                 $this->foldSelectionSet($fieldNode->selectionSet, $depth)

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -205,7 +205,8 @@ class ResolveInfoTest extends TestCase
 
         $schema = new Schema(['query' => $pingPongQuery]);
         $result = GraphQL::executeQuery($schema, $query)->toArray();
-        $this->assertEquals(['data' => ['string' => 'a string']], $result);
+        
+        self::assertEquals(['data' => ['ping' => 'pong']], $result);
     }
 
     public function testMergedFragmentsFieldSelection() : void

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -194,7 +194,7 @@ class ResolveInfoTest extends TestCase
             'fields' => [
                 'ping' => [
                     'type'    => Type::string(),
-                    'resolve' => function ($value, $args, $context, ResolveInfo $info) : string {
+                    'resolve' => static function ($value, $args, $context, ResolveInfo $info) : string {
                         self::assertEquals([], $info->getFieldSelection());
 
                         return 'pong';
@@ -273,7 +273,7 @@ class ResolveInfoTest extends TestCase
             }
             image {
                 width
-                height
+                heightp
                 ...MyImage
             }
             ...Replies01

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -189,7 +189,7 @@ class ResolveInfoTest extends TestCase
             }
         ';
 
-        $stringQuery = new ObjectType([
+        $pingPongQuery = new ObjectType([
             'name'   => 'Query',
             'fields' => [
                 'ping' => [

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -194,7 +194,7 @@ class ResolveInfoTest extends TestCase
             'fields' => [
                 'string' => [
                     'type'    => Type::string(),
-                    'resolve' => function ($value, $args, $context, ResolveInfo $info) {
+                    'resolve' => function ($value, $args, $context, ResolveInfo $info) : string {
                         self::assertEquals([], $info->getFieldSelection());
 
                         return 'pong';

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -184,7 +184,7 @@ class ResolveInfoTest extends TestCase
     public function testFieldSelectionOnScalarTypes() : void
     {
         $query = '
-            query string {
+            query Ping {
                 string
             }
         ';

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -203,7 +203,7 @@ class ResolveInfoTest extends TestCase
             ],
         ]);
 
-        $schema = new Schema(['query' => $stringQuery]);
+        $schema = new Schema(['query' => $pingPongQuery]);
         $result = GraphQL::executeQuery($schema, $query)->toArray();
         $this->assertEquals(['data' => ['string' => 'a string']], $result);
     }

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -181,6 +181,33 @@ class ResolveInfoTest extends TestCase
         self::assertEquals($expectedDeepSelection, $actualDeepSelection);
     }
 
+    public function testFieldSelectionOnScalarTypes() : void
+    {
+        $query = '
+            query string {
+                string
+            }
+        ';
+
+        $stringQuery = new ObjectType([
+            'name'   => 'Query',
+            'fields' => [
+                'string' => [
+                    'type'    => Type::string(),
+                    'resolve' => function ($value, $args, $context, ResolveInfo $info) {
+                        $this->assertEquals([], $info->getFieldSelection());
+
+                        return 'a string';
+                    },
+                ],
+            ],
+        ]);
+
+        $schema = new Schema(['query' => $stringQuery]);
+        $result = GraphQL::executeQuery($schema, $query)->toArray();
+        $this->assertEquals(['data' => ['string' => 'a string']], $result);
+    }
+
     public function testMergedFragmentsFieldSelection() : void
     {
         $image = new ObjectType([

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -197,7 +197,7 @@ class ResolveInfoTest extends TestCase
                     'resolve' => function ($value, $args, $context, ResolveInfo $info) {
                         $this->assertEquals([], $info->getFieldSelection());
 
-                        return 'a string';
+                        return 'pong';
                     },
                 ],
             ],

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -185,7 +185,7 @@ class ResolveInfoTest extends TestCase
     {
         $query = '
             query Ping {
-                string
+                ping
             }
         ';
 

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -195,7 +195,7 @@ class ResolveInfoTest extends TestCase
                 'string' => [
                     'type'    => Type::string(),
                     'resolve' => function ($value, $args, $context, ResolveInfo $info) {
-                        $this->assertEquals([], $info->getFieldSelection());
+                        self::assertEquals([], $info->getFieldSelection());
 
                         return 'pong';
                     },

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -273,7 +273,7 @@ class ResolveInfoTest extends TestCase
             }
             image {
                 width
-                heightp
+                height
                 ...MyImage
             }
             ...Replies01

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -192,7 +192,7 @@ class ResolveInfoTest extends TestCase
         $stringQuery = new ObjectType([
             'name'   => 'Query',
             'fields' => [
-                'string' => [
+                'ping' => [
                     'type'    => Type::string(),
                     'resolve' => function ($value, $args, $context, ResolveInfo $info) : string {
                         self::assertEquals([], $info->getFieldSelection());


### PR DESCRIPTION
Support calling ResolveInfo::getFieldSelection() on scalar types

Related: https://github.com/webonyx/graphql-php/pull/528