### PR TITLE
Handle nullable `DirectiveNode#astNode` in `SchemaValidationContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Fixes:
-- Handle nullable `DirectiveNode#astNode` in `SchemaValidationContext` 
+- Handle nullable `DirectiveNode#astNode` in `SchemaValidationContext` (#708)
 
 ## v14.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Fixes:
+- Handle nullable `DirectiveNode#astNode` in `SchemaValidationContext` 
+
 ## v14.1.0
 
 New:

--- a/src/Type/SchemaValidationContext.php
+++ b/src/Type/SchemaValidationContext.php
@@ -168,9 +168,13 @@ class SchemaValidationContext
         foreach ($directives as $directive) {
             // Ensure all directives are in fact GraphQL directives.
             if (! $directive instanceof Directive) {
+                $nodes = is_object($directive)
+                    ? $directive->astNode
+                    : null;
+
                 $this->reportError(
                     'Expected directive but got: ' . Utils::printSafe($directive) . '.',
-                    is_object($directive) ? $directive->astNode : null
+                    $nodes
                 );
                 continue;
             }
@@ -223,7 +227,7 @@ class SchemaValidationContext
 
             $nodes = Utils::map(
                 $directiveList,
-                static function (Directive $directive) : DirectiveDefinitionNode {
+                static function (Directive $directive) : ?DirectiveDefinitionNode {
                     return $directive->astNode;
                 }
             );


### PR DESCRIPTION
```
TypeError : Return value of GraphQL\Type\SchemaValidationContext::GraphQL\Type\{closure}() must be an instance of GraphQL\Language\AST\DirectiveDefinitionNode, null returned
 /workdir/vendor/webonyx/graphql-php/src/Type/SchemaValidationContext.php:227
 /workdir/vendor/webonyx/graphql-php/src/Utils/Utils.php:172
 /workdir/vendor/webonyx/graphql-php/src/Type/SchemaValidationContext.php:228
 /workdir/vendor/webonyx/graphql-php/src/Type/SchemaValidationContext.php:154
 /workdir/vendor/webonyx/graphql-php/src/Type/Schema.php:527
 /workdir/vendor/webonyx/graphql-php/src/Type/Schema.php:480
 /workdir/src/Console/ValidateSchemaCommand.php:43
```