### PR TITLE
Add message level when using custom warning handler

### DIFF
--- a/src/Error/Warning.php
+++ b/src/Error/Warning.php
@@ -96,22 +96,26 @@ final class Warning
 
     public static function warnOnce(string $errorMessage, int $warningId, ?int $messageLevel = null) : void
     {
+        $messageLevel = $messageLevel ?: E_USER_WARNING;
+
         if (self::$warningHandler !== null) {
             $fn = self::$warningHandler;
-            $fn($errorMessage, $warningId);
+            $fn($errorMessage, $warningId, $messageLevel);
         } elseif ((self::$enableWarnings & $warningId) > 0 && ! isset(self::$warned[$warningId])) {
             self::$warned[$warningId] = true;
-            trigger_error($errorMessage, $messageLevel ?: E_USER_WARNING);
+            trigger_error($errorMessage, $messageLevel);
         }
     }
 
     public static function warn(string $errorMessage, int $warningId, ?int $messageLevel = null) : void
     {
+        $messageLevel = $messageLevel ?: E_USER_WARNING;
+
         if (self::$warningHandler !== null) {
             $fn = self::$warningHandler;
-            $fn($errorMessage, $warningId);
+            $fn($errorMessage, $warningId, $messageLevel);
         } elseif ((self::$enableWarnings & $warningId) > 0) {
-            trigger_error($errorMessage, $messageLevel ?: E_USER_WARNING);
+            trigger_error($errorMessage, $messageLevel);
         }
     }
 }


### PR DESCRIPTION
I need to make silent `error_trigger` but since it was already refused [here](https://github.com/webonyx/graphql-php/pull/234#issuecomment-362502148) I'm going to implement my own handler make it silent. This will fix the issue when using` isTypeOf` the first entry is null because of the `warnOnce` that trigger error not silently. Thanks to @murtukov while trying to write some documentation on `isTypeOf`...