### PR TITLE
fix $debug type in StandardServer::send500Error()

### DIFF
--- a/src/Server/StandardServer.php
+++ b/src/Server/StandardServer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace GraphQL\Server;
 
+use GraphQL\Error\DebugFlag;
 use GraphQL\Error\FormattedError;
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Error\DebugFlag;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Utils\Utils;

--- a/src/Server/StandardServer.php
+++ b/src/Server/StandardServer.php
@@ -6,6 +6,7 @@ namespace GraphQL\Server;
 
 use GraphQL\Error\FormattedError;
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Error\DebugFlag;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Utils\Utils;
@@ -50,12 +51,12 @@ class StandardServer
      * (e.g. during schema instantiation).
      *
      * @param Throwable $error
-     * @param bool      $debug
+     * @param int       $debug
      * @param bool      $exitWhenDone
      *
      * @api
      */
-    public static function send500Error($error, $debug = false, $exitWhenDone = false)
+    public static function send500Error($error, $debug = DebugFlag::NONE, $exitWhenDone = false)
     {
         $response = [
             'errors' => [FormattedError::createFromException($error, $debug)],


### PR DESCRIPTION
`$debug` in `StandardServer::send500Error()` should be `int` in the same way as in definition of the `FormattedError::createFromException()`