### PR TITLE
POC - Localized errors

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -83,7 +83,7 @@ class Error extends Exception implements JsonSerializable, ClientAware
     protected $extensions = [];
 
     /**
-     * @param string|ErrorCode             $message
+     * @param string|ErrorCode             $messageOrCode
      * @param Node|Node[]|Traversable|null $nodes
      * @param mixed[]                      $positions
      * @param mixed[]|null                 $path
@@ -100,12 +100,11 @@ class Error extends Exception implements JsonSerializable, ClientAware
         array $extensions = []
     ) {
         if ($messageOrCode instanceof ErrorCode) {
-            $message = $messageOrCode->getFormattedMessage();
-            $this->extensions['code'] = $messageOrCode->getCode();
+            $message                     = $messageOrCode->getFormattedMessage();
+            $this->extensions['code']    = $messageOrCode->getCode();
             $this->extensions['message'] = $messageOrCode->getMessage();
-            $this->extensions['args'] = $messageOrCode->getArgs();
-        }
-        else {
+            $this->extensions['args']    = $messageOrCode->getArgs();
+        } else {
             $message = $messageOrCode;
         }
 
@@ -118,11 +117,10 @@ class Error extends Exception implements JsonSerializable, ClientAware
             $nodes = [$nodes];
         }
 
-        $this->nodes      = $nodes;
-        $this->source     = $source;
-        $this->positions  = $positions;
-        $this->path       = $path;
-
+        $this->nodes     = $nodes;
+        $this->source    = $source;
+        $this->positions = $positions;
+        $this->path      = $path;
 
         $extensions = count($extensions) > 0 ? $extensions : (
         $previous instanceof self
@@ -130,7 +128,7 @@ class Error extends Exception implements JsonSerializable, ClientAware
             : []
         );
 
-        foreach($extensions as $key => $val) {
+        foreach ($extensions as $key => $val) {
             $this->extensions[$key] = $val;
         }
 

--- a/src/Error/ErrorCode.php
+++ b/src/Error/ErrorCode.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Error;
+
+class ErrorCode
+{
+    const ERR_UNKNOWN_DIRECTIVE = 'unknownDirective';
+    const ERR_CANT_SPREAD_FRAGMENT = 'cantSpreadFragment';
+
+    static $messages = [
+        self::ERR_UNKNOWN_DIRECTIVE => 'Unknown directive "%s".',
+        self::ERR_CANT_SPREAD_FRAGMENT => 'Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".'
+    ];
+
+    private $code;
+    private $args;
+
+    function __construct(string $code, array $args = []) {
+        if(!isset(static::$messages[$code])) {
+            throw Exception("Unknown code: " . $code);
+        }
+        $this->code = $code;
+        $this->args = $args;
+    }
+
+    function getFormattedMessage() : string {
+        return sprintf(static::$messages[$this->code], ...$this->args);
+    }
+
+    function getMessage() : string {
+        return static::$messages[$this->code];
+    }
+
+    function getArgs() : array {
+        return $this->args;
+    }
+
+    function getCode() : string {
+        return $this->code;
+    }
+}

--- a/src/Error/ErrorCode.php
+++ b/src/Error/ErrorCode.php
@@ -4,40 +4,58 @@ declare(strict_types=1);
 
 namespace GraphQL\Error;
 
+use Exception;
+use function sprintf;
+
 class ErrorCode
 {
-    const ERR_UNKNOWN_DIRECTIVE = 'unknownDirective';
+    const ERR_UNKNOWN_DIRECTIVE    = 'unknownDirective';
     const ERR_CANT_SPREAD_FRAGMENT = 'cantSpreadFragment';
 
-    static $messages = [
+    /** @var array<string,string> */
+    protected static $messages = [
         self::ERR_UNKNOWN_DIRECTIVE => 'Unknown directive "%s".',
-        self::ERR_CANT_SPREAD_FRAGMENT => 'Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".'
+        self::ERR_CANT_SPREAD_FRAGMENT => 'Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".',
     ];
 
+    /** @var string */
     private $code;
+
+    /** @var mixed[] */
     private $args;
 
-    function __construct(string $code, array $args = []) {
-        if(!isset(static::$messages[$code])) {
-            throw Exception("Unknown code: " . $code);
+    /**
+     * @param mixed[] $args
+     */
+    public function __construct(string $code, array $args = [])
+    {
+        if (! isset(static::$messages[$code])) {
+            throw new Exception('Unknown code: ' . $code);
         }
         $this->code = $code;
         $this->args = $args;
     }
 
-    function getFormattedMessage() : string {
+    public function getFormattedMessage() : string
+    {
         return sprintf(static::$messages[$this->code], ...$this->args);
     }
 
-    function getMessage() : string {
+    public function getMessage() : string
+    {
         return static::$messages[$this->code];
     }
 
-    function getArgs() : array {
+    /**
+     * @return mixed[] array
+     */
+    public function getArgs() : array
+    {
         return $this->args;
     }
 
-    function getCode() : string {
+    public function getCode() : string
+    {
         return $this->code;
     }
 }

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -379,24 +379,23 @@ class FormattedError
     /**
      * @deprecated as of v0.8.0
      *
-     * @param string|ErrorCode           $error
+     * @param string|ErrorCode $error
      * @param SourceLocation[] $locations
      *
      * @return mixed[]
      */
     public static function create($error, array $locations = [])
     {
-        if($error instanceof ErrorCode) {
+        if ($error instanceof ErrorCode) {
             $formatted = [
                 'message' => $error->getFormattedMessage(),
                 'extensions' => [
                     'code' => $error->getCode(),
                     'message' => $error->getMessage(),
-                    'args' => $error->getArgs()
-                ]
+                    'args' => $error->getArgs(),
+                ],
             ];
-        }
-        else {
+        } else {
             $formatted = ['message' => $error];
         }
 

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -379,14 +379,26 @@ class FormattedError
     /**
      * @deprecated as of v0.8.0
      *
-     * @param string           $error
+     * @param string|ErrorCode           $error
      * @param SourceLocation[] $locations
      *
      * @return mixed[]
      */
     public static function create($error, array $locations = [])
     {
-        $formatted = ['message' => $error];
+        if($error instanceof ErrorCode) {
+            $formatted = [
+                'message' => $error->getFormattedMessage(),
+                'extensions' => [
+                    'code' => $error->getCode(),
+                    'message' => $error->getMessage(),
+                    'args' => $error->getArgs()
+                ]
+            ];
+        }
+        else {
+            $formatted = ['message' => $error];
+        }
 
         if (count($locations) > 0) {
             $formatted['locations'] = array_map(

--- a/src/Validator/Rules/PossibleFragmentSpreads.php
+++ b/src/Validator/Rules/PossibleFragmentSpreads.php
@@ -154,7 +154,7 @@ class PossibleFragmentSpreads extends ValidationRule
         return new ErrorCode(ErrorCode::ERR_CANT_SPREAD_FRAGMENT, [
             $fragName,
             $parentType,
-            $fragType
+            $fragType,
         ]);
     }
 }

--- a/src/Validator/Rules/PossibleFragmentSpreads.php
+++ b/src/Validator/Rules/PossibleFragmentSpreads.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQL\Validator\Rules;
 
 use GraphQL\Error\Error;
+use GraphQL\Error\ErrorCode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NodeKind;
@@ -148,13 +149,12 @@ class PossibleFragmentSpreads extends ValidationRule
         return null;
     }
 
-    public static function typeIncompatibleSpreadMessage($fragName, $parentType, $fragType)
+    public static function typeIncompatibleSpreadMessage($fragName, $parentType, $fragType) : ErrorCode
     {
-        return sprintf(
-            'Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".',
+        return new ErrorCode(ErrorCode::ERR_CANT_SPREAD_FRAGMENT, [
             $fragName,
             $parentType,
             $fragType
-        );
+        ]);
     }
 }


### PR DESCRIPTION
Proof of concept for alternative fix to https://github.com/webonyx/graphql-php/pull/713

I didn't want to complete the work until I get some positive feedback, so for now I just converted two errors.

Features:
* backwards compatible. No major bump required.
* All error strings are centralized in one place
* No new public API properties exposed; everything is done with the [extensions](http://spec.graphql.org/draft/#example-fce18) entry on `Error` already provided by the graphql spec 
* errors can be localized on front or back end
* addition of error codes allows client code to do logical branching as desired when errors occur

Notes:
* I didn't bring in the enum class like I did the last time I implemented something like this because I figure we'll already have enough to talk about without it, but the option is always there.
* The `ErrorCode` as first argument to `Error` might be a bit awkward, but the `extensions` argument is currently the seventh argument on the `Error` constructor and I didn't want to make a bigger mess than I had to for right now. If we go all-in on something like this we can rearrange `Error` to be cleaner.

That's the general idea. I expect you guys to have lots of feedback, and I'm ready to do my best to address it. 
