### PR TITLE
Updates to allow printing of Schema Directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 + Cannot return null for non-nullable field "parentType.fieldName".
 ```
 - Simplified Deferred implementation
+- Allow SchemaPrinter to print Schema Directives
 
 #### v0.13.5
 - Fix coroutine executor when using with promise (#486) 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -317,8 +317,7 @@ class SchemaPrinter
         }
 
         if ($type instanceof ObjectType) {
-          $result= self::printObject($type, $options);
-            return $result;
+            return self::printObject($type, $options);
         }
 
         if ($type instanceof InterfaceType) {

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -353,27 +353,6 @@ class SchemaPrinter
      */
     private static function printObject(ObjectType $type, array $options) : string
     {
-      $directives = $type->astNode->directives;
-      $schemaDirectives = !empty($directives) ? implode(' ',
-          array_map(
-              static function ($d) {
-                $s = " @" . $d->name->value;
-                if ($d->arguments->count() > 0) {
-                  $s .= "(";
-                  foreach ($d->arguments as $argument) {
-                    $s .= $argument->name->value . ": ";
-                    $s .= Printer::doPrint($argument->value);
-                  }
-                  $s .= ")";
-                }
-
-                return $s;
-              },
-              iterator_to_array($directives->getIterator())
-          )
-      ) : '';
-
-
         $interfaces            = $type->getInterfaces();
         $implementedInterfaces = ! empty($interfaces)
             ? ' implements ' . implode(
@@ -388,7 +367,7 @@ class SchemaPrinter
             : '';
 
         return self::printDescription($options, $type) .
-            sprintf("type %s%s%s {\n%s\n}", $type->name, $implementedInterfaces, $schemaDirectives, self::printFields($options, $type));
+            sprintf("type %s%s%s {\n%s\n}", $type->name, $implementedInterfaces, self::printSchemaDirectives($type), self::printFields($options, $type));
     }
 
     /**
@@ -432,7 +411,7 @@ class SchemaPrinter
     private static function printInterface(InterfaceType $type, array $options) : string
     {
         return self::printDescription($options, $type) .
-            sprintf("interface %s {\n%s\n}", $type->name, self::printFields($options, $type));
+            sprintf("interface %s%s {\n%s\n}", $type->name, self::printSchemaDirectives($type), self::printFields($options, $type));
     }
 
     /**
@@ -508,5 +487,37 @@ class SchemaPrinter
             [Introspection::class, 'isIntrospectionType'],
             $options
         );
+    }
+
+  /**
+   * @param \GraphQL\Type\Definition\Type $type
+   *
+   * @return string
+   */
+    public static function printSchemaDirectives(Type $type) : string {
+
+      if (!$type->astNode || !$type->astNode->directives) {
+        return '';
+      }
+
+      $directives = $type->astNode->directives;
+      return $directives->count() > 0 ? (' ' . implode(' ',
+              array_map(
+                  static function ($d) {
+                    $s = "@" . $d->name->value;
+                    if ($d->arguments->count() > 0) {
+                      $s .= "(";
+                      foreach ($d->arguments as $argument) {
+                        $s .= $argument->name->value . ": ";
+                        $s .= Printer::doPrint($argument->value);
+                      }
+                      $s .= ")";
+                    }
+
+                    return $s;
+                  },
+                  iterator_to_array($directives->getIterator())
+              )
+          )) : '';
     }
 }

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -516,7 +516,7 @@ class SchemaPrinter
         return $count > 0 ? (' ' . implode(
             ' ',
             array_map(
-                static function ($directive) {
+                static function ($directive) : string {
                     $directiveString = '@' . $directive->name->value;
                     if ($directive->arguments->count() > 0) {
                         $directiveString .= '(';

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -24,6 +24,7 @@ use function array_values;
 use function count;
 use function explode;
 use function implode;
+use function iterator_to_array;
 use function ksort;
 use function mb_strlen;
 use function preg_match_all;
@@ -488,35 +489,32 @@ class SchemaPrinter
         );
     }
 
-  /**
-   * @param \GraphQL\Type\Definition\Type $type
-   *
-   * @return string
-   */
-    public static function printSchemaDirectives(Type $type) : string {
+    public static function printSchemaDirectives(Type $type) : string
+    {
+        if (! $type->astNode || ! $type->astNode->directives) {
+            return '';
+        }
 
-      if (!$type->astNode || !$type->astNode->directives) {
-        return '';
-      }
+        $directives = $type->astNode->directives;
 
-      $directives = $type->astNode->directives;
-      return $directives->count() > 0 ? (' ' . implode(' ',
-              array_map(
-                  static function ($d) {
-                    $s = "@" . $d->name->value;
-                    if ($d->arguments->count() > 0) {
-                      $s .= "(";
-                      foreach ($d->arguments as $argument) {
-                        $s .= $argument->name->value . ": ";
-                        $s .= Printer::doPrint($argument->value);
-                      }
-                      $s .= ")";
+        return $directives->count() > 0 ? (' ' . implode(
+            ' ',
+            array_map(
+                static function ($directive) {
+                    $directiveString = '@' . $directive->name->value;
+                    if ($directive->arguments->count() > 0) {
+                        $directiveString .= '(';
+                        foreach ($directive->arguments as $argument) {
+                            $directiveString .= $argument->name->value . ': ';
+                            $directiveString .= Printer::doPrint($argument->value);
+                        }
+                        $directiveString .= ')';
                     }
 
-                    return $s;
-                  },
-                  iterator_to_array($directives->getIterator())
-              )
-          )) : '';
+                    return $directiveString;
+                },
+                iterator_to_array($directives->getIterator())
+            )
+        )) : '';
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1238,8 +1238,9 @@ EOT;
         self::assertEquals($introspectionSchema, $output);
     }
 
-    public function testPrintSchemaDirectiveNoArgs() {
-      $exceptedSdl = "
+    public function testPrintSchemaDirectiveNoArgs()
+    {
+        $exceptedSdl = '
 directive @sd on OBJECT
 
 type Bar @sd {
@@ -1249,16 +1250,17 @@ type Bar @sd {
 type Query {
   foo: Bar
 }
-";
+';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveWithStringArgs() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveWithStringArgs()
+    {
+        $exceptedSdl = '
 directive @sd(field: String!) on OBJECT
 
 type Bar @sd(field: "String") {
@@ -1270,14 +1272,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveWithNumberArgs() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveWithNumberArgs()
+    {
+        $exceptedSdl = '
 directive @sd(field: Int!) on OBJECT
 
 type Bar @sd(field: 1) {
@@ -1289,14 +1292,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveWithArrayArgs() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveWithArrayArgs()
+    {
+        $exceptedSdl = '
 directive @sd(field: [Int!]) on OBJECT
 
 type Bar @sd(field: [1, 2, 3, 4]) {
@@ -1308,14 +1312,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveWithTypeArgs() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveWithTypeArgs()
+    {
+        $exceptedSdl = '
 directive @sd(field: Foo) on OBJECT
 
 type Bar @sd(field: {bar: "test"}) {
@@ -1331,14 +1336,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveOptionalArgs() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveOptionalArgs()
+    {
+        $exceptedSdl = '
 directive @sd(field: String) on OBJECT
 
 type Bar @sd(field: "Testing") {
@@ -1355,14 +1361,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintMultipleSchemaDirectives() {
-      $exceptedSdl = '
+    public function testPrintMultipleSchemaDirectives()
+    {
+        $exceptedSdl = '
 directive @sd(field: [Int!]) on OBJECT
 
 directive @sdb on OBJECT
@@ -1376,14 +1383,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveOnClassWithInterface() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveOnClassWithInterface()
+    {
+        $exceptedSdl = '
 directive @sd on OBJECT
 
 type Bar implements Foo @sd {
@@ -1399,14 +1407,15 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 
-    public function testPrintSchemaDirectiveOnInterface() {
-      $exceptedSdl = '
+    public function testPrintSchemaDirectiveOnInterface()
+    {
+        $exceptedSdl = '
 directive @sd on INTERFACE
 
 type Bar implements Foo {
@@ -1422,9 +1431,9 @@ type Query {
 }
 ';
 
-      $schema = BuildSchema::build($exceptedSdl);
-      $actual = $this->printForTest($schema);
+        $schema = BuildSchema::build($exceptedSdl);
+        $actual = $this->printForTest($schema);
 
-      self::assertEquals($exceptedSdl, $actual);
+        self::assertEquals($exceptedSdl, $actual);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1237,4 +1237,104 @@ enum __TypeKind {
 EOT;
         self::assertEquals($introspectionSchema, $output);
     }
+
+    public function testPrintSchemaDirectiveNoArgs() {
+      $exceptedSdl = "
+directive @sd on OBJECT
+
+type Bar @sd {
+  foo: String
+}
+
+type Query {
+  foo: Bar
+}
+";
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveWithStringArgs() {
+      $exceptedSdl = '
+directive @sd(field: String!) on OBJECT
+
+type Bar @sd(field: "String") {
+  foo: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveWithNumberArgs() {
+      $exceptedSdl = '
+directive @sd(field: Int!) on OBJECT
+
+type Bar @sd(field: 1) {
+  foo: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveWithArrayArgs() {
+      $exceptedSdl = '
+directive @sd(field: [Int!]) on OBJECT
+
+type Bar @sd(field: [1, 2, 3, 4]) {
+  foo: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveOptionalArgs() {
+      $exceptedSdl = '
+directive @sd(field: String) on OBJECT
+
+type Bar @sd(field: "Testing") {
+  foo: String
+}
+
+type Foo @sd {
+  bar: String
+}
+
+type Query {
+  foo: Bar
+  bar: Foo
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1337,4 +1337,71 @@ type Query {
 
       self::assertEquals($exceptedSdl, $actual);
     }
+
+    public function testPrintMultipleSchemaDirectives() {
+      $exceptedSdl = '
+directive @sd(field: [Int!]) on OBJECT
+
+directive @sdb on OBJECT
+
+type Bar @sd(field: [1, 2, 3, 4]) @sdb {
+  foo: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveOnClassWithInterface() {
+      $exceptedSdl = '
+directive @sd on OBJECT
+
+type Bar implements Foo @sd {
+  foo: String
+}
+
+interface Foo {
+  bar: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
+    public function testPrintSchemaDirectiveOnInterface() {
+      $exceptedSdl = '
+directive @sd on INTERFACE
+
+type Bar implements Foo {
+  foo: String
+}
+
+interface Foo @sd {
+  bar: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1314,6 +1314,29 @@ type Query {
       self::assertEquals($exceptedSdl, $actual);
     }
 
+    public function testPrintSchemaDirectiveWithTypeArgs() {
+      $exceptedSdl = '
+directive @sd(field: Foo) on OBJECT
+
+type Bar @sd(field: {bar: "test"}) {
+  foo: String
+}
+
+type Foo {
+  bar: String
+}
+
+type Query {
+  foo: Bar
+}
+';
+
+      $schema = BuildSchema::build($exceptedSdl);
+      $actual = $this->printForTest($schema);
+
+      self::assertEquals($exceptedSdl, $actual);
+    }
+
     public function testPrintSchemaDirectiveOptionalArgs() {
       $exceptedSdl = '
 directive @sd(field: String) on OBJECT


### PR DESCRIPTION
## Overview
I have been working to get a working Apollo Federation server set up using this library. In doing so one of the requirements of Apollo Federation is that you need to serve the printed schema via the `Query._service` field, however, Apollo Federation relys heavily on schema directives and the current SchemaPrinter doesn't print any schema directives although the library allows adding them.

## Problem
The current SchemaPrinter doesn't support printing Schema Directives

### Example
Given schema:
```
directive @sd on OBJECT

type Bar @sd {
  foo: String
}

type Query {
  foo: Bar
}
```
`SchemaPrinter::doPrint(...);`
will print:
```
directive @sd on OBJECT

type Bar {
  foo: String
}

type Query {
  foo: Bar
}
```
Notice the missing `@sd` on `Bar`.

## Solution
I added a piece of code similar to the interfaces printing in `printObject` which now prints Schema Directives

## Testing
Added test cases for:
1. Schema Directive No Arguments
2. Schema Directive String Argument
3. Schema Directive Int Argument
4. Schema Directive Array Argument
5. Schema Directive with Type Arguments
6. Schema Directive Optional Arguments
7. Multiple Schema Directives
8. Schema Directive on a class with an interface
9. Schema Directive on an interface