### PR TITLE
Rule to validate subscriptions include one field

### DIFF
--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -34,6 +34,7 @@ use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use GraphQL\Validator\Rules\QuerySecurityRule;
 use GraphQL\Validator\Rules\ScalarLeafs;
+use GraphQL\Validator\Rules\SingleFieldSubscription;
 use GraphQL\Validator\Rules\UniqueArgumentNames;
 use GraphQL\Validator\Rules\UniqueDirectivesPerLocation;
 use GraphQL\Validator\Rules\UniqueFragmentNames;
@@ -139,6 +140,7 @@ class DocumentValidator
                 ExecutableDefinitions::class        => new ExecutableDefinitions(),
                 UniqueOperationNames::class         => new UniqueOperationNames(),
                 LoneAnonymousOperation::class       => new LoneAnonymousOperation(),
+                SingleFieldSubscription::class      => new SingleFieldSubscription(),
                 KnownTypeNames::class               => new KnownTypeNames(),
                 FragmentsOnCompositeTypes::class    => new FragmentsOnCompositeTypes(),
                 VariablesAreInputTypes::class       => new VariablesAreInputTypes(),

--- a/src/Validator/Rules/SingleFieldSubscription.php
+++ b/src/Validator/Rules/SingleFieldSubscription.php
@@ -17,7 +17,10 @@ use function sprintf;
 
 class SingleFieldSubscription extends ValidationRule
 {
-    public function getVisitor(ValidationContext $context)
+    /**
+     * @return array<string, callable>
+     */
+    public function getVisitor(ValidationContext $context) : array
     {
         return [
             NodeKind::OPERATION_DEFINITION => static function (OperationDefinitionNode $node) use ($context) : VisitorOperation {
@@ -43,7 +46,7 @@ class SingleFieldSubscription extends ValidationRule
         ];
     }
 
-    public static function multipleFieldsInOperation($operationName)
+    public static function multipleFieldsInOperation(?string $operationName) : string
     {
         if ($operationName === null) {
             return sprintf('Anonymous Subscription must select only one top level field.');

--- a/src/Validator/Rules/SingleFieldSubscription.php
+++ b/src/Validator/Rules/SingleFieldSubscription.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Validator\Rules;
+
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorOperation;
+use GraphQL\Validator\ValidationContext;
+use function array_splice;
+use function count;
+use function sprintf;
+
+class SingleFieldSubscription extends ValidationRule
+{
+    public function getVisitor(ValidationContext $context)
+    {
+        return [
+            NodeKind::OPERATION_DEFINITION => static function (OperationDefinitionNode $node) use ($context) : VisitorOperation {
+                if ($node->operation === 'subscription') {
+                    $selections = $node->selectionSet->selections;
+
+                    if (count($selections) !== 1) {
+                        if ($selections instanceof NodeList) {
+                            $offendingSelections = $selections->splice(1, count($selections));
+                        } else {
+                            $offendingSelections = array_splice($selections, 1);
+                        }
+
+                        $context->reportError(new Error(
+                            self::multipleFieldsInOperation($node->name->value ?? null),
+                            $offendingSelections
+                        ));
+                    }
+                }
+
+                return Visitor::skipNode();
+            },
+        ];
+    }
+
+    public static function multipleFieldsInOperation($operationName)
+    {
+        if ($operationName === null) {
+            return sprintf('Anonymous Subscription must select only one top level field.');
+        }
+
+        return sprintf('Subscription "%s" must select only one top level field.', $operationName);
+    }
+}

--- a/tests/Validator/SingleFieldSubscriptionsTest.php
+++ b/tests/Validator/SingleFieldSubscriptionsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Validator;
+
+use GraphQL\Error\FormattedError;
+use GraphQL\Language\SourceLocation;
+use GraphQL\Validator\Rules\SingleFieldSubscription;
+use function array_map;
+
+class SingleFieldSubscriptionsTest extends ValidatorTestCase
+{
+    /**
+     * @see it('valid single field subscription')
+     */
+    public function testValidSingleFieldSubscription() : void
+    {
+        $this->expectPassesRule(
+            new SingleFieldSubscription(),
+            '
+      subscription sub {
+        catSubscribe {
+          meows
+        }
+      }
+        '
+        );
+    }
+
+    /**
+     * @see it('valid single field bulk subscriptions')
+     */
+    public function testValidSingleFieldBulkSubscriptions() : void
+    {
+        $this->expectPassesRule(
+            new SingleFieldSubscription(),
+            '
+      subscription sub {
+        catSubscribe {
+          meows
+        }
+      }
+      
+      subscription sub2 {
+        dogSubscribe {
+          barks
+        }
+      }
+        '
+        );
+    }
+
+    /**
+     * @see it('valid single field anonymous subscription')
+     */
+    public function testValidSingleFieldAnonymousSubscription() : void
+    {
+        $this->expectPassesRule(
+            new SingleFieldSubscription(),
+            '
+      subscription {
+        catSubscribe {
+          meows
+        }
+      }
+        '
+        );
+    }
+
+    /**
+     * @see it('valid single field subscription')
+     */
+    public function testValidSingleFieldSubscriptionWithMultipleResultFields() : void
+    {
+        $this->expectPassesRule(
+            new SingleFieldSubscription(),
+            '
+      subscription {
+        catSubscribe {
+          meows
+          meowVolume
+        }
+      }
+        '
+        );
+    }
+
+    /**
+     * @see it('invalid multiple field subscription')
+     */
+    public function testInvalidMultipleFieldSubscription() : void
+    {
+        $this->expectFailsRule(
+            new SingleFieldSubscription(),
+            '
+      subscription sub {
+        catSubscribe {
+          meows
+        }
+        barkSubscribe {
+          barks
+        }
+      }
+        ',
+            [$this->multipleFieldsInOperation('sub', [6, 9])]
+        );
+    }
+
+    /**
+     * @see it('invalid multiple field anonymous subscription')
+     */
+    public function testInvalidMultipleFieldAnonymousSubscription() : void
+    {
+        $this->expectFailsRule(
+            new SingleFieldSubscription(),
+            '
+      subscription {
+        catSubscribe {
+          meows
+        }
+        barkSubscribe {
+          barks
+        }
+      }
+        ',
+            [$this->multipleFieldsInOperation(null, [6, 9])]
+        );
+    }
+
+    /**
+     * @see it('invalid many fields subscription')
+     */
+    public function testInvalidManyFieldsSubscription() : void
+    {
+        $this->expectFailsRule(
+            new SingleFieldSubscription(),
+            '
+      subscription sub {
+        first: catSubscribe {
+          meows
+        }
+        second: catSubscribe {
+          meows
+        }
+        third: catSubscribe {
+          meows
+        }
+      }
+        ',
+            [$this->multipleFieldsInOperation('sub', [6, 9], [9, 9])]
+        );
+    }
+
+    /**
+     * @see it('invalid many fields anonymous subscription')
+     */
+    public function testInvalidManyFieldAnonymousSubscription() : void
+    {
+        $this->expectFailsRule(
+            new SingleFieldSubscription(),
+            '
+      subscription {
+        first: catSubscribe {
+          meows
+        }
+        second: catSubscribe {
+          meows
+        }
+        third: catSubscribe {
+          meows
+        }
+      }
+        ',
+            [$this->multipleFieldsInOperation(null, [6, 9], [9, 9])]
+        );
+    }
+
+    private function multipleFieldsInOperation($operationName, ...$locations)
+    {
+        return FormattedError::create(
+            SingleFieldSubscription::multipleFieldsInOperation($operationName),
+            array_map(static function (array $location) : SourceLocation {
+                [$line, $column] = $location;
+
+                return new SourceLocation($line, $column);
+            }, $locations)
+        );
+    }
+}

--- a/tests/Validator/SingleFieldSubscriptionsTest.php
+++ b/tests/Validator/SingleFieldSubscriptionsTest.php
@@ -176,7 +176,10 @@ class SingleFieldSubscriptionsTest extends ValidatorTestCase
         );
     }
 
-    private function multipleFieldsInOperation($operationName, ...$locations)
+    /**
+     * @param array<int, int> ...$locations A tuple of line and column
+     */
+    private function multipleFieldsInOperation(?string $operationName, array ...$locations)
     {
         return FormattedError::create(
             SingleFieldSubscription::multipleFieldsInOperation($operationName),

--- a/tests/Validator/ValidatorTestCase.php
+++ b/tests/Validator/ValidatorTestCase.php
@@ -349,9 +349,18 @@ abstract class ValidatorTestCase extends TestCase
             ],
         ]);
 
+        $subscriptionRoot = new ObjectType([
+            'name'   => 'SubscriptionRoot',
+            'fields' => [
+                'catSubscribe'  => ['type' => $Cat],
+                'barkSubscribe' => ['type' => $Dog],
+            ],
+        ]);
+
         return new Schema([
-            'query'      => $queryRoot,
-            'directives' => [
+            'query'        => $queryRoot,
+            'subscription' => $subscriptionRoot,
+            'directives'   => [
                 Directive::includeDirective(),
                 Directive::skipDirective(),
                 new Directive([


### PR DESCRIPTION
Subscriptions must only include one field.

A GraphQL subscription is valid only if it contains a single root field.

Spec: http://spec.graphql.org/June2018/#sec-Single-root-field
JS rule: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/SingleFieldSubscriptionsRule.js