### PR TITLE
Fix ServerConfig and SchemaConfig

### DIFF
--- a/src/Server/ServerConfig.php
+++ b/src/Server/ServerConfig.php
@@ -54,7 +54,7 @@ class ServerConfig
         return $instance;
     }
 
-    /** @var Schema */
+    /** @var Schema|null */
     private $schema;
 
     /** @var mixed|callable */
@@ -69,22 +69,22 @@ class ServerConfig
     /** @var callable|null */
     private $errorsHandler;
 
-    /** @var bool */
+    /** @var bool|int */
     private $debug = false;
 
     /** @var bool */
     private $queryBatching = false;
 
-    /** @var ValidationRule[]|callable */
+    /** @var ValidationRule[]|callable|null */
     private $validationRules;
 
-    /** @var callable */
+    /** @var callable|null */
     private $fieldResolver;
 
-    /** @var PromiseAdapter */
+    /** @var PromiseAdapter|null */
     private $promiseAdapter;
 
-    /** @var callable */
+    /** @var callable|null */
     private $persistentQueryLoader;
 
     /**
@@ -158,7 +158,7 @@ class ServerConfig
     /**
      * Set validation rules for this server.
      *
-     * @param ValidationRule[]|callable $validationRules
+     * @param ValidationRule[]|callable|null $validationRules
      *
      * @return self
      *
@@ -263,7 +263,7 @@ class ServerConfig
     }
 
     /**
-     * @return Schema
+     * @return Schema|null
      */
     public function getSchema()
     {
@@ -287,7 +287,7 @@ class ServerConfig
     }
 
     /**
-     * @return PromiseAdapter
+     * @return PromiseAdapter|null
      */
     public function getPromiseAdapter()
     {
@@ -295,7 +295,7 @@ class ServerConfig
     }
 
     /**
-     * @return ValidationRule[]|callable
+     * @return ValidationRule[]|callable|null
      */
     public function getValidationRules()
     {
@@ -303,7 +303,7 @@ class ServerConfig
     }
 
     /**
-     * @return callable
+     * @return callable|null
      */
     public function getFieldResolver()
     {
@@ -311,7 +311,7 @@ class ServerConfig
     }
 
     /**
-     * @return callable
+     * @return callable|null
      */
     public function getPersistentQueryLoader()
     {
@@ -319,7 +319,7 @@ class ServerConfig
     }
 
     /**
-     * @return bool
+     * @return bool|int
      */
     public function getDebug()
     {

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -72,7 +72,7 @@ class Schema
     private $validationErrors;
 
     /** @var SchemaTypeExtensionNode[] */
-    public $extensionASTNodes;
+    public $extensionASTNodes = [];
 
     /**
      * @param mixed[]|SchemaConfig $config
@@ -448,7 +448,7 @@ class Schema
     }
 
     /**
-     * @return SchemaDefinitionNode
+     * @return SchemaDefinitionNode|null
      */
     public function getAstNode()
     {

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -27,32 +27,32 @@ use function is_callable;
  */
 class SchemaConfig
 {
-    /** @var ObjectType */
+    /** @var ObjectType|null */
     public $query;
 
-    /** @var ObjectType */
+    /** @var ObjectType|null */
     public $mutation;
 
-    /** @var ObjectType */
+    /** @var ObjectType|null */
     public $subscription;
 
     /** @var Type[]|callable */
-    public $types;
+    public $types = [];
 
     /** @var Directive[] */
-    public $directives;
+    public $directives = [];
 
     /** @var callable|null */
     public $typeLoader;
 
-    /** @var SchemaDefinitionNode */
+    /** @var SchemaDefinitionNode|null */
     public $astNode;
 
     /** @var bool */
-    public $assumeValid;
+    public $assumeValid = false;
 
     /** @var SchemaTypeExtensionNode[] */
-    public $extensionASTNodes;
+    public $extensionASTNodes = [];
 
     /**
      * Converts an array of options to instance of SchemaConfig
@@ -115,7 +115,7 @@ class SchemaConfig
     }
 
     /**
-     * @return SchemaDefinitionNode
+     * @return SchemaDefinitionNode|null
      */
     public function getAstNode()
     {
@@ -133,7 +133,7 @@ class SchemaConfig
     }
 
     /**
-     * @return ObjectType
+     * @return ObjectType|null
      *
      * @api
      */
@@ -143,7 +143,7 @@ class SchemaConfig
     }
 
     /**
-     * @param ObjectType $query
+     * @param ObjectType|null $query
      *
      * @return SchemaConfig
      *
@@ -157,7 +157,7 @@ class SchemaConfig
     }
 
     /**
-     * @return ObjectType
+     * @return ObjectType|null
      *
      * @api
      */
@@ -167,7 +167,7 @@ class SchemaConfig
     }
 
     /**
-     * @param ObjectType $mutation
+     * @param ObjectType|null $mutation
      *
      * @return SchemaConfig
      *
@@ -181,7 +181,7 @@ class SchemaConfig
     }
 
     /**
-     * @return ObjectType
+     * @return ObjectType|null
      *
      * @api
      */
@@ -191,7 +191,7 @@ class SchemaConfig
     }
 
     /**
-     * @param ObjectType $subscription
+     * @param ObjectType|null $subscription
      *
      * @return SchemaConfig
      *
@@ -205,13 +205,13 @@ class SchemaConfig
     }
 
     /**
-     * @return Type[]
+     * @return Type[]|callable
      *
      * @api
      */
     public function getTypes()
     {
-        return $this->types ?: [];
+        return $this->types;
     }
 
     /**
@@ -235,7 +235,7 @@ class SchemaConfig
      */
     public function getDirectives()
     {
-        return $this->directives ?: [];
+        return $this->directives;
     }
 
     /**
@@ -253,7 +253,7 @@ class SchemaConfig
     }
 
     /**
-     * @return callable
+     * @return callable|null
      *
      * @api
      */

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -609,11 +609,7 @@ class SchemaExtender
             }
         }
 
-        $schemaExtensionASTNodes = count($schemaExtensions) > 0
-            ? ($schema->extensionASTNodes
-                ? array_merge($schema->extensionASTNodes, $schemaExtensions)
-                : $schemaExtensions)
-            : $schema->extensionASTNodes;
+        $schemaExtensionASTNodes = array_merge($schema->extensionASTNodes, $schemaExtensions);
 
         $types = array_merge(
             // Iterate through all types, getting the type definition for each, ensuring


### PR DESCRIPTION
According to setDebug it can be `int` as well.

It would be nice to document in the docblock of setDebug what `int` values are `true` and `false` equivalent to. Can you tell me?

----

Reasons for WIP:

There are more issues here... for example `fieldResolver` can be `null`. I need to check everything.

Then I want to check SchemaConfig too - query, mutation and subscription are all nullable for instance...

