### PR TITLE
Remove config validation section

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,13 +1,3 @@
-# Config Validation
-Defining types using arrays may be error-prone, but **graphql-php** provides config validation
-tool to report when config has unexpected structure. 
-
-This validation tool is **disabled by default** because it is time-consuming operation which only 
-makes sense during development.
-
-To enable validation - call: `GraphQL\Type\Definition\Config::enableValidation();` in your bootstrap
-but make sure to restrict it to debug/development mode only.
-
 # Type Registry
 **graphql-php** expects that each type in Schema is presented by single instance. Therefore
 if you define your types as separate PHP classes you need to ensure that each type is referenced only once.


### PR DESCRIPTION
At first I wanted to improve it but then I realized it's basically a duplicate of https://github.com/webonyx/graphql-php/blob/master/docs/type-system/schema.md#schema-validation

This "duplicate" likely exactly lead to this situation that there's now outdated information.

TL;DR: I think simply removing it here is enough as there's only one clear location now discussing schema validation