### PR TITLE
Fix double Error wrapping

### DIFF
--- a/src/Executor/Values.php
+++ b/src/Executor/Values.php
@@ -124,7 +124,7 @@ class Values
                                     $error->getSource(),
                                     $error->getPositions(),
                                     $error->getPath(),
-                                    $error,
+                                    $error->getPrevious(),
                                     $error->getExtensions()
                                 );
                             }


### PR DESCRIPTION
Since `$error` already is an instance of the Error class this results in wrapping an Error by another Error which is useless and complicates error handling. In my opinion this should be fixed.