### PR TITLE
check for false node  in visit

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, \\(callable\\)\\|null given\\.$#"
-			count: 4
+			count: 3
 			path: src/Language/Visitor.php
 
 		-

--- a/src/Executor/Values.php
+++ b/src/Executor/Values.php
@@ -314,12 +314,12 @@ class Values
     /**
      * @deprecated as of 0.12 (Use coerceValue() directly for richer information)
      *
-     * @param mixed[] $value
+     * @param mixed[]                                                $value
+     * @param ScalarType|EnumType|InputObjectType|ListOfType|NonNull $type
      *
      * @return string[]
      *
      * @codeCoverageIgnore
-     * @paarm ScalarType|EnumType|InputObjectType|ListOfType|NonNull $type
      */
     public static function isValidPHPValue($value, InputType $type)
     {

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -277,11 +277,16 @@ class Visitor
 
                 $visitFn = self::getVisitFn($visitor, $node->kind, $isLeaving);
 
-                if ($visitFn) {
+                if ($visitFn !== null) {
                     $result    = $visitFn($node, $key, $parent, $path, $ancestors);
                     $editValue = null;
 
-                    if ($result !== null) {
+                    if ($result === false) {
+                        if (! $isLeaving) {
+                            array_pop($path);
+                            continue;
+                        }
+                    } elseif ($result !== null) {
                         if ($result instanceof VisitorOperation) {
                             if ($result->doBreak) {
                                 break;

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -281,12 +281,7 @@ class Visitor
                     $result    = $visitFn($node, $key, $parent, $path, $ancestors);
                     $editValue = null;
 
-                    if ($result === false) {
-                        if (! $isLeaving) {
-                            array_pop($path);
-                            continue;
-                        }
-                    } elseif ($result !== null) {
+                    if ($result !== null) {
                         if ($result instanceof VisitorOperation) {
                             if ($result->doBreak) {
                                 break;

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -417,23 +417,18 @@ class Visitor
 
                     $result = $fn(...func_get_args());
 
-                    if (! ($result instanceof VisitorOperation)) {
-                        if ($result !== null) {
+                    if ($result instanceof VisitorOperation) {
+                        if ($result->doContinue) {
+                            $skipping[$i] = $node;
+                        } elseif ($result->doBreak) {
+                            $skipping[$i] = $result;
+                        } elseif ($result->removeNode) {
                             return $result;
                         }
-                        continue;
-                    }
-
-                    if ($result->doContinue) {
-                        $skipping[$i] = $node;
-                    } elseif ($result->doBreak) {
-                        $skipping[$i] = $result;
-                    } elseif ($result->removeNode) {
+                    } elseif ($result !== null) {
                         return $result;
                     }
                 }
-
-                return null;
             },
             'leave' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) {
                 for ($i = 0; $i < $visitorsCount; $i++) {

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -399,7 +399,7 @@ class Visitor
         $skipping      = new SplFixedArray($visitorsCount);
 
         return [
-            'enter' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) : ?VisitorOperation {
+            'enter' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) {
                 for ($i = 0; $i < $visitorsCount; $i++) {
                     if (! empty($skipping[$i])) {
                         continue;
@@ -418,6 +418,9 @@ class Visitor
                     $result = $fn(...func_get_args());
 
                     if (! ($result instanceof VisitorOperation)) {
+                        if ($result !== null) {
+                            return $result;
+                        }
                         continue;
                     }
 

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -399,7 +399,7 @@ class Visitor
         $skipping      = new SplFixedArray($visitorsCount);
 
         return [
-            'enter' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) {
+            'enter' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) : ?VisitorOperation {
                 for ($i = 0; $i < $visitorsCount; $i++) {
                     if (! empty($skipping[$i])) {
                         continue;
@@ -417,18 +417,20 @@ class Visitor
 
                     $result = $fn(...func_get_args());
 
-                    if ($result instanceof VisitorOperation) {
-                        if ($result->doContinue) {
-                            $skipping[$i] = $node;
-                        } elseif ($result->doBreak) {
-                            $skipping[$i] = $result;
-                        } elseif ($result->removeNode) {
-                            return $result;
-                        }
-                    } elseif ($result !== null) {
+                    if (! ($result instanceof VisitorOperation)) {
+                        continue;
+                    }
+
+                    if ($result->doContinue) {
+                        $skipping[$i] = $node;
+                    } elseif ($result->doBreak) {
+                        $skipping[$i] = $result;
+                    } elseif ($result->removeNode) {
                         return $result;
                     }
                 }
+
+                return null;
             },
             'leave' => static function (Node $node) use ($visitors, $skipping, $visitorsCount) {
                 for ($i = 0; $i < $visitorsCount; $i++) {

--- a/src/Validator/Rules/KnownArgumentNamesOnDirectives.php
+++ b/src/Validator/Rules/KnownArgumentNamesOnDirectives.php
@@ -9,6 +9,8 @@ use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorOperation;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Utils\Utils;
@@ -85,12 +87,12 @@ class KnownArgumentNamesOnDirectives extends ValidationRule
         }
 
         return [
-            NodeKind::DIRECTIVE => static function (DirectiveNode $directiveNode) use ($directiveArgs, $context) : bool {
+            NodeKind::DIRECTIVE => static function (DirectiveNode $directiveNode) use ($directiveArgs, $context) : VisitorOperation {
                 $directiveName = $directiveNode->name->value;
                 $knownArgs     = $directiveArgs[$directiveName] ?? null;
 
                 if ($directiveNode->arguments === null || $knownArgs === null) {
-                    return false;
+                    return Visitor::skipNode();
                 }
 
                 foreach ($directiveNode->arguments as $argNode) {
@@ -106,7 +108,7 @@ class KnownArgumentNamesOnDirectives extends ValidationRule
                     ));
                 }
 
-                return false;
+                return Visitor::skipNode();
             },
         ];
     }


### PR DESCRIPTION
Fix for #685 

A recent [commit](cab1599) introduced a flaw in directive parsing. It seems to have been drawn from the js library, but there's a check for [false](https://github.com/graphql/graphql-js/blob/master/src/language/visitor.js#L308) that apparently didn't get brought over. 

Note: I tried to re-port the entire block in the surrounding code, but the tests blew up. Some day we should re-port the entire visit function, as it has diverged quite a bit.