### PR TITLE
Revert "Optimize lazy types (#684)"

### DIFF
--- a/src/Type/Definition/FieldArgument.php
+++ b/src/Type/Definition/FieldArgument.php
@@ -30,14 +30,19 @@ class FieldArgument
     /** @var mixed[] */
     public $config;
 
-    /** @var Type&InputType */
+    /** @var InputType&Type */
     private $type;
 
-    /** @param mixed[] $def */
+    /**
+     * @param mixed[] $def
+     */
     public function __construct(array $def)
     {
         foreach ($def as $key => $value) {
             switch ($key) {
+                case 'type':
+                    $this->type = $value;
+                    break;
                 case 'name':
                     $this->name = $value;
                     break;
@@ -75,17 +80,7 @@ class FieldArgument
 
     public function getType() : Type
     {
-        if (! isset($this->type)) {
-            /**
-             * TODO: replace this phpstan cast with native assert
-             *
-             * @var Type&InputType
-             */
-            $type       = Schema::resolveType($this->config['type']);
-            $this->type = $type;
-        }
-
-        return $this->type;
+        return Schema::resolveType($this->type);
     }
 
     public function defaultValueExists() : bool
@@ -107,7 +102,7 @@ class FieldArgument
                 sprintf('%s.%s(%s:) %s', $parentType->name, $parentField->name, $this->name, $e->getMessage())
             );
         }
-        $type = $this->getType();
+        $type = $this->type;
         if ($type instanceof WrappingType) {
             $type = $type->getWrappedType(true);
         }

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -59,7 +59,7 @@ class FieldDefinition
      */
     public $config;
 
-    /** @var OutputType&Type */
+    /** @var callable|(OutputType&Type) */
     public $type;
 
     /** @var callable|string */
@@ -71,6 +71,7 @@ class FieldDefinition
     protected function __construct(array $config)
     {
         $this->name      = $config['name'];
+        $this->type      = $config['type'];
         $this->resolveFn = $config['resolve'] ?? null;
         $this->mapFn     = $config['map'] ?? null;
         $this->args      = isset($config['args']) ? FieldArgument::createMap($config['args']) : [];
@@ -176,17 +177,7 @@ class FieldDefinition
 
     public function getType() : Type
     {
-        if (! isset($this->type)) {
-            /**
-             * TODO: replace this phpstan cast with native assert
-             *
-             * @var Type&OutputType
-             */
-            $type       = Schema::resolveType($this->config['type']);
-            $this->type = $type;
-        }
-
-        return $this->type;
+        return Schema::resolveType($this->type);
     }
 
     /**

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -44,9 +44,6 @@ class InputObjectField
                     break;
                 case 'defaultValueExists':
                     break;
-                case 'type':
-                    // do nothing; type is lazy loaded in getType
-                    break;
                 default:
                     $this->{$k} = $v;
             }
@@ -59,17 +56,12 @@ class InputObjectField
      */
     public function getType() : Type
     {
-        if (! isset($this->type)) {
-            /**
-             * TODO: replace this phpstan cast with native assert
-             *
-             * @var Type&InputType
-             */
-            $type       = Schema::resolveType($this->config['type']);
-            $this->type = $type;
-        }
-
-        return $this->type;
+        /**
+         * TODO: Replace this cast with native assert
+         *
+         * @var Type&InputType
+         */
+        return Schema::resolveType($this->type);
     }
 
     public function defaultValueExists() : bool
@@ -92,7 +84,7 @@ class InputObjectField
         } catch (Error $e) {
             throw new InvariantViolation(sprintf('%s.%s: %s', $parentType->name, $this->name, $e->getMessage()));
         }
-        $type = $this->getType();
+        $type = $this->type;
         if ($type instanceof WrappingType) {
             $type = $type->getWrappedType(true);
         }

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -373,11 +373,11 @@ class Schema
      */
     public static function resolveType($type) : Type
     {
-        if ($type instanceof Type) {
-            return $type;
+        if (is_callable($type)) {
+            return $type();
         }
 
-        return $type();
+        return $type;
     }
 
     /**


### PR DESCRIPTION
This reverts commit 6096b0174c2b40f3bff9889f3a91dcf071bae933.

@mfn Reported that his graphql-laravel tests are breaking since we merged my optimizations. I think we're going to have to hide some previously public members, and try this again in a major version release.