### PR TITLE
Fix CoroutineExecutor

### DIFF
--- a/src/Experimental/Executor/CoroutineExecutor.php
+++ b/src/Experimental/Executor/CoroutineExecutor.php
@@ -367,7 +367,7 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
 
         $this->run();
 
-        if ($this->pending > 0) {
+        if ($this->pending > 0 || $this->doResolve === null) {
             return;
         }
 

--- a/src/Experimental/Executor/CoroutineExecutor.php
+++ b/src/Experimental/Executor/CoroutineExecutor.php
@@ -91,7 +91,7 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
     /** @var int|null */
     private $pending;
 
-    /** @var callable */
+    /** @var callable|null */
     private $doResolve;
 
     public function __construct(
@@ -177,6 +177,7 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
         $this->queue      = new SplQueue();
         $this->schedule   = new SplQueue();
         $this->pending    = 0;
+        $this->doResolve  = null;
 
         $this->collector = new Collector($this->schema, $this);
         $this->collector->initialize($this->documentNode, $this->operationName);
@@ -245,6 +246,7 @@ class CoroutineExecutor implements Runtime, ExecutorImplementation
         $this->queue          = new SplQueue();
         $this->schedule       = new SplQueue();
         $this->pending        = null;
+        $this->doResolve      = null;
         $this->collector      = null;
         $this->variableValues = null;
 


### PR DESCRIPTION
Fixes this bug:

```
Error: Function name must be a string

<projectpath>/vendor/webonyx/graphql-php/src/Experimental/Executor/CoroutineExecutor.php:367
```

I wrote down how this happened here: https://github.com/webonyx/graphql-php/pull/551#issuecomment-563269245
