### PR TITLE
Make query batching implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **BREAKING:** Removed deprecated directive introspection fields (onOperation, onFragment, onField)
 - **BREAKING:** Removal of `VariablesDefaultValueAllowed` validation rule. All variables may now specify a default value.
 - **BREAKING:** renamed `ProvidedNonNullArguments` to `ProvidedRequiredArguments` (no longer require values to be provided to non-null arguments which provide a default value).
+- **BREAKING:** Query batching is on by default
 - Add schema validation: Input Objects must not contain non-nullable circular references (#492)
 - Added retrieving query complexity once query has been completed (#316) 
 - Allow input types to be passed in from variables using \stdClass instead of associative arrays (#535)

--- a/docs/executing-queries.md
+++ b/docs/executing-queries.md
@@ -100,7 +100,6 @@ rootValue  | `mixed` | Any value that represents a root of your data graph. It i
 context  | `mixed` | Any value that holds information shared between all field resolvers. Most often they use it to pass currently logged in user, locale details, etc.<br><br>It will be available as the 3rd argument in all field resolvers. (see section on [Field Definitions](type-system/object-types.md#field-configuration-options) for reference) **graphql-php** never modifies this value and passes it *as is* to all underlying resolvers.
 fieldResolver | `callable` | A resolver function to use when one is not provided by the schema. If not provided, the [default field resolver is used](data-fetching.md#default-field-resolver).
 validationRules | `array` or `callable` | A set of rules for query validation step. The default value is all available rules. The empty array would allow skipping query validation (may be convenient for persisted queries which are validated before persisting and assumed valid during execution).<br><br>Pass `callable` to return different validation rules for different queries (e.g. empty array for persisted query and a full list of rules for regular queries). When passed, it is expected to have the following signature: <br><br> **function ([OperationParams](reference.md#graphqlserveroperationparams) $params, DocumentNode $node, $operationType): array**
-queryBatching | `bool` | Flag indicating whether this server supports query batching ([apollo-style](https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862)).<br><br> Defaults to **false**
 debug | `int` | Debug flags. See [docs on error debugging](error-handling.md#debugging-tools) (flag values are the same).
 persistentQueryLoader | `callable` | A function which is called to fetch actual query when server encounters **queryId** in request vs **query**.<br><br> The server does not implement persistence part (which you will have to build on your own), but it allows you to execute queries which were persisted previously.<br><br> Expected function signature:<br> **function ($queryId, [OperationParams](reference.md#graphqlserveroperationparams) $params)** <br><br>Function is expected to return query **string** or parsed **DocumentNode** <br><br> [Read more about persisted queries](https://dev-blog.apollodata.com/persisted-graphql-queries-with-apollo-client-119fd7e6bba5).
 errorFormatter | `callable` | Custom error formatter. See [error handling docs](error-handling.md#custom-error-handling-and-formatting).
@@ -127,7 +126,7 @@ $server = new StandardServer($config);
 ```
 
 ## Query batching
-Standard Server supports query batching ([apollo-style](https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862)).
+Standard Server supports batching queries used by clients like ([Apollo](https://dev-blog.apollodata.com/query-batching-in-apollo-63acfd859862)).
 
 One of the major benefits of Server over a sequence of **executeQuery()** calls is that
 [Deferred resolvers](data-fetching.md#solving-n1-problem) won't be isolated in queries.
@@ -145,16 +144,6 @@ So for example following batch will require single DB request (if user field is 
     "query": "{user(id: 3) { id }}"
   }
 ]
-```
-
-To enable query batching, pass **queryBatching** option in server config:
-```php
-<?php
-use GraphQL\Server\StandardServer;
-
-$server = new StandardServer([
-    'queryBatching' => true
-]);
 ```
 
 # Custom Validation Rules

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1877,19 +1877,6 @@ function setDebug($set = true)
 
 ```php
 /**
- * Allow batching queries (disabled by default)
- *
- * @param bool $enableBatching
- *
- * @return self
- *
- * @api
- */
-function setQueryBatching($enableBatching)
-```
-
-```php
-/**
  * @return self
  *
  * @api

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -228,7 +228,7 @@ class Helper
         $result         = [];
 
         foreach ($operations as $operation) {
-            $result[] = $this->promiseToExecuteOperation($promiseAdapter, $config, $operation, true);
+            $result[] = $this->promiseToExecuteOperation($promiseAdapter, $config, $operation);
         }
 
         $result = $promiseAdapter->all($result);
@@ -241,24 +241,11 @@ class Helper
         return $result;
     }
 
-    /**
-     * @param bool $isBatch
-     *
-     * @return Promise
-     */
-    private function promiseToExecuteOperation(
-        PromiseAdapter $promiseAdapter,
-        ServerConfig $config,
-        OperationParams $op,
-        $isBatch = false
-    ) {
+    private function promiseToExecuteOperation(PromiseAdapter $promiseAdapter, ServerConfig $config, OperationParams $op) : Promise
+    {
         try {
             if (! $config->getSchema()) {
                 throw new InvariantViolation('Schema is required for the server');
-            }
-
-            if ($isBatch && ! $config->getQueryBatching()) {
-                throw new RequestError('Batched queries are not supported by this server');
             }
 
             $errors = $this->validateOperationParams($op);

--- a/src/Server/ServerConfig.php
+++ b/src/Server/ServerConfig.php
@@ -72,9 +72,6 @@ class ServerConfig
     /** @var bool */
     private $debug = false;
 
-    /** @var bool */
-    private $queryBatching = false;
-
     /** @var ValidationRule[]|callable */
     private $validationRules;
 
@@ -223,18 +220,6 @@ class ServerConfig
     }
 
     /**
-     * Allow batching queries (disabled by default)
-     *
-     * @api
-     */
-    public function setQueryBatching(bool $enableBatching) : self
-    {
-        $this->queryBatching = $enableBatching;
-
-        return $this;
-    }
-
-    /**
      * @return self
      *
      * @api
@@ -324,13 +309,5 @@ class ServerConfig
     public function getDebug()
     {
         return $this->debug;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getQueryBatching()
-    {
-        return $this->queryBatching;
     }
 }

--- a/tests/Server/QueryExecutionTest.php
+++ b/tests/Server/QueryExecutionTest.php
@@ -277,42 +277,12 @@ class QueryExecutionTest extends ServerTestCase
         return $result;
     }
 
-    public function testBatchedQueriesAreDisabledByDefault() : void
-    {
-        $batch = [
-            ['query' => '{invalid}'],
-            ['query' => '{f1,fieldWithSafeException}'],
-        ];
-
-        $result = $this->executeBatchedQuery($batch);
-
-        $expected = [
-            [
-                'errors' => [
-                    [
-                        'message'  => 'Batched queries are not supported by this server',
-                        'extensions' => ['category' => 'request'],
-                    ],
-                ],
-            ],
-            [
-                'errors' => [
-                    [
-                        'message'  => 'Batched queries are not supported by this server',
-                        'extensions' => ['category' => 'request'],
-                    ],
-                ],
-            ],
-        ];
-
-        self::assertEquals($expected[0], $result[0]->toArray());
-        self::assertEquals($expected[1], $result[1]->toArray());
-    }
-
     /**
      * @param mixed[][] $qs
+     *
+     * @return ExecutionResult[]
      */
-    private function executeBatchedQuery(array $qs)
+    private function executeBatchedQuery(array $qs) : array
     {
         $batch = [];
         foreach ($qs as $params) {
@@ -462,8 +432,6 @@ class QueryExecutionTest extends ServerTestCase
 
     public function testExecutesBatchedQueries() : void
     {
-        $this->config->setQueryBatching(true);
-
         $batch = [
             ['query' => '{invalid}'],
             ['query' => '{f1,fieldWithSafeException}'],
@@ -517,7 +485,6 @@ class QueryExecutionTest extends ServerTestCase
         $calls = [];
 
         $this->config
-            ->setQueryBatching(true)
             ->setRootValue('1')
             ->setContext([
                 'buffer' => static function ($num) use (&$calls) {

--- a/tests/Server/ServerConfigTest.php
+++ b/tests/Server/ServerConfigTest.php
@@ -28,7 +28,6 @@ class ServerConfigTest extends TestCase
         self::assertNull($config->getFieldResolver());
         self::assertNull($config->getPersistentQueryLoader());
         self::assertFalse($config->getDebug());
-        self::assertFalse($config->getQueryBatching());
     }
 
     public function testAllowsSettingSchema() : void
@@ -192,7 +191,6 @@ class ServerConfigTest extends TestCase
             'persistentQueryLoader' => static function () {
             },
             'debug'                 => true,
-            'queryBatching'         => true,
         ];
 
         $config = ServerConfig::create($arr);
@@ -206,7 +204,6 @@ class ServerConfigTest extends TestCase
         self::assertSame($arr['fieldResolver'], $config->getFieldResolver());
         self::assertSame($arr['persistentQueryLoader'], $config->getPersistentQueryLoader());
         self::assertTrue($config->getDebug());
-        self::assertTrue($config->getQueryBatching());
     }
 
     public function testThrowsOnInvalidArrayKey() : void


### PR DESCRIPTION
Query batching is IMO client's thing and server should support it implicitly. Looking at the code, the only thing the _query batching feature toggle_ did was throwing exception when batch request was received and batching was not enabled. 

Also, Apollo [states](https://www.apollographql.com/docs/react/networking/network-layer/#query-batching): 

> Batching works only with server that support batched queries (for example graphql-server). Batched requests to servers that don’t support batching will fail.

StandardServer supports it. The flag had no other behaviour so I came to conclusion was just adding unnecessary complexity. WDYT?