### PR TITLE
Optimize

### DIFF
--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -30,7 +30,10 @@ class FieldArgument
     /** @var mixed[] */
     public $config;
 
-    /** @var InputType&Type */
+    /**
+     * @TODO: narrow this type to Type&InputType with native asserts
+     * @var Type
+     */
     private $type;
 
     /**
@@ -40,9 +43,6 @@ class FieldArgument
     {
         foreach ($def as $key => $value) {
             switch ($key) {
-                case 'type':
-                    $this->type = $value;
-                    break;
                 case 'name':
                     $this->name = $value;
                     break;
@@ -80,7 +80,7 @@ class FieldArgument
 
     public function getType() : Type
     {
-        return Schema::resolveType($this->type);
+        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
     }
 
     public function defaultValueExists() : bool
@@ -102,7 +102,7 @@ class FieldArgument
                 sprintf('%s.%s(%s:) %s', $parentType->name, $parentField->name, $this->name, $e->getMessage())
             );
         }
-        $type = $this->type;
+        $type = $this->getType();
         if ($type instanceof WrappingType) {
             $type = $type->getWrappedType(true);
         }

--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -30,15 +30,10 @@ class FieldArgument
     /** @var mixed[] */
     public $config;
 
-    /**
-     * @var Type&InputType
-     * @var Type
-     */
+    /** @var Type&InputType */
     private $type;
 
-    /**
-     * @param mixed[] $def
-     */
+    /** @param mixed[] $def */
     public function __construct(array $def)
     {
         foreach ($def as $key => $value) {

--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -31,7 +31,7 @@ class FieldArgument
     public $config;
 
     /**
-     * @TODO: narrow this type to Type&InputType with native asserts
+     * @var Type&InputType
      * @var Type
      */
     private $type;
@@ -80,7 +80,17 @@ class FieldArgument
 
     public function getType() : Type
     {
-        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
+        if (! isset($this->type)) {
+            /**
+             * TODO: replace this phpstan cast with native assert
+             *
+             * @var Type&InputType
+             */
+            $type       = Schema::resolveType($this->config['type']);
+            $this->type = $type;
+        }
+
+        return $this->type;
     }
 
     public function defaultValueExists() : bool

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -59,10 +59,7 @@ class FieldDefinition
      */
     public $config;
 
-    /**
-     * @TODO narrow this type to OutputType&Type with native asserts
-     * @var Type
-     */
+    /** @var OutputType&Type */
     public $type;
 
     /** @var callable|string */
@@ -179,7 +176,17 @@ class FieldDefinition
 
     public function getType() : Type
     {
-        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
+        if (! isset($this->type)) {
+            /**
+             * TODO: replace this phpstan cast with native assert
+             *
+             * @var Type&OutputType
+             */
+            $type       = Schema::resolveType($this->config['type']);
+            $this->type = $type;
+        }
+
+        return $this->type;
     }
 
     /**

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -59,7 +59,10 @@ class FieldDefinition
      */
     public $config;
 
-    /** @var Type  */
+    /**
+     * @TODO narrow this type to OutputType&Type with native asserts
+     * @var Type
+     */
     public $type;
 
     /** @var callable|string */

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -59,7 +59,7 @@ class FieldDefinition
      */
     public $config;
 
-    /** @var callable|(OutputType&Type) */
+    /** @var Type  */
     public $type;
 
     /** @var callable|string */
@@ -71,7 +71,6 @@ class FieldDefinition
     protected function __construct(array $config)
     {
         $this->name      = $config['name'];
-        $this->type      = $config['type'];
         $this->resolveFn = $config['resolve'] ?? null;
         $this->mapFn     = $config['map'] ?? null;
         $this->args      = isset($config['args']) ? FieldArgument::createMap($config['args']) : [];
@@ -177,7 +176,7 @@ class FieldDefinition
 
     public function getType() : Type
     {
-        return Schema::resolveType($this->type);
+        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
     }
 
     /**

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -59,7 +59,17 @@ class InputObjectField
      */
     public function getType() : Type
     {
-        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
+        if (! isset($this->type)) {
+            /**
+             * TODO: replace this phpstan cast with native assert
+             *
+             * @var Type&InputType
+             */
+            $type       = Schema::resolveType($this->config['type']);
+            $this->type = $type;
+        }
+
+        return $this->type;
     }
 
     public function defaultValueExists() : bool
@@ -82,7 +92,7 @@ class InputObjectField
         } catch (Error $e) {
             throw new InvariantViolation(sprintf('%s.%s: %s', $parentType->name, $this->name, $e->getMessage()));
         }
-        $type = $this->type;
+        $type = $this->getType();
         if ($type instanceof WrappingType) {
             $type = $type->getWrappedType(true);
         }

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -44,6 +44,9 @@ class InputObjectField
                     break;
                 case 'defaultValueExists':
                     break;
+                case 'type':
+                    // do nothing; type is lazy loaded in getType
+                    break;
                 default:
                     $this->{$k} = $v;
             }
@@ -56,12 +59,7 @@ class InputObjectField
      */
     public function getType() : Type
     {
-        /**
-         * TODO: Replace this cast with native assert
-         *
-         * @var Type&InputType
-         */
-        return Schema::resolveType($this->type);
+        return $this->type ?? ($this->type = Schema::resolveType($this->config['type']));
     }
 
     public function defaultValueExists() : bool

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -373,7 +373,7 @@ class Schema
      */
     public static function resolveType($type) : Type
     {
-        if($type instanceof Type) {
+        if ($type instanceof Type) {
             return $type;
         }
 

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -377,11 +377,7 @@ class Schema
             return $type;
         }
 
-        if (is_callable($type)) {
-            return $type();
-        }
-
-        return $type;
+        return $type();
     }
 
     /**

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -373,6 +373,10 @@ class Schema
      */
     public static function resolveType($type) : Type
     {
+        if($type instanceof Type) {
+            return $type;
+        }
+
         if (is_callable($type)) {
             return $type();
         }


### PR DESCRIPTION
Hi again. I've been working with some profilers (phpbench and blackfire), and I'm afraid that while my lazy load feature does speed up my application, the performance of normal non-lazy loaded types has suffered a bit. Apologies for that, I really feel awful about it. One of the culprits is that new `Schema.resolveType` method; in my app it was getting called over 25k times (!). I came up with a few simple one-liners in this PR to lessen the pain (and drop the number of calls by an order of magnitude). Here's some profiler data to look at:

Before lazy-load-type branch:

```
\GraphQL\Benchmarks\HugeSchemaBench

    benchSchema.............................I0 [μ Mo]/r: 144.375 144.375 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSchemaLazy.........................I0 [μ Mo]/r: 0.027 0.027 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQuery.........................I0 [μ Mo]/r: 190.369 190.369 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQueryLazy.....................I0 [μ Mo]/r: 174.710 174.710 (ms) [μSD μRSD]/r: 0.000ms 0.00%

\GraphQL\Benchmarks\LexerBench

    benchIntrospectionQuery.................I4 [μ Mo]/r: 6.979 7.021 (ms) [μSD μRSD]/r: 0.069ms 0.98%

\GraphQL\Benchmarks\StarWarsBench

    benchSchema.............................I1 [μ Mo]/r: 0.522 0.522 (ms) [μSD μRSD]/r: 0.002ms 0.47%
    benchHeroQuery..........................I1 [μ Mo]/r: 2.923 2.923 (ms) [μSD μRSD]/r: 0.043ms 1.47%
    benchNestedQuery........................I1 [μ Mo]/r: 6.756 6.755 (ms) [μSD μRSD]/r: 0.026ms 0.38%
    benchQueryWithFragment..................I1 [μ Mo]/r: 7.702 7.702 (ms) [μSD μRSD]/r: 0.068ms 0.88%
    benchStarWarsIntrospectionQuery.........I1 [μ Mo]/r: 61.422 61.422 (ms) [μSD μRSD]/r: 0.205ms 0.33%

10 subjects, 19 iterations, 170 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.027 [59.578 59.583] 0.027 (ms)
⅀T: 703.026ms μSD/r 0.041ms μRSD/r: 0.452%
```

lazy-load-type branch:
```
\GraphQL\Benchmarks\HugeSchemaBench

    benchSchema.............................I0 [μ Mo]/r: 161.602 161.602 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSchemaLazy.........................I0 [μ Mo]/r: 0.033 0.033 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQuery.........................I0 [μ Mo]/r: 192.488 192.488 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQueryLazy.....................I0 [μ Mo]/r: 176.220 176.220 (ms) [μSD μRSD]/r: 0.000ms 0.00%

\GraphQL\Benchmarks\LexerBench

    benchIntrospectionQuery.................I4 [μ Mo]/r: 6.903 6.849 (ms) [μSD μRSD]/r: 0.122ms 1.76%

\GraphQL\Benchmarks\StarWarsBench

    benchSchema.............................I1 [μ Mo]/r: 0.657 0.657 (ms) [μSD μRSD]/r: 0.015ms 2.28%
    benchHeroQuery..........................I1 [μ Mo]/r: 3.012 3.012 (ms) [μSD μRSD]/r: 0.018ms 0.58%
    benchNestedQuery........................I1 [μ Mo]/r: 6.943 6.943 (ms) [μSD μRSD]/r: 0.039ms 0.57%
    benchQueryWithFragment..................I1 [μ Mo]/r: 7.727 7.727 (ms) [μSD μRSD]/r: 0.006ms 0.08%
    benchStarWarsIntrospectionQuery.........I1 [μ Mo]/r: 64.418 64.419 (ms) [μSD μRSD]/r: 0.264ms 0.41%

10 subjects, 19 iterations, 170 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.033 [62.000 61.995] 0.033 (ms)
⅀T: 730.371ms μSD/r 0.046ms μRSD/r: 0.568%
```

With these new changes:
```
\GraphQL\Benchmarks\HugeSchemaBench

    benchSchema.............................I0 [μ Mo]/r: 153.389 153.389 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSchemaLazy.........................I0 [μ Mo]/r: 0.027 0.027 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQuery.........................I0 [μ Mo]/r: 194.549 194.549 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    benchSmallQueryLazy.....................I0 [μ Mo]/r: 176.023 176.023 (ms) [μSD μRSD]/r: 0.000ms 0.00%

\GraphQL\Benchmarks\LexerBench

    benchIntrospectionQuery.................I4 [μ Mo]/r: 6.936 6.915 (ms) [μSD μRSD]/r: 0.044ms 0.63%

\GraphQL\Benchmarks\StarWarsBench

    benchSchema.............................I1 [μ Mo]/r: 0.627 0.627 (ms) [μSD μRSD]/r: 0.000ms 0.03%
    benchHeroQuery..........................I1 [μ Mo]/r: 3.172 3.172 (ms) [μSD μRSD]/r: 0.072ms 2.27%
    benchNestedQuery........................I1 [μ Mo]/r: 7.426 7.426 (ms) [μSD μRSD]/r: 0.104ms 1.40%
    benchQueryWithFragment..................I1 [μ Mo]/r: 7.934 7.934 (ms) [μSD μRSD]/r: 0.141ms 1.77%
    benchStarWarsIntrospectionQuery.........I1 [μ Mo]/r: 62.809 62.809 (ms) [μSD μRSD]/r: 0.170ms 0.27%

10 subjects, 19 iterations, 170 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 0.027 [61.289 61.287] 0.027 (ms)
⅀T: 722.602ms μSD/r 0.053ms μRSD/r: 0.637%
```

I also ran the same benchmark suite using blackfire:

master before lazy-load-type branch:
https://blackfire.io/profiles/fcb3e9f6-b1f8-4bb5-8fe1-adc0b5fcb5ca/graph

lazy-load-type branch:
https://blackfire.io/profiles/2249b69a-ef69-4f12-8d21-37a6b859553b/graph

this branch:
https://blackfire.io/profiles/8c31e726-a77d-4a4d-9944-2aa2ae912fe6/graph


~~So, I don't entirely understand what's happening, yet. Some of the benchmarks seem to have returned to their original values, but for some reason HugeSchemaBench.benchSchema (the one that has 600+ fields, and extracts them all) has gone up a bit. 🤔 I'll have to figure that one out in the morning.~~ edit: I think phpbench is wildly unpredictable and fluctutates a lot from run to run; it probably also doesn't help that I was running a game at the same time. I rebooted, killed other processes, and got a more stable result.

I will keep working on this until I get all the numbers back the way they were, but in the meantime I just wanted to get your thoughts and get the discussion started. Thanks as always for your suggestions. edit: I think I'm satisfied with this now, if you are. Let me know if you want me to keep working at it.