### PR TITLE
Modifies the chr() check to properly handle \u0000 codes in the range…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add schema validation: Input Objects must not contain non-nullable circular references (#492)
 - Added retrieving query complexity once query has been completed (#316) 
 - Allow input types to be passed in from variables using \stdClass instead of associative arrays (#535)
+- Fixes parsing of string literals of the form \u0000 for code points in the range [128, 255] inclusive
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -442,9 +442,6 @@ class Utils
      */
     public static function chr($ord, $encoding = 'UTF-8')
     {
-        if ($ord <= 127) {
-            return chr($ord);
-        }
         if ($encoding === 'UCS-4BE') {
             return pack('N', $ord);
         }

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -442,7 +442,7 @@ class Utils
      */
     public static function chr($ord, $encoding = 'UTF-8')
     {
-        if ($ord <= 255) {
+        if ($ord <= 127) {
             return chr($ord);
         }
         if ($encoding === 'UCS-4BE') {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -8,6 +8,7 @@ use GraphQL\Utils\Utils;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use function mb_check_encoding;
 
 class UtilsTest extends TestCase
 {
@@ -19,5 +20,40 @@ class UtilsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Key requiredKey is expected to be set and not to be null');
         Utils::assign($object, [], ['requiredKey']);
+    }
+
+    /**
+     * @param int    $input
+     * @param string $expected
+     *
+     * @dataProvider    chrUtf8DataProvider
+     */
+    public function testChrUtf8Generation($input, $expected) : void
+    {
+        $result = Utils::chr($input);
+        self::assertTrue(mb_check_encoding($result, 'UTF-8'));
+        self::assertEquals($expected, $result);
+    }
+
+    public function chrUtf8DataProvider()
+    {
+        return [
+            'alphabet' => [
+                'input' => 0x0061,
+                'expected' => 'a',
+            ],
+            'numeric' => [
+                'input' => 0x0030,
+                'expected' => '0',
+            ],
+            'between 128 and 256' => [
+                'input' => 0x00E9,
+                'expected' => 'é',
+            ],
+            'emoji' => [
+                'input' => 0x231A,
+                'expected' => '⌚',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
… [127, 255] in the lexer

This caused the lexer to output invalid UTF-8 for input like 'pok\u00E9mon'. The output for the é
would be the decimal byte 233, which would indicate that it should be a 4 byte unicode sequence,
but the following bytes didn't have the leading 10 prefix, so the sequence was invalid UTF-8.