### PR TITLE
Fix public types

### DIFF
--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -6,6 +6,7 @@ namespace GraphQL\Type\Definition;
 
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\Warning;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\Utils;
@@ -187,6 +188,51 @@ class FieldDefinition
         }
 
         return $this->type;
+    }
+
+    public function __isset(string $name) : bool
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed' . 
+                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+
+                return isset($this->type);
+        }
+
+        return false;
+    }
+
+    public function __get(string $name)
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed' . 
+                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+
+                return $this->getType();
+        }
+
+        return null;
+    }
+
+    public function __set(string $name, $value)
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public setter for 'type' on FieldDefinition has been deprecated and will be removed' . 
+                    ' in the next major version.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+                $this->type = $value;
+        }
     }
 
     /**

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -60,7 +60,7 @@ class FieldDefinition
     public $config;
 
     /** @var OutputType&Type */
-    public $type;
+    private $type;
 
     /** @var callable|string */
     private $complexityFn;

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -195,8 +195,8 @@ class FieldDefinition
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed' . 
-                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed" .
+                    " in the next major version. Please update your code to use the 'getType' method.",
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
 
@@ -211,8 +211,8 @@ class FieldDefinition
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed' . 
-                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    "The public getter for 'type' on FieldDefinition has been deprecated and will be removed" .
+                    " in the next major version. Please update your code to use the 'getType' method.",
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
 
@@ -227,8 +227,8 @@ class FieldDefinition
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public setter for 'type' on FieldDefinition has been deprecated and will be removed' . 
-                    ' in the next major version.",
+                    "The public setter for 'type' on FieldDefinition has been deprecated and will be removed" .
+                    ' in the next major version.',
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
                 $this->type = $value;

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -24,7 +24,7 @@ class InputObjectField
     public $description;
 
     /** @var Type&InputType */
-    public $type;
+    private $type;
 
     /** @var InputValueDefinitionNode|null */
     public $astNode;

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -6,6 +6,7 @@ namespace GraphQL\Type\Definition;
 
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\Warning;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\Utils;
@@ -52,6 +53,51 @@ class InputObjectField
             }
         }
         $this->config = $opts;
+    }
+
+    public function __isset(string $name) : bool
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed' . 
+                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+
+                return isset($this->type);
+        }
+
+        return false;
+    }
+
+    public function __get(string $name)
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed' . 
+                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+
+                return $this->getType();
+        }
+
+        return null;
+    }
+
+    public function __set(string $name, $value)
+    {
+        switch ($name) {
+            case 'type':
+                Warning::warnOnce(
+                    "The public setter for 'type' on InputObjectField has been deprecated and will be removed' . 
+                    ' in the next major version.",
+                    Warning::WARNING_CONFIG_DEPRECATION
+                );
+                $this->type = $value;
+        }
     }
 
     /**

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -60,8 +60,8 @@ class InputObjectField
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed' . 
-                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed" .
+                    " in the next major version. Please update your code to use the 'getType' method.",
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
 
@@ -76,8 +76,8 @@ class InputObjectField
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed' . 
-                    ' in the next major version. Please update your code to use the 'getType' method.",
+                    "The public getter for 'type' on InputObjectField has been deprecated and will be removed" .
+                    " in the next major version. Please update your code to use the 'getType' method.",
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
 
@@ -92,8 +92,8 @@ class InputObjectField
         switch ($name) {
             case 'type':
                 Warning::warnOnce(
-                    "The public setter for 'type' on InputObjectField has been deprecated and will be removed' . 
-                    ' in the next major version.",
+                    "The public setter for 'type' on InputObjectField has been deprecated and will be removed" .
+                    ' in the next major version.',
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
                 $this->type = $value;

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -184,7 +184,7 @@ class SchemaExtender
         foreach ($oldFieldMap as $fieldName => $field) {
             $newFieldMap[$fieldName] = [
                 'description' => $field->description,
-                'type' => static::extendType($field->type),
+                'type' => static::extendType($field->getType()),
                 'astNode' => $field->astNode,
             ];
 

--- a/src/Utils/Value.php
+++ b/src/Utils/Value.php
@@ -181,7 +181,7 @@ class Value
                             sprintf(
                                 'Field %s of required type %s was not provided',
                                 $fieldPath,
-                                $field->type->toString()
+                                $field->getType()->toString()
                             ),
                             $blameNode
                         )

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -216,9 +216,10 @@ class DefinitionTest extends TestCase
         ]);
 
         Warning::setWarningHandler(function ($message) : void {
-            $this->assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+            self::assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
         });
 
+        // @phpstan-ignore-next-line type is private, but we're allowing its access temporarily via a magic method
         $type = $fieldDef->type;
     }
 
@@ -230,10 +231,11 @@ class DefinitionTest extends TestCase
         ]);
 
         Warning::setWarningHandler(function ($message) : void {
-            $this->assertEquals($message, 'The public setter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version.');
+            self::assertEquals($message, 'The public setter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version.');
         });
 
-        $fieldDef->type = null;
+        // @phpstan-ignore-next-line type is private, but we're allowing its access temporarily via a magic method
+        $fieldDef->type = Type::int();
     }
 
     public function testPublicTypeIssetDeprecation() : void
@@ -244,7 +246,7 @@ class DefinitionTest extends TestCase
         ]);
 
         Warning::setWarningHandler(function ($message) : void {
-            $this->assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+            self::assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
         });
 
         isset($fieldDef->type);

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace GraphQL\Tests\Type;
 
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\Warning;
 use GraphQL\Tests\PHPUnit\ArraySubsetAsserts;
 use GraphQL\Tests\Type\TestClasses\MyCustomType;
 use GraphQL\Tests\Type\TestClasses\OtherCustom;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ListOfType;
@@ -18,6 +20,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Schema;
+use PHPUnit\Framework\Error\Warning as PhpUnitWarning;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use function count;
@@ -203,6 +206,48 @@ class DefinitionTest extends TestCase
         $feedFieldType = $feedField->getType();
         self::assertInstanceOf('GraphQL\Type\Definition\ListOfType', $feedFieldType);
         self::assertSame($this->blogArticle, $feedFieldType->getWrappedType());
+    }
+
+    public function testPublicTypeDeprecation() : void
+    {
+        $fieldDef = FieldDefinition::create([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(function ($message) : void {
+            $this->assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+        });
+
+        $type = $fieldDef->type;
+    }
+
+    public function testPublicTypeSetDeprecation() : void
+    {
+        $fieldDef = FieldDefinition::create([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(function ($message) : void {
+            $this->assertEquals($message, 'The public setter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version.');
+        });
+
+        $fieldDef->type = null;
+    }
+
+    public function testPublicTypeIssetDeprecation() : void
+    {
+        $fieldDef = FieldDefinition::create([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(function ($message) : void {
+            $this->assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+        });
+
+        isset($fieldDef->type);
     }
 
     /**

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -215,7 +215,7 @@ class DefinitionTest extends TestCase
             'name' => 'GenericField',
         ]);
 
-        Warning::setWarningHandler(function ($message) : void {
+        Warning::setWarningHandler(static function ($message) : void {
             self::assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
         });
 
@@ -230,7 +230,7 @@ class DefinitionTest extends TestCase
             'name' => 'GenericField',
         ]);
 
-        Warning::setWarningHandler(function ($message) : void {
+        Warning::setWarningHandler(static function ($message) : void {
             self::assertEquals($message, 'The public setter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version.');
         });
 
@@ -245,7 +245,7 @@ class DefinitionTest extends TestCase
             'name' => 'GenericField',
         ]);
 
-        Warning::setWarningHandler(function ($message) : void {
+        Warning::setWarningHandler(static function ($message) : void {
             self::assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
         });
 

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -12,6 +12,7 @@ use GraphQL\Tests\Type\TestClasses\OtherCustom;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ListOfType;
@@ -208,7 +209,7 @@ class DefinitionTest extends TestCase
         self::assertSame($this->blogArticle, $feedFieldType->getWrappedType());
     }
 
-    public function testPublicTypeDeprecation() : void
+    public function testFieldDefinitionPublicTypeGetDeprecation() : void
     {
         $fieldDef = FieldDefinition::create([
             'type' => Type::string(),
@@ -223,7 +224,7 @@ class DefinitionTest extends TestCase
         $type = $fieldDef->type;
     }
 
-    public function testPublicTypeSetDeprecation() : void
+    public function testFieldDefinitionPublicTypeSetDeprecation() : void
     {
         $fieldDef = FieldDefinition::create([
             'type' => Type::string(),
@@ -238,7 +239,7 @@ class DefinitionTest extends TestCase
         $fieldDef->type = Type::int();
     }
 
-    public function testPublicTypeIssetDeprecation() : void
+    public function testFieldDefinitionPublicTypeIssetDeprecation() : void
     {
         $fieldDef = FieldDefinition::create([
             'type' => Type::string(),
@@ -247,6 +248,50 @@ class DefinitionTest extends TestCase
 
         Warning::setWarningHandler(static function ($message) : void {
             self::assertEquals($message, 'The public getter for \'type\' on FieldDefinition has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+        });
+
+        isset($fieldDef->type);
+    }
+
+    public function testInputObjectFieldPublicTypeGetDeprecation() : void
+    {
+        $fieldDef = new InputObjectField([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(static function ($message) : void {
+            self::assertEquals($message, 'The public getter for \'type\' on InputObjectField has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
+        });
+
+        // @phpstan-ignore-next-line type is private, but we're allowing its access temporarily via a magic method
+        $type = $fieldDef->type;
+    }
+
+    public function testInputObjectFieldPublicTypeSetDeprecation() : void
+    {
+        $fieldDef = new InputObjectField([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(static function ($message) : void {
+            self::assertEquals($message, 'The public setter for \'type\' on InputObjectField has been deprecated and will be removed in the next major version.');
+        });
+
+        // @phpstan-ignore-next-line type is private, but we're allowing its access temporarily via a magic method
+        $fieldDef->type = Type::int();
+    }
+
+    public function testInputObjectFieldPublicTypeIssetDeprecation() : void
+    {
+        $fieldDef = new InputObjectField([
+            'type' => Type::string(),
+            'name' => 'GenericField',
+        ]);
+
+        Warning::setWarningHandler(static function ($message) : void {
+            self::assertEquals($message, 'The public getter for \'type\' on InputObjectField has been deprecated and will be removed in the next major version. Please update your code to use the \'getType\' method.');
         });
 
         isset($fieldDef->type);


### PR DESCRIPTION
# Background

Recently, I added an optimization that lazy loads all types (whether they are callable or not) on fields. Because the types are no longer written at construction time, it is no longer appropriate or safe to access the `type` fields publicly.

# Changes
* made type private on `FieldDefinition` and `InputObjectField` (it was already private on `FieldArgument` )
* modified a few places in the code to use the getters

This is indeed an API change, so I imagine some kind of version bump will be in order.