### PR TITLE
Bump php action in order to use composer v1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@1.7.0
+      uses: shivammathur/setup-php@2.2.2
       with:
         php-version: ${{ matrix.php  }}
         coverage: none
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@1.7.0
+      uses: shivammathur/setup-php@2.2.2
       with:
         php-version: 7.1
         coverage: none
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@1.7.0
+      uses: shivammathur/setup-php@2.2.2
       with:
         php-version: 7.1
         coverage: none
@@ -122,7 +122,7 @@ jobs:
         ref: ${{ github.ref }}
 
     - name: Install PHP
-      uses: shivammathur/setup-php@1.7.0
+      uses: shivammathur/setup-php@2.2.2
       with:
         php-version: 7.2
         coverage: pcov


### PR DESCRIPTION
_this fixes the build as composer dep was not locked and v2 was being installed, see https://github.com/simPod/graphql-php/runs/737889280_