### PR TITLE
Allow `DocumentNode` in `OperationParams#query`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -307,11 +307,16 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
+			count: 1
+			path: src/Server/Helper.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, GraphQL\\\\Language\\\\AST\\\\DocumentNode|string given\\.$#"
 			count: 2
 			path: src/Server/Helper.php
 
 		-
-			message: "#^Only booleans are allowed in &&, string given on the left side\\.$#"
+			message: "#^Only booleans are allowed in &&, GraphQL\\\\Language\\\\AST\\\\DocumentNode|string given on the left side\\.$#"
 			count: 1
 			path: src/Server/Helper.php
 
@@ -323,11 +328,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 5
-			path: src/Server/Helper.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 1
 			path: src/Server/Helper.php
 
 		-

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -161,9 +161,9 @@ class Helper
             $errors[] = new RequestError('GraphQL Request parameters "query" and "queryId" are mutually exclusive');
         }
 
-        if ($params->query !== null && (! is_string($params->query) || empty($params->query))) {
+        if ($params->query !== null && ! $params->query instanceof DocumentNode && (! is_string($params->query) || empty($params->query))) {
             $errors[] = new RequestError(
-                'GraphQL Request parameter "query" must be string, but got ' .
+                'GraphQL Request parameter "query" must be string or DocumentNode, but got ' .
                 Utils::printSafeJson($params->query)
             );
         }

--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQL\Server;
 
+use GraphQL\Language\AST\DocumentNode;
 use function array_change_key_case;
 use function is_string;
 use function json_decode;
@@ -31,7 +32,7 @@ class OperationParams
 
     /**
      * @api
-     * @var string
+     * @var string|DocumentNode
      */
     public $query;
 

--- a/tests/Server/RequestValidationTest.php
+++ b/tests/Server/RequestValidationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Server;
 
+use GraphQL\Language\Parser;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
 use PHPUnit\Framework\TestCase;
@@ -84,15 +85,29 @@ class RequestValidationTest extends TestCase
         );
     }
 
-    public function testFailsWhenQueryParameterIsNotString() : void
+    public function testFailsWhenQueryParameterIsInvalid() : void
     {
+        // Only string or DocumentNode is valid parameter
         $parsedBody = OperationParams::create([
             'query' => ['t' => '{my query}'],
         ]);
 
         $this->assertInputError(
             $parsedBody,
-            'GraphQL Request parameter "query" must be string, but got {"t":"{my query}"}'
+            'GraphQL Request parameter "query" must be string or DocumentNode, but got {"t":"{my query}"}'
+        );
+    }
+
+    public function testQueryCanBeDocumentNode() : void
+    {
+        $doc =  Parser::parse('{my query}');
+
+        $parsedBody = OperationParams::create(['query' => $doc]);
+
+        self::assertEquals(
+            $doc,
+            $parsedBody->query,
+            'GraphQL Request parameter "query" must be string or DocumentNode, but got {"t":"{my query}"}'
         );
     }
 


### PR DESCRIPTION
In WPGraphQL we want to parse the GraphQL queries to `DocumentNode` by ourselves before passing it to the graphql-php Server instance via `OperationParams`. This would allow us to add an filter on which userland plugins can hook into for AST inspection, transformation and [caching](https://github.com/valu-digital/wp-graphql-cache).


But unfortunately the current `validateOperationParams` in the Helper class does not allow it to be a `DocumentNode`.

But later in the file the it can skip parsing if it is already a `DocumentNode`:

https://github.com/webonyx/graphql-php/blob/1f0ec2408010e01879b1f980afac65de2344c631/src/Server/Helper.php#L279-L285


Here's the WPGraphQL PR for the filters https://github.com/wp-graphql/wp-graphql/pull/1302

I realize this implementation might not be ideal since `OperationParams` is mean to represent "HTTP parameters" where AST does not necessarily make sense but I could not figure any other way to do this without larger refactoring. Other ideas would be very welcome.

Thanks!