### PR TITLE
Fixing arguments order when getting value from AST

### DIFF
--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -42,8 +42,11 @@ use stdClass;
 use Throwable;
 use Traversable;
 use function array_combine;
+use function array_flip;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
+use function array_replace;
 use function count;
 use function floatval;
 use function intval;
@@ -410,6 +413,10 @@ class AST
                     return $field->name->value;
                 }
             );
+
+            // re-order $fields with $fieldNodes order to keep order of the user's input
+            $fields = array_replace(array_flip(array_keys($fieldNodes)), $fields);
+
             foreach ($fields as $field) {
                 /** @var VariableNode|NullValueNode|IntValueNode|FloatValueNode|StringValueNode|BooleanValueNode|EnumValueNode|ListValueNode|ObjectValueNode $fieldNode */
                 $fieldName = $field->name;

--- a/tests/Utils/ValueFromAstTest.php
+++ b/tests/Utils/ValueFromAstTest.php
@@ -251,4 +251,12 @@ class ValueFromAstTest extends TestCase
             ['int' => 42, 'requiredBool' => true]
         );
     }
+
+    public function testValuesReturnedAreOrderedAsInTheAST()
+    {
+        $testInputObj = $this->inputObj();
+
+        // assertSame is used here because we have to check that the array keys have the same order
+        self::assertSame(['requiredBool' => true, 'bool' => true, 'int' => 21], AST::valueFromAST(Parser::parseValue('{ requiredBool: true, bool: $foo, int: 21 }'), $testInputObj, ['foo' => true]));
+    }
 }


### PR DESCRIPTION
Hello,
Given the following `InputObjectType` :
```php
new InputObjectType([
    'name'   => 'order',
    'fields' => [
        'foo'  => ['type' => Type::string()],
        'bar'  => ['type' => Type::string()]
    ],
]);
```
and something like `order: {bar: "ASC", foo: "ASC"}` as value, the return of `GraphQL\Utils\AST::valueFromAST` will be `['foo' => 'ASC', 'bar' = 'ASC']`.

However when the order of arguments has importance, like constructing an `ORDER` SQL clause, this can pose a problem and the return should be `['bar' => 'ASC', 'foo' = 'ASC']`.

The aim of this PR is to fix this by using the order given by the user instead of the order defining during the field configuration.

I used directly `assertSame()` in the test case instead of the helper method `runTestCaseWithVars` because this method use `assertEquals` and this doesn't test the order of the keys.

Tell me if I should replace `assertEquals` by `assertSame` in the helper method, I was not sure about that.

fix : https://github.com/api-platform/core/issues/2808