### PR TITLE
print @deprecated directive when deprecationReason is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 + Cannot return null for non-nullable field "parentType.fieldName".
 ```
 - Simplified Deferred implementation
+- Having an empty string in `deprecationReason` will now print the `@deprecated` directive (only a `null` `deprecationReason` won't print the `@deprecated` directive).
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -902,7 +902,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
 			path: src/Utils/SchemaPrinter.php
 
 		-

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -393,10 +393,10 @@ class SchemaPrinter
     private static function printDeprecated($fieldOrEnumVal) : string
     {
         $reason = $fieldOrEnumVal->deprecationReason;
-        if (empty($reason)) {
+        if ($reason === '' || $reason === null) {
             return '';
         }
-        if ($reason === '' || $reason === Directive::DEFAULT_DEPRECATION_REASON) {
+        if ($reason === Directive::DEFAULT_DEPRECATION_REASON) {
             return ' @deprecated';
         }
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -393,10 +393,10 @@ class SchemaPrinter
     private static function printDeprecated($fieldOrEnumVal) : string
     {
         $reason = $fieldOrEnumVal->deprecationReason;
-        if ($reason === '' || $reason === null) {
+        if ($reason === null) {
             return '';
         }
-        if ($reason === Directive::DEFAULT_DEPRECATION_REASON) {
+        if ($reason === '' || $reason === Directive::DEFAULT_DEPRECATION_REASON) {
             return ' @deprecated';
         }
 

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -178,7 +178,7 @@ type Query {
         ];
         yield 'when deprecationReason is empty string' => [
             '',
-            '',
+            ' @deprecated',
         ];
         yield 'when deprecationReason is the default deprecation reason' => [
             Directive::DEFAULT_DEPRECATION_REASON,

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Utils;
 
+use Generator;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;
@@ -146,6 +147,47 @@ type Query {
 ',
             $output
         );
+    }
+
+    /**
+     * @see it('Prints Field With "@deprecated" Directive')
+     *
+     * @dataProvider deprecationReasonDataProvider
+     */
+    public function testPrintDeprecatedField(?string $deprecationReason, string $expectedDeprecationDirective) : void
+    {
+        $output = $this->printSingleFieldSchema([
+            'type' => Type::int(),
+            'deprecationReason' => $deprecationReason,
+        ]);
+        self::assertSame(
+            '
+type Query {
+  singleField: Int' . $expectedDeprecationDirective . '
+}
+',
+            $output
+        );
+    }
+
+    public function deprecationReasonDataProvider() : Generator
+    {
+        yield 'when deprecationReason is null' => [
+            null,
+            '',
+        ];
+        yield 'when deprecationReason is empty string' => [
+            '',
+            '',
+        ];
+        yield 'when deprecationReason is the default deprecation reason' => [
+            Directive::DEFAULT_DEPRECATION_REASON,
+            ' @deprecated',
+        ];
+        yield 'when deprecationReason is not empty string' => [
+            'this is deprecated',
+            ' @deprecated(reason: "this is deprecated")',
+        ];
     }
 
     /**


### PR DESCRIPTION
## Why
- `if ($reason === '')` can't be `true` after `if (empty($reason))`
=> because `empty()` already test all falsy values (including `''`)

## How
- add tests for current `@deprecated` printing behavior
- ~remove the useless condition~ replace `empty()` with `=== null`