### PR TITLE
Make sure resolveField function is preserved in SchemaExtender

### DIFF
--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -391,6 +391,7 @@ class SchemaExtender
             'astNode' => $type->astNode,
             'extensionASTNodes' => static::getExtensionASTNodes($type),
             'isTypeOf' => $type->config['isTypeOf'] ?? null,
+            'resolveField' => $type->resolveFieldFn ?? null,
         ]);
     }
 


### PR DESCRIPTION
For ObjectTypes, SchemaExtender did not copy over `resolveType` config
option. See test for an example.