### PR TITLE
Scrutinizer: Analyze only src

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,6 +22,10 @@ tools:
     external_code_coverage:
         timeout: 3600
 
+filter:
+    paths:
+        - "src/"
+
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection


### PR DESCRIPTION
I noticed [this failure](https://scrutinizer-ci.com/g/webonyx/graphql-php/inspections/68739c79-cb95-486f-8742-0ad3701250ec) in build from https://github.com/webonyx/graphql-php/pull/539

What about this change? Tests are here often more "messy", long, and have high complexity, I'd rather focus on src with these checks.