### PR TITLE
Fixed assumption that throwables from custom scalar are always client-safe

### DIFF
--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -224,7 +224,11 @@ class ValuesOfCorrectType extends ValidationRule
                         $context,
                         $fieldName
                     ),
-                    $node
+                    $node,
+                    null,
+                    null,
+                    null,
+                    $error
                 )
             );
         }

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -1361,6 +1361,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
             'Field "invalidArg" argument "arg" requires type Invalid, found 123; Invalid scalar is always invalid: 123',
             $errors[0]->getMessage()
         );
+        self::assertFalse($errors[0]->isClientSafe());
     }
 
     /**


### PR DESCRIPTION
Exceptions thrown in parseLiteral are currently caught and thrown as `Error` with client-safe true.