### PR TITLE
Allow \stdClass for input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Add schema validation: Input Objects must not contain non-nullable circular references (#492)
 - Added retrieving query complexity once query has been completed (#316) 
-- Allow input types to be passed in from variables using \stdClass instead of associative arrays
+- Allow input types to be passed in from variables using \stdClass instead of associative arrays (#535)
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add schema validation: Input Objects must not contain non-nullable circular references (#492)
 - Added retrieving query complexity once query has been completed (#316) 
+- Allow input types to be passed in from variables using \stdClass instead of associative arrays
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/docs/executing-queries.md
+++ b/docs/executing-queries.md
@@ -1,8 +1,8 @@
 # Using Facade Method
-Query execution is a complex process involving multiple steps, including query **parsing**, 
+Query execution is a complex process involving multiple steps, including query **parsing**,
 **validating** and finally **executing** against your [schema](type-system/schema.md).
 
-**graphql-php** provides a convenient facade for this process in class 
+**graphql-php** provides a convenient facade for this process in class
 [`GraphQL\GraphQL`](reference.md#graphqlgraphql):
 
 ```php
@@ -10,26 +10,26 @@ Query execution is a complex process involving multiple steps, including query *
 use GraphQL\GraphQL;
 
 $result = GraphQL::executeQuery(
-    $schema, 
-    $queryString, 
-    $rootValue = null, 
-    $context = null, 
-    $variableValues = null, 
+    $schema,
+    $queryString,
+    $rootValue = null,
+    $context = null,
+    $variableValues = null,
     $operationName = null,
     $fieldResolver = null,
     $validationRules = null
 );
 ```
 
-It returns an instance of [`GraphQL\Executor\ExecutionResult`](reference.md#graphqlexecutorexecutionresult) 
+It returns an instance of [`GraphQL\Executor\ExecutionResult`](reference.md#graphqlexecutorexecutionresult)
 which can be easily converted to array:
 
 ```php
 $serializableResult = $result->toArray();
 ```
 
-Returned array contains **data** and **errors** keys, as described by the 
-[GraphQL spec](http://facebook.github.io/graphql/#sec-Response-Format). 
+Returned array contains **data** and **errors** keys, as described by the
+[GraphQL spec](http://facebook.github.io/graphql/#sec-Response-Format).
 This array is suitable for further serialization (e.g. using **json_encode**).
 See also the section on [error handling and formatting](error-handling.md).
 
@@ -41,14 +41,14 @@ schema       | [`GraphQL\Type\Schema`](#) | **Required.** Instance of your appli
 queryString  | `string` or `GraphQL\Language\AST\DocumentNode` | **Required.** Actual GraphQL query string to be parsed, validated and executed. If you parse query elsewhere before executing - pass corresponding AST document here to avoid new parsing.
 rootValue  | `mixed` | Any value that represents a root of your data graph. It is passed as the 1st argument to field resolvers of [Query type](type-system/schema.md#query-and-mutation-types). Can be omitted or set to null if actual root values are fetched by Query type itself.
 context  | `mixed` | Any value that holds information shared between all field resolvers. Most often they use it to pass currently logged in user, locale details, etc.<br><br>It will be available as the 3rd argument in all field resolvers. (see section on [Field Definitions](type-system/object-types.md#field-configuration-options) for reference) **graphql-php** never modifies this value and passes it *as is* to all underlying resolvers.
-variableValues | `array` | Map of variable values passed along with query string. See section on [query variables on official GraphQL website](http://graphql.org/learn/queries/#variables)
+variableValues | `array` | Map of variable values passed along with query string. See section on [query variables on official GraphQL website](http://graphql.org/learn/queries/#variables). Note that while variableValues must be an associative array, the values inside it can be nested using \stdClass if desired.
 operationName | `string` | Allows the caller to specify which operation in queryString will be run, in cases where queryString contains multiple top-level operations.
 fieldResolver | `callable` | A resolver function to use when one is not provided by the schema. If not provided, the [default field resolver is used](data-fetching.md#default-field-resolver).
 validationRules | `array` | A set of rules for query validation step. The default value is all available rules. Empty array would allow skipping query validation (may be convenient for persisted queries which are validated before persisting and assumed valid during execution)
 
 # Using Server
-If you are building HTTP GraphQL API, you may prefer our Standard Server 
-(compatible with [express-graphql](https://github.com/graphql/express-graphql)). 
+If you are building HTTP GraphQL API, you may prefer our Standard Server
+(compatible with [express-graphql](https://github.com/graphql/express-graphql)).
 It supports more features out of the box, including parsing HTTP requests, producing a spec-compliant response; [batched queries](#query-batching); persisted queries.
 
 Usage example (with plain PHP):
@@ -105,11 +105,11 @@ debug | `int` | Debug flags. See [docs on error debugging](error-handling.md#deb
 persistentQueryLoader | `callable` | A function which is called to fetch actual query when server encounters **queryId** in request vs **query**.<br><br> The server does not implement persistence part (which you will have to build on your own), but it allows you to execute queries which were persisted previously.<br><br> Expected function signature:<br> **function ($queryId, [OperationParams](reference.md#graphqlserveroperationparams) $params)** <br><br>Function is expected to return query **string** or parsed **DocumentNode** <br><br> [Read more about persisted queries](https://dev-blog.apollodata.com/persisted-graphql-queries-with-apollo-client-119fd7e6bba5).
 errorFormatter | `callable` | Custom error formatter. See [error handling docs](error-handling.md#custom-error-handling-and-formatting).
 errorsHandler | `callable` | Custom errors handler. See [error handling docs](error-handling.md#custom-error-handling-and-formatting).
-promiseAdapter | [`PromiseAdapter`](reference.md#graphqlexecutorpromisepromiseadapter) | Required for [Async PHP](data-fetching/#async-php) only. 
+promiseAdapter | [`PromiseAdapter`](reference.md#graphqlexecutorpromisepromiseadapter) | Required for [Async PHP](data-fetching/#async-php) only.
 
 **Server config instance**
 
-If you prefer fluid interface for config with autocomplete in IDE and static time validation, 
+If you prefer fluid interface for config with autocomplete in IDE and static time validation,
 use [`GraphQL\Server\ServerConfig`](reference.md#graphqlserverserverconfig) instead of an array:
 
 ```php
@@ -129,7 +129,7 @@ $server = new StandardServer($config);
 ## Query batching
 Standard Server supports query batching ([apollo-style](https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862)).
 
-One of the major benefits of Server over a sequence of **executeQuery()** calls is that 
+One of the major benefits of Server over a sequence of **executeQuery()** calls is that
 [Deferred resolvers](data-fetching.md#solving-n1-problem) won't be isolated in queries.
 So for example following batch will require single DB request (if user field is deferred):
 
@@ -186,11 +186,11 @@ $myValiationRules = array_merge(
 );
 
 $result = GraphQL::executeQuery(
-    $schema, 
-    $queryString, 
-    $rootValue = null, 
-    $context = null, 
-    $variableValues = null, 
+    $schema,
+    $queryString,
+    $rootValue = null,
+    $context = null,
+    $variableValues = null,
     $operationName = null,
     $fieldResolver = null,
     $myValiationRules // <-- this will override global validation rules for this request
@@ -199,7 +199,7 @@ $result = GraphQL::executeQuery(
 
 Or with a standard server:
 ```php
-<?php 
+<?php
 use GraphQL\Server\StandardServer;
 
 $server = new StandardServer([

--- a/src/Utils/Value.php
+++ b/src/Utils/Value.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ScalarType;
+use stdClass;
 use Throwable;
 use Traversable;
 use function array_key_exists;
@@ -156,6 +157,11 @@ class Value
                         $path
                     ),
                 ]);
+            }
+
+            // Cast \stdClass to associative array before checking the fields. Note that the coerced value will be an array.
+            if ($value instanceof stdClass) {
+                $value = (array) $value;
             }
 
             $errors       = [];

--- a/tests/Executor/VariablesTest.php
+++ b/tests/Executor/VariablesTest.php
@@ -309,6 +309,24 @@ class VariablesTest extends TestCase
         self::assertEquals($expected, $result->toArray());
     }
 
+    public function testUsingStdClassVariables() : void
+    {
+        $doc = '
+            query q($input:TestNestedInputObject) {
+                fieldWithNestedInputObject(input: $input)
+            }
+        ';
+
+        // executes with complex input:
+        $params = ['input' => (object) ['na' => (object) ['a' => 'foo', 'b' => ['bar'], 'c' => 'baz'], 'nb' => 'test']];
+        $result = $this->executeQuery($doc, $params);
+
+        self::assertEquals(
+            ['data' => ['fieldWithNestedInputObject' => '{"na":{"a":"foo","b":["bar"],"c":"baz"},"nb":"test"}']],
+            $result->toArray()
+        );
+    }
+
     /**
      * @see it('allows nullable inputs to be omitted')
      */

--- a/tests/Utils/CoerceValueTest.php
+++ b/tests/Utils/CoerceValueTest.php
@@ -292,6 +292,13 @@ class CoerceValueTest extends TestCase
         $this->expectError($result, 'Expected type TestInputObject to be an object.');
     }
 
+    public function testReturnsNoErrorForStdClassInput() : void
+    {
+        $result = Value::coerceValue((object) ['foo' => 123], $this->testInputObject);
+        $this->expectNoErrors($result);
+        self::assertEquals(['foo' => 123], $result['value']);
+    }
+
     /**
      * @see it('returns no error for an invalid field')
      */


### PR DESCRIPTION
Allow `\stdClass` in `GraphQL\Util\Value::coerceValue`. `\stdClass` will be cast to an associative array, and the coerced value will still be an associative array.

Useful for when you want to parse incoming variables JSON with `\stdClass` (for example, if you have custom scalars that have this requirement, but cannot distinguish between scalars and inputs at the variables level).

Note that the variables map is still required to be an associative array - one way that users can parse variables JSON in this way is to parse in `\stdClass` mode, then cast the map to an array:
```php
$variables = (array)json_decode('{"a": {}, "b": []}', false);
var_dump($variables);
/* array(2) {
  ["a"]=>
  object(stdClass)#1 (0) {
  }
  ["b"]=>
  array(0) {
  }
}
*/
```
Fixes #534.

Please let me know if the implementation, tests or docs changes are incorrect or lacking.

Thanks,
Adam
