### PR TITLE
Fix branch coverage reporting

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
-service_name: github-actions
 coverage_clover: /tmp/coverage/*.xml
 json_path: /tmp/coverage/coverage.json

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
     name: PHP ${{ matrix.php }} Test ${{ matrix.env }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install PHP
       uses: shivammathur/setup-php@1.7.0
@@ -55,7 +55,7 @@ jobs:
     name: Coding Standard
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install PHP
       uses: shivammathur/setup-php@1.7.0
@@ -86,7 +86,7 @@ jobs:
     name: PHPStan
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install PHP
       uses: shivammathur/setup-php@1.7.0
@@ -117,7 +117,9 @@ jobs:
     name: Code Coverage
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
 
     - name: Install PHP
       uses: shivammathur/setup-php@1.7.0
@@ -148,12 +150,12 @@ jobs:
       continue-on-error: true
 
     - name: Code coverage
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_GIT_COMMIT: ${{ github.sha }}
-        COVERALLS_GIT_BRANCH: ${{ github.ref }}
       run: |
         ./vendor/bin/phpunit --coverage-clover /tmp/coverage/clover_executor.xml
         EXECUTOR=coroutine ./vendor/bin/phpunit --coverage-clover /tmp/coverage/clover_executor-coroutine.xml
-        wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.2.0/php-coveralls.phar
-        php7.1 php-coveralls.phar --verbose
+
+    - name: Report to Coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_RUN_LOCALLY: 1
+      run: vendor/bin/php-coveralls --verbose

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
     "graphql",
     "API"
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/simPod/php-coveralls"
+    }
+  ],
   "require": {
     "php": "^7.1||^8.0",
     "ext-json": "*",
@@ -15,6 +21,7 @@
   },
   "require-dev": {
     "doctrine/coding-standard": "^6.0",
+    "php-coveralls/php-coveralls": "dev-add-support-for-github-actions@dev",
     "phpbench/phpbench": "^0.14",
     "phpstan/phpstan": "0.12.2",
     "phpstan/phpstan-phpunit": "0.12.1",


### PR DESCRIPTION
This resolves git branch reporting to Coveralls (https://github.com/webonyx/graphql-php/pull/603#issuecomment-570932469)

By default, GA checkout gets into detached head state on commit ref so it was not possible for Coveralls phar to fetch git info. Also there needs some magic to be done to issue proper request to coveralls.io, should be handled through @Smolevich's PR to php-coveralls (it needed slight modifications tho https://github.com/Smolevich/php-coveralls/pull/1)