### PR TITLE
Remove dead code

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -56,8 +56,6 @@ class Deferred
         try {
             $cb = $this->callback;
             $this->promise->resolve($cb());
-        } catch (Exception $e) {
-            $this->promise->reject($e);
         } catch (Throwable $e) {
             $this->promise->reject($e);
         }

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -164,7 +164,7 @@ class Error extends Exception implements JsonSerializable, ClientAware
             $source        = $error->source;
             $positions     = $error->positions;
             $extensions    = $error->extensions;
-        } elseif ($error instanceof Exception || $error instanceof Throwable) {
+        } elseif ($error instanceof Throwable) {
             $message       = $error->getMessage();
             $originalError = $error;
         } else {

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -177,7 +177,7 @@ class FormattedError
     public static function createFromException($e, $debug = false, $internalErrorMessage = null)
     {
         Utils::invariant(
-            $e instanceof Exception || $e instanceof Throwable,
+            $e instanceof Throwable,
             'Expected exception, got %s',
             Utils::getVariableType($e)
         );
@@ -244,7 +244,7 @@ class FormattedError
         }
 
         Utils::invariant(
-            $e instanceof Exception || $e instanceof Throwable,
+            $e instanceof Throwable,
             'Expected exception, got %s',
             Utils::getVariableType($e)
         );

--- a/src/Executor/Promise/Adapter/SyncPromise.php
+++ b/src/Executor/Promise/Adapter/SyncPromise.php
@@ -85,7 +85,7 @@ class SyncPromise
 
     public function reject($reason) : self
     {
-        if (! $reason instanceof Exception && ! $reason instanceof Throwable) {
+        if (! $reason instanceof Throwable) {
             throw new Exception('SyncPromise::reject() has to be called with an instance of \Throwable');
         }
 
@@ -122,8 +122,6 @@ class SyncPromise
                 if ($this->state === self::FULFILLED) {
                     try {
                         $promise->resolve($onFulfilled === null ? $this->result : $onFulfilled($this->result));
-                    } catch (Exception $e) {
-                        $promise->reject($e);
                     } catch (Throwable $e) {
                         $promise->reject($e);
                     }
@@ -134,8 +132,6 @@ class SyncPromise
                         } else {
                             $promise->resolve($onRejected($this->result));
                         }
-                    } catch (Exception $e) {
-                        $promise->reject($e);
                     } catch (Throwable $e) {
                         $promise->reject($e);
                     }

--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -69,8 +69,6 @@ class SyncPromiseAdapter implements PromiseAdapter
                     'reject',
                 ]
             );
-        } catch (Exception $e) {
-            $promise->reject($e);
         } catch (Throwable $e) {
             $promise->reject($e);
         }

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -626,8 +626,6 @@ class ReferenceExecutor implements ExecutorImplementation
             $contextValue = $this->exeContext->contextValue;
 
             return $resolveFn($rootValue, $args, $contextValue, $info);
-        } catch (Exception $error) {
-            return $error;
         } catch (Throwable $error) {
             return $error;
         }
@@ -917,12 +915,6 @@ class ReferenceExecutor implements ExecutorImplementation
     {
         try {
             return $returnType->serialize($result);
-        } catch (Exception $error) {
-            throw new InvariantViolation(
-                'Expected a value of type "' . Utils::printSafe($returnType) . '" but received: ' . Utils::printSafe($result),
-                0,
-                $error
-            );
         } catch (Throwable $error) {
             throw new InvariantViolation(
                 'Expected a value of type "' . Utils::printSafe($returnType) . '" but received: ' . Utils::printSafe($result),

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -379,8 +379,6 @@ abstract class Type implements JsonSerializable
     {
         try {
             return $this->toString();
-        } catch (Exception $e) {
-            echo $e;
         } catch (Throwable $e) {
             echo $e;
         }

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -243,11 +243,6 @@ class AST
             // to an externally represented value before converting into an AST.
             try {
                 $serialized = $type->serialize($value);
-            } catch (Exception $error) {
-                if ($error instanceof Error && $type instanceof EnumType) {
-                    return null;
-                }
-                throw $error;
             } catch (Throwable $error) {
                 if ($error instanceof Error && $type instanceof EnumType) {
                     return null;
@@ -464,8 +459,6 @@ class AST
             // no value is returned.
             try {
                 return $type->parseLiteral($valueNode, $variables);
-            } catch (Exception $error) {
-                return $undefined;
             } catch (Throwable $error) {
                 return $undefined;
             }

--- a/src/Utils/Value.php
+++ b/src/Utils/Value.php
@@ -66,16 +66,6 @@ class Value
             // the original error.
             try {
                 return self::ofValue($type->parseValue($value));
-            } catch (Exception $error) {
-                return self::ofErrors([
-                    self::coercionError(
-                        sprintf('Expected type %s', $type->name),
-                        $blameNode,
-                        $path,
-                        $error->getMessage(),
-                        $error
-                    ),
-                ]);
             } catch (Throwable $error) {
                 return self::ofErrors([
                     self::coercionError(

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -267,10 +267,10 @@ class DocumentValidator
             ? count(array_filter(
                 $value,
                 static function ($item) {
-                    return $item instanceof Exception || $item instanceof Throwable;
+                    return $item instanceof Throwable;
                 }
             )) === count($value)
-            : ($value instanceof Exception || $value instanceof Throwable);
+            : ($value instanceof Throwable);
     }
 
     public static function append(&$arr, $items)

--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -214,20 +214,6 @@ class ValuesOfCorrectType extends ValidationRule
         // may throw to indicate failure.
         try {
             $type->parseLiteral($node);
-        } catch (Exception $error) {
-            // Ensure a reference to the original error is maintained.
-            $context->reportError(
-                new Error(
-                    self::getBadValueMessage(
-                        (string) $locationType,
-                        Printer::doPrint($node),
-                        $error->getMessage(),
-                        $context,
-                        $fieldName
-                    ),
-                    $node
-                )
-            );
         } catch (Throwable $error) {
             // Ensure a reference to the original error is maintained.
             $context->reportError(


### PR DESCRIPTION
Since PHP5 support is no longer supported we can safely remove this.

Btw. I also noticed this little [todo](https://github.com/webonyx/graphql-php/blob/cd31b00dd33d73a1b5577e2c7204a3233b3d355d/src/Executor/Promise/Adapter/ReactPromiseAdapter.php#L80) but I don't have enough experience with React to implement it. How do you even use Generators with React? It doesn't seem to have coroutines like Amphp.