### PR TITLE
Fix __typename field in QueryPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed error with __typename fields in QueryPlan (#544)
 - **BREAKING/BUGFIX:** Strict coercion of scalar types (#278)
 - **BREAKING:** Removed deprecated directive introspection fields (onOperation, onFragment, onField)
 - **BREAKING:** Removal of `VariablesDefaultValueAllowed` validation rule. All variables may now specify a default value.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 ## Master
 
+### Breaking: QueryPlan with introspection fields
+Now when in __typename field is present, QueryPlan return the field definition.
+
 ### Breaking (major): dropped deprecations
  - dropped deprecated `GraphQL\Schema`. Use `GraphQL\Type\Schema`.
 

--- a/src/Type/Definition/QueryPlan.php
+++ b/src/Type/Definition/QueryPlan.php
@@ -11,6 +11,7 @@ use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\SelectionSetNode;
+use GraphQL\Type\Introspection;
 use GraphQL\Type\Schema;
 use function array_diff_key;
 use function array_filter;
@@ -167,7 +168,8 @@ class QueryPlan
         foreach ($selectionSet->selections as $selectionNode) {
             if ($selectionNode instanceof FieldNode) {
                 $fieldName     = $selectionNode->name->value;
-                $type          = $parentType->getField($fieldName);
+                $typeNameDef   = Introspection::typeNameMetaFieldDef();
+                $type          = $fieldName === $typeNameDef->name ? $typeNameDef: $parentType->getField($fieldName);
                 $selectionType = $type->getType();
 
                 $subfields = [];

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -12,6 +12,7 @@ use GraphQL\Type\Definition\QueryPlan;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Introspection;
 use GraphQL\Type\Schema;
 use PHPUnit\Framework\TestCase;
 
@@ -73,6 +74,7 @@ final class QueryPlanTest extends TestCase
       query Test {
         article {
             author {
+                __typename
                 name
                 pic(width: 100, height: 200) {
                     url
@@ -114,6 +116,11 @@ final class QueryPlanTest extends TestCase
                 'type' => $author,
                 'args' => [],
                 'fields' => [
+                    '__typename' => [
+                        'type' => Introspection::typeNameMetaFieldDef()->type,
+                        'args' => [],
+                        'fields' => [],
+                    ],
                     'name' => [
                         'type' => Type::string(),
                         'args' => [],
@@ -243,6 +250,7 @@ final class QueryPlanTest extends TestCase
             'url',
             'width',
             'height',
+            '__typename',
             'name',
             'pic',
             'id',


### PR DESCRIPTION
If query contains__typename field, QueryPlan throw 'Field "__typename" is not defined for type ... '