### PR TITLE
Add test for input object not required field with default value

### DIFF
--- a/tests/Regression/SpecJuin2018/InputObjectRequiredFieldsTest.php
+++ b/tests/Regression/SpecJuin2018/InputObjectRequiredFieldsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Regression\SpecJuin2018;
+
+use GraphQL\GraphQL;
+use GraphQL\Utils\BuildSchema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Required-Fields
+ */
+class InputObjectRequiredFieldsTest extends TestCase
+{
+    public function testInputObjectNotRequiredFieldWithDefaultValueValidation()
+    {
+        $schemaStr = '
+            input FooQueryInput {
+                nonNullWithDefaultValue: String! = "foo"
+            }
+
+            type Query {
+                foo(input: FooQueryInput!): Boolean
+            }
+
+            schema {
+                query: Query
+            }
+        ';
+
+        $query = '
+            {
+                foo(input: {})
+            }
+        ';
+
+        $schema = BuildSchema::build($schemaStr);
+        $result = GraphQL::executeQuery($schema, $query, null, null, []);
+
+        $this->assertCount(0, $result->errors, 'An input field is required if it has a non‐null type and does not have a default value. Otherwise, the input object field is optional.');
+    }
+}


### PR DESCRIPTION
From the GraphQL specification of June 2018.

> An input field is required if it has a non‐null type and does not have
> a default value. Otherwise, the input object field is optional.

Note
----

I see that this bug has been fixed on the `master` branch as breaking change but not yet released.
It will be nice to backport this patch on the branch `0.13.x` with a BC layer.

I have not time to dig deeper in order to implements the patch but I provide at least a failed test for that.