### PR TITLE
Fix NodeList::getFieldSelection() return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "psr/http-message": "^1.0",
     "react/promise": "2.*",
     "simpod/php-coveralls-mirror": "^3.0",
-    "squizlabs/php_codesniffer": "^3.5.2"
+    "squizlabs/php_codesniffer": "3.5.4"
   },
   "config": {
     "preferred-install": "dist",

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -83,8 +83,8 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
-     * @param int|string   $offset
-     * @param Node|mixed[] $value
+     * @param int|string|null $offset
+     * @param Node|mixed[]    $value
      *
      * @phpstan-param T|mixed[] $value
      */

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -83,8 +83,8 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
-     * @param int|string|null $offset
-     * @param Node|mixed[]    $value
+     * @param int|string   $offset
+     * @param Node|mixed[] $value
      *
      * @phpstan-param T|mixed[] $value
      */

--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -175,7 +175,7 @@ class ResolveInfo
      *
      * @param int $depth How many levels to include in output
      *
-     * @return bool[]
+     * @return array<string, bool>
      *
      * @api
      */


### PR DESCRIPTION
Correcting the return type of `ResolveInfo.getFieldSelection`.

Not a big deal, but it was causing stanning errors in my app code.

Also fixed one of the new contravariant errors that was introduced in a recent version of PHPStan.