### PR TITLE
cast numbers to string

### DIFF
--- a/src/Language/AST/IntValueNode.php
+++ b/src/Language/AST/IntValueNode.php
@@ -9,6 +9,6 @@ class IntValueNode extends Node implements ValueNode
     /** @var string */
     public $kind = NodeKind::INT;
 
-    /** @var mixed */
+    /** @var string */
     public $value;
 }

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -183,11 +183,11 @@ class Printer
                     },
 
                     NodeKind::INT => static function (IntValueNode $node) : string {
-                        return strval($node->value);
+                        return (string)$node->value;
                     },
 
                     NodeKind::FLOAT => static function (FloatValueNode $node) : string {
-                        return strval($node->value);
+                        return (string)$node->value;
                     },
 
                     NodeKind::STRING => function (StringValueNode $node, $key) {

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -183,11 +183,11 @@ class Printer
                     },
 
                     NodeKind::INT => static function (IntValueNode $node) : string {
-                        return (string)$node->value;
+                        return (string) $node->value;
                     },
 
                     NodeKind::FLOAT => static function (FloatValueNode $node) : string {
-                        return (string)$node->value;
+                        return $node->value;
                     },
 
                     NodeKind::STRING => function (StringValueNode $node, $key) {

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -57,6 +57,7 @@ use function preg_replace;
 use function sprintf;
 use function str_replace;
 use function strpos;
+use function strval;
 
 /**
  * Prints AST to string. Capable of printing GraphQL queries and Type definition language.
@@ -181,12 +182,12 @@ class Printer
                             . $node->selectionSet;
                     },
 
-                    NodeKind::INT => static function (IntValueNode $node) {
-                        return $node->value;
+                    NodeKind::INT => static function (IntValueNode $node) : string {
+                        return strval($node->value);
                     },
 
                     NodeKind::FLOAT => static function (FloatValueNode $node) : string {
-                        return $node->value;
+                        return strval($node->value);
                     },
 
                     NodeKind::STRING => function (StringValueNode $node, $key) {

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -57,7 +57,6 @@ use function preg_replace;
 use function sprintf;
 use function str_replace;
 use function strpos;
-use function strval;
 
 /**
  * Prints AST to string. Capable of printing GraphQL queries and Type definition language.

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -183,7 +183,7 @@ class Printer
                     },
 
                     NodeKind::INT => static function (IntValueNode $node) : string {
-                        return (string) $node->value;
+                        return $node->value;
                     },
 
                     NodeKind::FLOAT => static function (FloatValueNode $node) : string {


### PR DESCRIPTION
I broke this one in one of my stanning throwdowns from a while ago: https://github.com/webonyx/graphql-php/commit/e1bce3275b3b3229d98e4db28183001990c3c64f#diff-6f9b96c905acf9bade29996c9a3639dbR567

The resolve method is supposed to return a nullable string, but can in fact return an int. The issue seems to be the relevant `Printer` lambdas, which were not always returning strings.