### PR TITLE
Fix default get/set behavior on InputObjectField and FieldDefinition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86,8 +86,13 @@ parameters:
 			path: src/Type/Definition/EnumType.php
 
 		-
+			message: "#^Variable property access on \\$this\\(GraphQL\\\\Type\\\\Definition\\\\FieldDefinition\\)\\.$#"
+			count: 2
+			path: src/Type/Definition/FieldDefinition.php
+
+		-
 			message: "#^Variable property access on \\$this\\(GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\)\\.$#"
-			count: 1
+			count: 3
 			path: src/Type/Definition/InputObjectField.php
 
 		-
@@ -649,6 +654,16 @@ parameters:
 			message: "#^Only booleans are allowed in a ternary operator condition, GraphQL\\\\Type\\\\Definition\\\\EnumType\\|GraphQL\\\\Type\\\\Definition\\\\InputObjectType\\|GraphQL\\\\Type\\\\Definition\\\\ListOfType\\|GraphQL\\\\Type\\\\Definition\\\\NonNull\\|GraphQL\\\\Type\\\\Definition\\\\ScalarType\\|null given\\.$#"
 			count: 4
 			path: tests/Language/VisitorTest.php
+
+		-
+			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\FieldDefinition\\:\\:\\$nonExistentProp\\.$#"
+			count: 1
+			path: tests/Type/DefinitionTest.php
+
+		-
+			message: "#^Access to an undefined property GraphQL\\\\Type\\\\Definition\\\\InputObjectField\\:\\:\\$nonExistentProp\\.$#"
+			count: 1
+			path: tests/Type/DefinitionTest.php
 
 		-
 			message: "#^Variable property access on \\$this\\(GraphQL\\\\Tests\\\\Type\\\\TypeLoaderTest\\)\\.$#"

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -222,6 +222,8 @@ class FieldDefinition
                 );
 
                 return $this->getType();
+            default:
+                return $this->$name;
         }
 
         return null;
@@ -237,6 +239,11 @@ class FieldDefinition
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
                 $this->type = $value;
+                break;
+
+            default:
+                $this->$name = $value;
+                break;
         }
     }
 

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -82,6 +82,8 @@ class InputObjectField
                 );
 
                 return $this->getType();
+            default:
+                return $this->$name;
         }
 
         return null;
@@ -97,6 +99,11 @@ class InputObjectField
                     Warning::WARNING_CONFIG_DEPRECATION
                 );
                 $this->type = $value;
+                break;
+
+            default:
+                $this->$name = $value;
+                break;
         }
     }
 

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -237,6 +237,9 @@ class DefinitionTest extends TestCase
 
         // @phpstan-ignore-next-line type is private, but we're allowing its access temporarily via a magic method
         $fieldDef->type = Type::int();
+
+        $fieldDef->nonExistentProp = 'someValue';
+        self::assertEquals($fieldDef->nonExistentProp, 'someValue');
     }
 
     public function testFieldDefinitionPublicTypeIssetDeprecation() : void
@@ -295,6 +298,9 @@ class DefinitionTest extends TestCase
         });
 
         isset($fieldDef->type);
+
+        $fieldDef->nonExistentProp = 'someValue';
+        self::assertEquals($fieldDef->nonExistentProp, 'someValue');
     }
 
     /**


### PR DESCRIPTION
As reported by @mfn, my recent addition of `__get`/`__set` magic methods to `FieldDefinition` and `InputObjectFIeld` as caused the portions of his code that rely on the getting and setting of undefined properties to fail. This PR restores the old default functionality.