### PR TITLE
fix phpdoc annotation for GraphQL\Type\Definition\ObjectType::$resolveFieldFn

### DIFF
--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -30,7 +30,7 @@ class FieldDefinition
      * Callback for resolving field value given parent value.
      * Mutually exclusive with `map`
      *
-     * @var callable
+     * @var callable|null
      */
     public $resolveFn;
 
@@ -38,7 +38,7 @@ class FieldDefinition
      * Callback for mapping list of parent values to list of field values.
      * Mutually exclusive with `resolve`
      *
-     * @var callable
+     * @var callable|null
      */
     public $mapFn;
 

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -62,7 +62,7 @@ class ObjectType extends Type implements OutputType, CompositeType, NullableType
     /** @var ObjectTypeExtensionNode[] */
     public $extensionASTNodes;
 
-    /** @var callable */
+    /** @var callable|null */
     public $resolveFieldFn;
 
     /** @var FieldDefinition[] */


### PR DESCRIPTION
The field should be nullable (as per definition in constructor) but the phpDoc annotation definition do not report the nullable type.