### PR TITLE
Fix AST::fromArray conversion of initial values (match initial to expected conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+Fix:
+- Parse `DirectiveDefinitionNode->locations` as `NodeList<NamedNode>` (fixes AST::fromArray conversion) (#723)
+- Parse `Parser::implementsInterfaces` as `NodeList<NamedTypeNode>` (fixes AST::fromArray conversion)
+- Fix signature of `Parser::unionMemberTypes` to match actual `NodeList<NamedTypeNode>`
+
 #### v14.3.0
 
 Feat:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -461,7 +461,7 @@ parameters:
 			path: src/Validator/Rules/KnownDirectives.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<string\\>\\|null given\\.$#"
+			message: "#^Only booleans are allowed in a negated boolean, array|null given\\.$#"
 			count: 1
 			path: src/Validator/Rules/KnownDirectives.php
 

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -108,14 +108,14 @@ use function sprintf;
  * @method static OperationTypeDefinitionNode operationTypeDefinition(Source|string $source, bool[] $options = [])
  * @method static ScalarTypeDefinitionNode scalarTypeDefinition(Source|string $source, bool[] $options = [])
  * @method static ObjectTypeDefinitionNode objectTypeDefinition(Source|string $source, bool[] $options = [])
- * @method static NamedTypeNode[] implementsInterfaces(Source|string $source, bool[] $options = [])
+ * @method static NodeList<NamedTypeNode> implementsInterfaces(Source|string $source, bool[] $options = [])
  * @method static NodeList<FieldDefinitionNode> fieldsDefinition(Source|string $source, bool[] $options = [])
  * @method static FieldDefinitionNode fieldDefinition(Source|string $source, bool[] $options = [])
  * @method static NodeList<InputValueDefinitionNode> argumentsDefinition(Source|string $source, bool[] $options = [])
  * @method static InputValueDefinitionNode inputValueDefinition(Source|string $source, bool[] $options = [])
  * @method static InterfaceTypeDefinitionNode interfaceTypeDefinition(Source|string $source, bool[] $options = [])
  * @method static UnionTypeDefinitionNode unionTypeDefinition(Source|string $source, bool[] $options = [])
- * @method static NamedTypeNode[] unionMemberTypes(Source|string $source, bool[] $options = [])
+ * @method static NodeList<NamedTypeNode> unionMemberTypes(Source|string $source, bool[] $options = [])
  * @method static EnumTypeDefinitionNode enumTypeDefinition(Source|string $source, bool[] $options = [])
  * @method static NodeList<EnumValueDefinitionNode> enumValuesDefinition(Source|string $source, bool[] $options = [])
  * @method static EnumValueDefinitionNode enumValueDefinition(Source|string $source, bool[] $options = [])
@@ -130,7 +130,7 @@ use function sprintf;
  * @method static EnumTypeExtensionNode enumTypeExtension(Source|string $source, bool[] $options = [])
  * @method static InputObjectTypeExtensionNode inputObjectTypeExtension(Source|string $source, bool[] $options = [])
  * @method static DirectiveDefinitionNode directiveDefinition(Source|string $source, bool[] $options = [])
- * @method static DirectiveLocation[] directiveLocations(Source|string $source, bool[] $options = [])
+ * @method static NodeList<NamedNode> directiveLocations(Source|string $source, bool[] $options = [])
  * @method static DirectiveLocation directiveLocation(Source|string $source, bool[] $options = [])
  */
 class Parser
@@ -1220,10 +1220,8 @@ class Parser
      * ImplementsInterfaces :
      *   - implements `&`? NamedType
      *   - ImplementsInterfaces & NamedType
-     *
-     * @return NamedTypeNode[]
      */
-    private function parseImplementsInterfaces() : array
+    private function parseImplementsInterfaces() : NodeList
     {
         $types = [];
         if ($this->expectOptionalKeyword('implements')) {
@@ -1237,7 +1235,7 @@ class Parser
             );
         }
 
-        return $types;
+        return new NodeList($types);
     }
 
     /**
@@ -1746,11 +1744,9 @@ class Parser
     }
 
     /**
-     * @return NameNode[]
-     *
      * @throws SyntaxError
      */
-    private function parseDirectiveLocations() : array
+    private function parseDirectiveLocations() : NodeList
     {
         // Optional leading pipe
         $this->skip(Token::PIPE);
@@ -1759,7 +1755,7 @@ class Parser
             $locations[] = $this->parseDirectiveLocation();
         } while ($this->skip(Token::PIPE));
 
-        return $locations;
+        return new NodeList($locations);
     }
 
     /**

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -130,8 +130,8 @@ use function sprintf;
  * @method static EnumTypeExtensionNode enumTypeExtension(Source|string $source, bool[] $options = [])
  * @method static InputObjectTypeExtensionNode inputObjectTypeExtension(Source|string $source, bool[] $options = [])
  * @method static DirectiveDefinitionNode directiveDefinition(Source|string $source, bool[] $options = [])
- * @method static NodeList<NamedNode> directiveLocations(Source|string $source, bool[] $options = [])
- * @method static DirectiveLocation directiveLocation(Source|string $source, bool[] $options = [])
+ * @method static NodeList<NameNode> directiveLocations(Source|string $source, bool[] $options = [])
+ * @method static NameNode directiveLocation(Source|string $source, bool[] $options = [])
  */
 class Parser
 {

--- a/src/Validator/Rules/KnownDirectives.php
+++ b/src/Validator/Rules/KnownDirectives.php
@@ -36,6 +36,7 @@ use GraphQL\Language\AST\UnionTypeExtensionNode;
 use GraphQL\Language\AST\VariableDefinitionNode;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\Directive;
+use GraphQL\Utils\Utils;
 use GraphQL\Validator\ASTValidationContext;
 use GraphQL\Validator\SDLValidationContext;
 use GraphQL\Validator\ValidationContext;
@@ -76,11 +77,11 @@ class KnownDirectives extends ValidationRule
                 continue;
             }
 
-            $locationsMap[$def->name->value] = array_map(
+            $locationsMap[$def->name->value] = Utils::map(
+                $def->locations,
                 static function ($name) : string {
                     return $name->value;
-                },
-                $def->locations
+                }
             );
         }
 

--- a/tests/Language/ParserTest.php
+++ b/tests/Language/ParserTest.php
@@ -753,6 +753,21 @@ GRAPHQL
             Parser::argumentsDefinition('(foo: Int!)')
         );
 
+        self::assertInstanceOf(
+            NodeList::class,
+            Parser::directiveLocations('| INPUT_OBJECT | OBJECT')
+        );
+
+        self::assertInstanceOf(
+            NodeList::class,
+            Parser::implementsInterfaces('implements Foo & Bar')
+        );
+
+        self::assertInstanceOf(
+            NodeList::class,
+            Parser::unionMemberTypes('= | Foo | Bar')
+        );
+
         $this->expectException(SyntaxError::class);
         Parser::constValueLiteral('$foo');
     }


### PR DESCRIPTION
- Parse `DirectiveDefinitionNode->locations` as `NodeList<NamedNode>`
- Parse `Parser::implementsInterfaces` as `NodeList<NamedTypeNode>`
- Update signature of `Parser::unionMemberTypes` to match actual `NodeList<NamedTypeNode>`

Fixes #723

Note: I wasn't sure how to address the phpstan error so I updated the baseline. I can revisit this if necessary.

```
 ------ ----------------------------------------------------------------------- 
  Line   src/Validator/Rules/KnownDirectives.php                                
 ------ ----------------------------------------------------------------------- 
         Ignored error pattern #^Only booleans are allowed in a negated         
         boolean, array<string\>\|null given\.$# in path                        
         /home/zimzat/files/sources/graphql-php/src/Validator/Rules/KnownDirec  
         tives.php was not matched in reported errors.                          
  102    Only booleans are allowed in a negated boolean, array|null given.      
 ------ ----------------------------------------------------------------------- 
```