### PR TITLE
Add an option to Schema Printer to exclude descriptions

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -166,7 +166,7 @@ class SchemaPrinter
 
     private static function printDescription($options, $def, $indentation = '', $firstInBlock = true) : string
     {
-        if (! $def->description) {
+        if ($options['excludeDescriptions'] || ! $def->description) {
             return '';
         }
         $lines = self::descriptionLines($def->description, 120 - strlen($indentation));

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -166,7 +166,7 @@ class SchemaPrinter
 
     private static function printDescription($options, $def, $indentation = '', $firstInBlock = true) : string
     {
-        if ($options['excludeDescriptions'] || ! $def->description) {
+        if (isset($options['excludeDescriptions']) || ! $def->description) {
             return '';
         }
         $lines = self::descriptionLines($def->description, 120 - strlen($indentation));


### PR DESCRIPTION
This helps certain tools like GraphQL Inspector to function properly

GraphQL Inspector(https://github.com/kamilkisiela/graphql-inspector) has a real problem with the way multi line comments are output by Schema Printer.

Adding an option to exclude type and field descriptions resolves this.