### PR TITLE
Modifies the lexer to parse UTF-16 surrogate pairs in string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added retrieving query complexity once query has been completed (#316) 
 - Allow input types to be passed in from variables using \stdClass instead of associative arrays (#535)
 - Fixes parsing of string literals of the form \u0000 for code points in the range [128, 255] inclusive
+- Parse UTF-16 surrogate pairs within string literals 
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -9,8 +9,11 @@ use GraphQL\Utils\BlockString;
 use GraphQL\Utils\Utils;
 use function chr;
 use function hexdec;
+use function mb_convert_encoding;
 use function ord;
+use function pack;
 use function preg_match;
+use function substr;
 
 /**
  * A Lexer is a stateful stream generator in that every time
@@ -522,8 +525,27 @@ class Lexer
                                 'Invalid character escape sequence: \\u' . $hex
                             );
                         }
+
                         $code = hexdec($hex);
+
+                        // UTF-16 surrogate pair detection and handling.
+                        $high_order_byte = $code >> 8;
+                        if (0xD8 <= $high_order_byte && $high_order_byte <= 0xDF) {
+                            [$utf_16_continuation] = $this->readChars(6, true);
+                            if (! preg_match('/\u[0-9a-fA-F]{4}/', $utf_16_continuation)) {
+                                throw new SyntaxError(
+                                    $this->source,
+                                    $this->position - 5,
+                                    'Invalid UTF-16 trailing surrogate: ' . $utf_16_continuation
+                                );
+                            }
+                            $surrogate_pair_hex = $hex . substr($utf_16_continuation, 2, 4);
+                            $value             .= mb_convert_encoding(pack('H*', $surrogate_pair_hex), 'UTF-8', 'UTF-16');
+                            break;
+                        }
+
                         $this->assertValidStringCharacterCode($code, $position - 2);
+
                         $value .= Utils::chr($code);
                         break;
                     default:

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -529,18 +529,18 @@ class Lexer
                         $code = hexdec($hex);
 
                         // UTF-16 surrogate pair detection and handling.
-                        $high_order_byte = $code >> 8;
-                        if (0xD8 <= $high_order_byte && $high_order_byte <= 0xDF) {
-                            [$utf_16_continuation] = $this->readChars(6, true);
-                            if (! preg_match('/^\\\u[0-9a-fA-F]{4}$/', $utf_16_continuation)) {
+                        $highOrderByte = $code >> 8;
+                        if (0xD8 <= $highOrderByte && $highOrderByte <= 0xDF) {
+                            [$utf16Continuation] = $this->readChars(6, true);
+                            if (! preg_match('/^\\\u[0-9a-fA-F]{4}$/', $utf16Continuation)) {
                                 throw new SyntaxError(
                                     $this->source,
                                     $this->position - 5,
-                                    'Invalid UTF-16 trailing surrogate: ' . $utf_16_continuation
+                                    'Invalid UTF-16 trailing surrogate: ' . $utf16Continuation
                                 );
                             }
-                            $surrogate_pair_hex = $hex . substr($utf_16_continuation, 2, 4);
-                            $value             .= mb_convert_encoding(pack('H*', $surrogate_pair_hex), 'UTF-8', 'UTF-16');
+                            $surrogatePairHex = $hex . substr($utf16Continuation, 2, 4);
+                            $value           .= mb_convert_encoding(pack('H*', $surrogatePairHex), 'UTF-8', 'UTF-16');
                             break;
                         }
 

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -532,7 +532,7 @@ class Lexer
                         $high_order_byte = $code >> 8;
                         if (0xD8 <= $high_order_byte && $high_order_byte <= 0xDF) {
                             [$utf_16_continuation] = $this->readChars(6, true);
-                            if (! preg_match('/\u[0-9a-fA-F]{4}/', $utf_16_continuation)) {
+                            if (! preg_match('/^\\\u[0-9a-fA-F]{4}$/', $utf_16_continuation)) {
                                 throw new SyntaxError(
                                     $this->source,
                                     $this->position - 5,

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -443,7 +443,7 @@ class LexerTest extends TestCase
             ['"bad \\uD835"', 'Invalid UTF-16 trailing surrogate: ', $this->loc(1, 13)],
             ['"bad \\uD835\\u1"', "Invalid UTF-16 trailing surrogate: \\u1", $this->loc(1, 13)],
             ['"bad \\uD835\\u1 esc"', "Invalid UTF-16 trailing surrogate: \\u1 es", $this->loc(1, 13)],
-            ['"bad \\uD835uuFFFF esc"', "Invalid UTF-16 trailing surrogate: uuFFFF", $this->loc(1, 13)],
+            ['"bad \\uD835uuFFFF esc"', 'Invalid UTF-16 trailing surrogate: uuFFFF', $this->loc(1, 13)],
             ['"bad \\uD835\\u0XX1 esc"', "Invalid UTF-16 trailing surrogate: \\u0XX1", $this->loc(1, 13)],
             ['"bad \\uD835\\uXXXX esc"', "Invalid UTF-16 trailing surrogate: \\uXXXX", $this->loc(1, 13)],
             ['"bad \\uD835\\uFXXX esc"', "Invalid UTF-16 trailing surrogate: \\uFXXX", $this->loc(1, 13)],

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -295,6 +295,16 @@ class LexerTest extends TestCase
             ],
             (array) $this->lexOne('"\u1234\u5678\u90AB\uCDEF"')
         );
+
+        self::assertArraySubset(
+            [
+                'kind' => Token::STRING,
+                'start' => 0,
+                'end' => 41,
+                'value' => '𝕌𝕋𝔽-16',
+            ],
+            (array) $this->lexOne('"\ud835\udd4C\ud835\udd4B\ud835\udd3d-16"')
+        );
     }
 
     /**
@@ -430,6 +440,13 @@ class LexerTest extends TestCase
             ['"bad \\uXXXX esc"', "Invalid character escape sequence: \\uXXXX", $this->loc(1, 7)],
             ['"bad \\uFXXX esc"', "Invalid character escape sequence: \\uFXXX", $this->loc(1, 7)],
             ['"bad \\uXXXF esc"', "Invalid character escape sequence: \\uXXXF", $this->loc(1, 7)],
+            ['"bad \\uD835"', 'Invalid UTF-16 trailing surrogate: ', $this->loc(1, 13)],
+            ['"bad \\uD835\\u1"', "Invalid UTF-16 trailing surrogate: \\u1", $this->loc(1, 13)],
+            ['"bad \\uD835\\u1 esc"', "Invalid UTF-16 trailing surrogate: \\u1 es", $this->loc(1, 13)],
+            ['"bad \\uD835\\u0XX1 esc"', "Invalid UTF-16 trailing surrogate: \\u0XX1", $this->loc(1, 13)],
+            ['"bad \\uD835\\uXXXX esc"', "Invalid UTF-16 trailing surrogate: \\uXXXX", $this->loc(1, 13)],
+            ['"bad \\uD835\\uFXXX esc"', "Invalid UTF-16 trailing surrogate: \\uFXXX", $this->loc(1, 13)],
+            ['"bad \\uD835\\uXXXF esc"', "Invalid UTF-16 trailing surrogate: \\uXXXF", $this->loc(1, 13)],
         ];
     }
 

--- a/tests/Language/LexerTest.php
+++ b/tests/Language/LexerTest.php
@@ -443,6 +443,7 @@ class LexerTest extends TestCase
             ['"bad \\uD835"', 'Invalid UTF-16 trailing surrogate: ', $this->loc(1, 13)],
             ['"bad \\uD835\\u1"', "Invalid UTF-16 trailing surrogate: \\u1", $this->loc(1, 13)],
             ['"bad \\uD835\\u1 esc"', "Invalid UTF-16 trailing surrogate: \\u1 es", $this->loc(1, 13)],
+            ['"bad \\uD835uuFFFF esc"', "Invalid UTF-16 trailing surrogate: uuFFFF", $this->loc(1, 13)],
             ['"bad \\uD835\\u0XX1 esc"', "Invalid UTF-16 trailing surrogate: \\u0XX1", $this->loc(1, 13)],
             ['"bad \\uD835\\uXXXX esc"', "Invalid UTF-16 trailing surrogate: \\uXXXX", $this->loc(1, 13)],
             ['"bad \\uD835\\uFXXX esc"', "Invalid UTF-16 trailing surrogate: \\uFXXX", $this->loc(1, 13)],


### PR DESCRIPTION
Here's the companion change to https://github.com/webonyx/graphql-php/pull/554. Happy to make any changes in the lexer to make it fit in better with the surrounding code