### PR TITLE
update phpbench

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,5 @@ Based on [PHPStan](https://github.com/phpstan/phpstan).
 ## Running benchmarks
 Benchmarks are run via [PHPBench](https://github.com/phpbench/phpbench).
 ```sh
-./vendor/bin/phpbench run .
+./vendor/bin/phpbench run benchmarks
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "amphp/amp": "^2.3",
     "doctrine/coding-standard": "^6.0",
     "nyholm/psr7": "^1.2",
-    "phpbench/phpbench": "^0.14",
+    "phpbench/phpbench": "^0.17.1",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "0.12.18",
     "phpstan/phpstan-phpunit": "0.12.6",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "amphp/amp": "^2.3",
     "doctrine/coding-standard": "^6.0",
     "nyholm/psr7": "^1.2",
-    "phpbench/phpbench": "^0.17.1",
+    "phpbench/phpbench": "^0.16.10",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "0.12.18",
     "phpstan/phpstan-phpunit": "0.12.6",


### PR DESCRIPTION
Bumping the minimum required version of phpbench to get a [fix](https://github.com/phpbench/phpbench/commit/cc354c33093581b22b8a5a05d5e4397d4a01b179#diff-384c8ba7168bc7b228a1b08c7de98d39) for an issue that was causing the benchmark script to fail in my PHP 7.4 environment.

Also, for some reason the syntax listed on `contributing.md` doesn't work for me, so I've updated it to what does work. If I'm just not understanding something simple please let me know.

