### PR TITLE
Temporarily use php-coveralls mirror to bypass Github limits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
     "graphql",
     "API"
   ],
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/simPod/php-coveralls"
-    }
-  ],
   "require": {
     "php": "^7.1||^8.0",
     "ext-json": "*",
@@ -21,7 +15,6 @@
   },
   "require-dev": {
     "doctrine/coding-standard": "^6.0",
-    "php-coveralls/php-coveralls": "dev-add-support-for-github-actions#b9c9d4c8ffdf837c589aba5da3f83e660350bfea",
     "phpbench/phpbench": "^0.14",
     "phpstan/phpstan": "0.12.2",
     "phpstan/phpstan-phpunit": "0.12.1",
@@ -30,6 +23,7 @@
     "phpunit/phpunit": "^7.2",
     "psr/http-message": "^1.0",
     "react/promise": "2.*",
+    "simpod/php-coveralls-mirror": "^3.0",
     "squizlabs/php_codesniffer": "^3.5.2"
   },
   "config": {


### PR DESCRIPTION
Instead of fork I released it through Packagist

See https://github.com/webonyx/graphql-php/commit/949e6f2057ab38decfd5242f5eb2a229899357e0/checks?check_suite_id=404111226  
https://travis-ci.org/webonyx/graphql-php/builds/637931105

Until this gets merged and released https://github.com/php-coveralls/php-coveralls/pull/275