### PR TITLE
description bug-fix: Trying to get property 'value' of non-object

### DIFF
--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -99,7 +99,7 @@ class ASTDefinitionBuilder
     private function getDescription($node)
     {
         if ($node->description) {
-            return $node->description->value;
+            return $node->description;
         }
         if (isset($this->options['commentDescriptions'])) {
             $rawValue = $this->getLeadingCommentBlock($node);


### PR DESCRIPTION
description-fix: Trying to get property 'value' of non-object
On a string