### PR TITLE
Drop Error::$message

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 ## Master
 
+- Dropped `GraphQL\Error\Error::$message`
+
 ### Breaking (major): dropped deprecations
  - dropped deprecated `GraphQL\Schema`. Use `GraphQL\Type\Schema`.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 ## Master
 
-- Dropped `GraphQL\Error\Error::$message`
+- Dropped `GraphQL\Error\Error::$message`, use `->getMessage()` instead.
 
 ### Breaking (major): dropped deprecations
  - dropped deprecated `GraphQL\Schema`. Use `GraphQL\Type\Schema`.

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -38,13 +38,6 @@ class Error extends Exception implements JsonSerializable, ClientAware
     const CATEGORY_GRAPHQL  = 'graphql';
     const CATEGORY_INTERNAL = 'internal';
 
-    /**
-     * A message describing the Error for debugging purposes.
-     *
-     * @var string
-     */
-    public $message;
-
     /** @var SourceLocation[] */
     private $locations;
 


### PR DESCRIPTION
It just overwrites parent's `Exception::$message` and is not initialised in constructor. I believe it can be dropped.