### PR TITLE
Added function to retrieve the query complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add schema validation: Input Objects must not contain non-nullable circular references (#492)
+- Added retrieving query complexity once query has been completed (#316) 
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -41,6 +41,9 @@ class QueryComplexity extends QuerySecurityRule
     /** @var ValidationContext */
     private $context;
 
+    /** @var int */
+    private $complexity;
+
     public function __construct($maxQueryComplexity)
     {
         $this->setMaxQueryComplexity($maxQueryComplexity);
@@ -52,7 +55,7 @@ class QueryComplexity extends QuerySecurityRule
 
         $this->variableDefs     = new ArrayObject();
         $this->fieldNodeAndDefs = new ArrayObject();
-        $complexity             = 0;
+        $this->complexity       = 0;
 
         return $this->invokeIfNeeded(
             $context,
@@ -79,16 +82,16 @@ class QueryComplexity extends QuerySecurityRule
                             return;
                         }
 
-                        $complexity = $this->fieldComplexity($operationDefinition, $complexity);
+                        $this->complexity = $this->fieldComplexity($operationDefinition, $complexity);
 
-                        if ($complexity <= $this->getMaxQueryComplexity()) {
+                        if ($this->getQueryComplexity() <= $this->getMaxQueryComplexity()) {
                             return;
                         }
 
                         $context->reportError(
                             new Error(self::maxQueryComplexityErrorMessage(
                                 $this->getMaxQueryComplexity(),
-                                $complexity
+                                $this->getQueryComplexity()
                             ))
                         );
                     },
@@ -257,6 +260,11 @@ class QueryComplexity extends QuerySecurityRule
         }
 
         return $args;
+    }
+
+    public function getQueryComplexity()
+    {
+        return $this->complexity;
     }
 
     public function getMaxQueryComplexity()

--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -25,6 +25,21 @@ class QueryComplexityTest extends QuerySecurityTestCase
         $this->assertDocumentValidators($query, 2, 3);
     }
 
+    public function testGetQueryComplexity() : void
+    {
+        $query = 'query MyQuery { human { firstName } }';
+
+        $rule = $this->getRule(5);
+
+        DocumentValidator::validate(
+            QuerySecuritySchema::buildSchema(),
+            Parser::parse($query),
+            [$rule]
+        );
+
+        self::assertEquals(2, $rule->getQueryComplexity(), $query);
+    }
+
     private function assertDocumentValidators($query, $queryComplexity, $startComplexity)
     {
         for ($maxComplexity = $startComplexity; $maxComplexity >= 0; --$maxComplexity) {


### PR DESCRIPTION
This adds a function to retrieve the query complexity once the query has been completed. I'll be using it for logging and to calculate rate limiting.

There aren't any breaking changes as it just adds a public method and adds tracking of the complexity.

It should fix #316 (with regards to query complexity, not query depth).