### PR TITLE
Drop scrutinizer checks as they're handled by PHPStan and code sniffer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -24,6 +24,4 @@ tools:
 
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
-    - 'issues.label("coding-style").new.exists'                 # No new coding style issues allowed
-    - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection


### PR DESCRIPTION
I'd like to jump before https://github.com/webonyx/graphql-php/pull/569 because IMO this is easier to merge and addresses the issue partially. The concern expressed there about build failures on Scrutinizer seems 100% valid to me. 

Builds often fail because of Scrutinizer reporting "new major severity issues introduction" even though PHPStan's smarter analysis is fine with the modified code. Eg. PHPStan can narrow the type based on PHPUnit assertion `self::assertInstanceOf()`, [Scrutinizer can not](https://scrutinizer-ci.com/g/webonyx/graphql-php/inspections/ab65f846-14b6-4050-b8ba-08a53ce20e31/issues/files/tests/Server/QueryExecutionTest.php?status=failed&conditionIds%5B0%5D=413156).

Running CS check on Scrutinizer is pointless, we run it in Travis.