### PR TITLE
Support DocumentNode, AST in Helper

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -19,6 +19,7 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema as SchemaType;
+use GraphQL\Utils\AST;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\ValidationRule;
@@ -45,7 +46,8 @@ class GraphQL
      * schema:
      *    The GraphQL type system to use when validating and executing a query.
      * source:
-     *    A GraphQL language formatted string representing the requested operation.
+     *    A GraphQL language formatted string representing the requested operation. You can also pass a DocumentNode,
+     *    or an array representation of an AST.
      * rootValue:
      *    The value provided as the first argument to resolver functions on the top
      *    level type (e.g. the query object type).
@@ -70,7 +72,7 @@ class GraphQL
      *    Empty array would allow to skip query validation (may be convenient for persisted
      *    queries which are validated before persisting and assumed valid during execution)
      *
-     * @param string|DocumentNode $source
+     * @param string|DocumentNode|array $source
      * @param mixed               $rootValue
      * @param mixed               $contextValue
      * @param mixed[]|null        $variableValues
@@ -131,6 +133,8 @@ class GraphQL
         try {
             if ($source instanceof DocumentNode) {
                 $documentNode = $source;
+            } else if (AST::isAst($source)) {
+                $documentNode = AST::fromArray($source);
             } else {
                 $documentNode = Parser::parse(new Source($source ?? '', 'GraphQL'));
             }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -72,11 +72,11 @@ class GraphQL
      *    Empty array would allow to skip query validation (may be convenient for persisted
      *    queries which are validated before persisting and assumed valid during execution)
      *
-     * @param string|DocumentNode|array $source
-     * @param mixed               $rootValue
-     * @param mixed               $contextValue
-     * @param mixed[]|null        $variableValues
-     * @param ValidationRule[]    $validationRules
+     * @param string|DocumentNode|mixed[] $source
+     * @param mixed                       $rootValue
+     * @param mixed                       $contextValue
+     * @param mixed[]|null                $variableValues
+     * @param ValidationRule[]            $validationRules
      *
      * @api
      */
@@ -133,7 +133,7 @@ class GraphQL
         try {
             if ($source instanceof DocumentNode) {
                 $documentNode = $source;
-            } else if (AST::isAst($source)) {
+            } elseif (AST::isAst($source)) {
                 $documentNode = AST::fromArray($source);
             } else {
                 $documentNode = Parser::parse(new Source($source ?? '', 'GraphQL'));

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -166,7 +166,13 @@ class Helper
             $errors[] = new RequestError('GraphQL Request parameters "query" and "queryId" are mutually exclusive');
         }
 
-        if ($params->query !== null && ! (is_string($params->query) || $params->query instanceof DocumentNode || AST::isAst($params->query))) {
+        if ($params->query !== null
+            && ! (
+                is_string($params->query)
+                || $params->query instanceof DocumentNode
+                || AST::isAst($params->query)
+            )
+        ) {
             $errors[] = new RequestError(
                 'GraphQL Request parameter "query" must be string, a DocumentNode, or an array representation of an AST, but got ' .
                 Utils::printSafeJson($params->query)

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -289,7 +289,9 @@ class Helper
 
             $doc = $op->queryId
                 ? $this->loadPersistedQuery($config, $op)
-                : (AST::isAst($op->query) ? AST::fromArray($op->query) : $op->query);
+                : (AST::isAst($op->query)
+                    ? AST::fromArray($op->query)
+                    : $op->query);
 
             if (! $doc instanceof DocumentNode) {
                 $doc = Parser::parse($doc);

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -15,7 +15,6 @@ use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\GraphQL;
 use GraphQL\Language\AST\DocumentNode;
-use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Parser;
 use GraphQL\Utils\AST;
 use GraphQL\Utils\Utils;

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -89,7 +89,7 @@ class AST
      */
     public static function fromArray(array $node) : Node
     {
-        if (! isset($node['kind']) || ! isset(NodeKind::$classMap[$node['kind']])) {
+        if (! static::isAst($node)) {
             throw new InvariantViolation('Unexpected node structure: ' . Utils::printSafeJson($node));
         }
 
@@ -116,6 +116,14 @@ class AST
         }
 
         return $instance;
+    }
+
+    /**
+     * @param mixed[] $node
+     */
+    public static function isAst($node) : bool
+    {
+        return isset($node['kind']) && isset(NodeKind::$classMap[$node['kind']]);
     }
 
     /**

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -121,9 +121,9 @@ class AST
     /**
      * @param mixed $maybeNode
      */
-    public static function isAst($node) : bool
+    public static function isAst($maybeNode) : bool
     {
-        return isset($node['kind']) && isset(NodeKind::$classMap[$node['kind']]);
+        return isset($maybeNode['kind']) && isset(NodeKind::$classMap[$maybeNode['kind']]);
     }
 
     /**

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -119,7 +119,7 @@ class AST
     }
 
     /**
-     * @param mixed[] $node
+     * @param mixed $maybeNode
      */
     public static function isAst($node) : bool
     {

--- a/tests/Server/RequestValidationTest.php
+++ b/tests/Server/RequestValidationTest.php
@@ -92,7 +92,7 @@ class RequestValidationTest extends TestCase
 
         $this->assertInputError(
             $parsedBody,
-            'GraphQL Request parameter "query" must be string, but got {"t":"{my query}"}'
+            'GraphQL Request parameter "query" must be string, a DocumentNode, or an array representation of an AST, but got {"t":"{my query}"}'
         );
     }
 


### PR DESCRIPTION
Fix for #279 

Recently I've started experimenting with [graphql-tag](https://github.com/apollographql/graphql-tag). It's a node package popular with users of [apollographql](https://github.com/apollographql?type=source) that does the parsing of graphql queries in the js layer (mainly so that Apollo can do merging and other operations on the AST, which is difficult on a string query).

As noted in issue #279, this library does not directly support an AST structure. I'm aware that you can doctor the incoming request using `AST::fromArray` before passing it to `\GraphQL\GraphQL::executeQuery`, but my original client code was using `StandardServer` and this does not expose any hook where this kind of preprocessing can happen.

So, in this PR I add knowledge of both `DocumentNode` and array representations of AST to `Helper`.

I'll wait for the green light before adding tests.

~~edit: note that I didn't actually change anything in the `GraphQL::executeQuery` entry point; wasn't sure how much push back I'm going to get on this, but I'm happy to modify it as well if anyone wants it.~~ Added the functionality.