### PR TITLE
Add Siler to complementary tools

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -6,6 +6,7 @@
 * [Laravel GraphQL](https://github.com/rebing/graphql-laravel) - Laravel wrapper for Facebook's GraphQL
 * [OverblogGraphQLBundle](https://github.com/overblog/GraphQLBundle) – Bundle for Symfony
 * [WP-GraphQL](https://github.com/wp-graphql/wp-graphql) - GraphQL API for WordPress
+* [Siler](https://github.com/leocavalcante/siler) - Straightforward way to map GraphQL SDL to resolver callables, also built-in support for Swoole
 
 # GraphQL PHP Tools
 


### PR DESCRIPTION
Siler uses this package underneath to provide GraphQL support.

https://siler.leocavalcante.dev/graphql

https://www.swoole.co.uk/article/Build-a-GraphQL-API-on-top-of-Swoole