### PR TITLE
Use psr7 request body instead of parsedBody

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -535,13 +535,11 @@ class Helper
             if (stripos($contentType[0], 'application/graphql') !== false) {
                 $bodyParams = ['query' => $request->getBody()->getContents()];
             } elseif (stripos($contentType[0], 'application/json') !== false) {
-                $bodyParams = $request->getParsedBody();
+            	$bodyParams = json_decode($request->getBody()->getContents(), true);
 
-                if ($bodyParams === null) {
-                    throw new InvariantViolation(
-                        'PSR-7 request is expected to provide parsed body for "application/json" requests but got null'
-                    );
-                }
+	            if (json_last_error()) {
+		            throw new RequestError('Could not parse JSON: ' . json_last_error_msg());
+	            }
 
                 if (! is_array($bodyParams)) {
                     throw new RequestError(

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -535,11 +535,11 @@ class Helper
             if (stripos($contentType[0], 'application/graphql') !== false) {
                 $bodyParams = ['query' => $request->getBody()->getContents()];
             } elseif (stripos($contentType[0], 'application/json') !== false) {
-            	$bodyParams = json_decode($request->getBody()->getContents(), true);
+                $bodyParams = json_decode($request->getBody()->getContents(), true);
 
-	            if (json_last_error()) {
-		            throw new RequestError('Could not parse JSON: ' . json_last_error_msg());
-	            }
+                if (json_last_error()) {
+                    throw new RequestError('Could not parse JSON: ' . json_last_error_msg());
+                }
 
                 if (! is_array($bodyParams)) {
                     throw new RequestError(

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -83,7 +83,7 @@ class Helper
                     : $this->readRawBody();
                 $bodyParams = json_decode($rawBody ?: '', true);
 
-                if (json_last_error()) {
+                if (json_last_error() !== JSON_ERROR_NONE) {
                     throw new RequestError('Could not parse JSON: ' . json_last_error_msg());
                 }
 

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -538,7 +538,7 @@ class Helper
             } elseif (stripos($contentType[0], 'application/json') !== false) {
                 $bodyParams = json_decode($request->getBody()->getContents(), true);
 
-                if (json_last_error()) {
+                if (json_last_error() !== JSON_ERROR_NONE) {
                     throw new RequestError('Could not parse JSON: ' . json_last_error_msg());
                 }
 

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -32,6 +32,7 @@ use function json_last_error;
 use function json_last_error_msg;
 use function sprintf;
 use function stripos;
+use const JSON_ERROR_NONE;
 
 /**
  * Contains functionality that could be re-used by various server implementations

--- a/tests/Server/Psr7/PsrRequestStub.php
+++ b/tests/Server/Psr7/PsrRequestStub.php
@@ -26,7 +26,11 @@ class PsrRequestStub implements ServerRequestInterface
     /** @var mixed[] */
     public $parsedBody;
 
-    /**
+    public function __construct() {
+    	$this->body = new PsrStreamStub();
+    }
+
+	/**
      * Retrieves the HTTP protocol version as a string.
      *
      * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").

--- a/tests/Server/Psr7/PsrRequestStub.php
+++ b/tests/Server/Psr7/PsrRequestStub.php
@@ -27,10 +27,10 @@ class PsrRequestStub implements ServerRequestInterface
     public $parsedBody;
 
     public function __construct() {
-    	$this->body = new PsrStreamStub();
+        $this->body = new PsrStreamStub();
     }
 
-	/**
+    /**
      * Retrieves the HTTP protocol version as a string.
      *
      * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").

--- a/tests/Server/Psr7/PsrStreamStub.php
+++ b/tests/Server/Psr7/PsrStreamStub.php
@@ -13,7 +13,7 @@ use const SEEK_SET;
  */
 class PsrStreamStub implements StreamInterface
 {
-    public $content;
+    public $content = "";
 
     /**
      * Reads all data from the stream into a string, from the beginning to end.

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -414,23 +414,9 @@ class RequestParsingTest extends TestCase
     {
         $body = 'not really{} a json';
 
-        $this->expectException(InvariantViolation::class);
-        $this->expectExceptionMessage('PSR-7 request is expected to provide parsed body for "application/json" requests but got null');
+        $this->expectException(RequestError::class);
+        $this->expectExceptionMessage('Could not parse JSON: Syntax error');
         $this->parsePsrRequest('application/json', $body);
-    }
-
-    public function testFailsParsingNonPreParsedPsrRequest() : void
-    {
-        try {
-            $this->parsePsrRequest('application/json', json_encode(null));
-            self::fail('Expected exception not thrown');
-        } catch (InvariantViolation $e) {
-            // Expecting parsing exception to be thrown somewhere else:
-            self::assertEquals(
-                'PSR-7 request is expected to provide parsed body for "application/json" requests but got null',
-                $e->getMessage()
-            );
-        }
     }
 
     /**

--- a/tests/Server/StandardServerTest.php
+++ b/tests/Server/StandardServerTest.php
@@ -55,7 +55,7 @@ class StandardServerTest extends ServerTestCase
 
     public function testSimplePsrRequestExecution() : void
     {
-        $body = ['query' => '{f1}'];
+        $body = json_encode(['query' => '{f1}']);
 
         $expected = [
             'data' => ['f1' => 'f1'],
@@ -65,12 +65,12 @@ class StandardServerTest extends ServerTestCase
         $this->assertPsrRequestEquals($expected, $request);
     }
 
-    private function preparePsrRequest($contentType, $parsedBody)
+    private function preparePsrRequest($contentType, $body)
     {
         $psrRequest                          = new PsrRequestStub();
         $psrRequest->headers['content-type'] = [$contentType];
         $psrRequest->method                  = 'POST';
-        $psrRequest->parsedBody              = $parsedBody;
+        $psrRequest->body->content           = $body;
 
         return $psrRequest;
     }
@@ -94,10 +94,10 @@ class StandardServerTest extends ServerTestCase
 
     public function testMultipleOperationPsrRequestExecution() : void
     {
-        $body = [
+        $body = json_encode([
             'query'         => 'query firstOp {fieldWithPhpError} query secondOp {f1}',
             'operationName' => 'secondOp',
-        ];
+        ]);
 
         $expected = [
             'data' => ['f1' => 'f1'],


### PR DESCRIPTION
According to the PSR-7 spec, the behavior of ServerRequestInterface::parsedBody is only really specified for multipart/form-data and application/x-www-form-urlencoded requests (in which case it should contain the contents of $_POST). With other request types, the parsedBody MAY return an unserialized version of the body, but since it's not really practical to build parsers for all known formats into a http library it should be perfectly acceptable to return nothing. This PR moves the parsing of the json body into parsePsrRequest.