### PR TITLE
Fix return type for ResolveInfo.getFieldSelection

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -175,7 +175,7 @@ class ResolveInfo
      *
      * @param int $depth How many levels to include in output
      *
-     * @return array<string, bool>
+     * @return array<string, mixed>
      *
      * @api
      */


### PR DESCRIPTION
Er, sorry--my previous fix for this was not correct. `ResolveInfo.getFieldSelection` can actually be a deeply nested structure. We apparently don't yet have the ability to express [recursive types](https://github.com/phpstan/phpdoc-parser/issues/9), yet, so `array<string, mixed>` may be the best we can do.