### PR TITLE
Use phpstan instead of scrutinizer's own checker

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,6 +20,7 @@ build:
                         analysis:
                           file: phpstan-checkstyle.xml
                           format: 'general-checkstyle'
+                    - php-scrutinizer-run
 
 tools:
     external_code_coverage:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,7 @@
 build:
+    dependencies:
+        override:
+            - command: 'composer install --ignore-platform-reqs --no-interaction'
     nodes:
         analysis:
             environment:
@@ -12,11 +15,7 @@ build:
                 override: true
             tests:
                 override:
-                    - php-scrutinizer-run
-
-    dependencies:
-        override:
-            - composer install --ignore-platform-reqs --no-interaction
+                    - command: './vendor/bin/phpstan analyse --ansi --memory-limit 256M'
 
 tools:
     external_code_coverage:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,7 @@
+checks:
+    php:
+        code_rating: true
+        duplication: true
 build:
     dependencies:
         override:
@@ -21,8 +25,7 @@ build:
                           format: 'general-checkstyle'
 
 tools:
-    external_code_coverage:
-        timeout: 3600
+  php_code_coverage: true
 
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,12 +15,10 @@ build:
                 override: true
             tests:
                 override:
-                    -
-                        command: ./vendor/bin/phpstan analyse --ansi --memory-limit 256M --error-format=checkstyle | sed '/^\s*$/d' > phpstan-checkstyle.xml
-                        analysis:
+                    - command: ./vendor/bin/phpstan analyse --ansi --memory-limit 256M --error-format=checkstyle | sed '/^\s*$/d' > phpstan-checkstyle.xml
+                      analysis:
                           file: phpstan-checkstyle.xml
                           format: 'general-checkstyle'
-                    - php-scrutinizer-run
 
 tools:
     external_code_coverage:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,6 @@
 checks:
     php:
         code_rating: true
-        duplication: true
 build:
     dependencies:
         override:
@@ -28,7 +27,4 @@ tools:
   php_code_coverage: true
 
 build_failure_conditions:
-    - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
-    - 'issues.label("coding-style").new.exists'                 # No new coding style issues allowed
-    - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,7 +15,11 @@ build:
                 override: true
             tests:
                 override:
-                    - command: './vendor/bin/phpstan analyse --ansi --memory-limit 256M'
+                    -
+                        command: ./vendor/bin/phpstan analyse --ansi --memory-limit 256M --error-format=checkstyle | sed '/^\s*$/d' > phpstan-checkstyle.xml
+                        analysis:
+                          file: phpstan-checkstyle.xml
+                          format: 'general-checkstyle'
 
 tools:
     external_code_coverage:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
 
     paths:
         - %currentWorkingDirectory%/src


### PR DESCRIPTION
Experimenting with replacing Scrutinizer's proprietary checker with PHPStan.

This doesn't work yet--supposedly any tool that implements the `general-checkstyle` format can replace Scrutinizer's own checks, but while Scrutinizer does parse the new data, it doesn't seem to display it in its report. Please let me know if you have any ideas...