### PR TITLE
Revert "move execution of lazy type to typeloader"

### DIFF
--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -341,6 +341,10 @@ class Schema
 
         $type = $typeLoader($typeName);
 
+        if (is_callable($type)) {
+            $type = $type();
+        }
+
         if (! $type instanceof Type) {
             throw new InvariantViolation(
                 sprintf(

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -42,7 +42,7 @@ class SchemaConfig
     /** @var Directive[]|null */
     public $directives;
 
-    /** @var callable(string $name):Type|null */
+    /** @var callable|null */
     public $typeLoader;
 
     /** @var SchemaDefinitionNode|null */
@@ -253,7 +253,7 @@ class SchemaConfig
     }
 
     /**
-     * @return callable(string $name):Type|null
+     * @return callable|null
      *
      * @api
      */

--- a/tests/Type/LazyTypeLoaderTest.php
+++ b/tests/Type/LazyTypeLoaderTest.php
@@ -6,7 +6,6 @@ namespace GraphQL\Tests\Type;
 
 use Exception;
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Exception\InvalidArgument;
 use GraphQL\Tests\PHPUnit\ArraySubsetAsserts;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -43,7 +42,7 @@ final class LazyTypeLoaderTest extends TestCase
     /** @var callable */
     private $postStoryMutationInput;
 
-    /** @var callable(string $name):Type */
+    /** @var callable */
     private $typeLoader;
 
     /** @var string[] */
@@ -174,24 +173,24 @@ final class LazyTypeLoaderTest extends TestCase
             },
         ]);
 
-        $this->typeLoader = function (string $name) : Type {
+        $this->typeLoader = function (string $name) : ?callable {
             $this->calls[] = $name;
             $prop          = lcfirst($name);
 
             switch ($prop) {
                 case 'node':
-                    return ($this->node)();
+                    return $this->node;
                 case 'blogStory':
-                    return ($this->blogStory)();
+                    return $this->blogStory;
                 case 'content':
-                    return ($this->content)();
+                    return $this->content;
                 case 'postStoryMutation':
-                    return ($this->postStoryMutation)();
+                    return $this->postStoryMutation;
                 case 'postStoryMutationInput':
-                    return ($this->postStoryMutationInput)();
+                    return $this->postStoryMutationInput;
             }
 
-            throw new InvalidArgument('Unknown type');
+            return null;
         };
     }
 


### PR DESCRIPTION
This reverts commit 484d2dd188fa0ac9267f3a59a62f9b6c60a487d4, the change we discussed that moves responsibility for loading types from client typeloader back to schema.

I'm still sort of not sure, one way or another. I had hoped I would develop a strong opinion after doing the performance work, but still nothing. 🤷 

Do you guys have any insights?