### PR TITLE
Fix the `@var` type hint for various `NodeList<Node>` usages.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -311,17 +311,7 @@ parameters:
 			path: src/Utils/ASTDefinitionBuilder.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\<GraphQL\\\\Language\\\\AST\\\\NamedTypeNode\\> given\\.$#"
-			count: 1
-			path: src/Utils/ASTDefinitionBuilder.php
-
-		-
 			message: "#^Only booleans are allowed in a ternary operator condition, GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\EnumValueDefinitionNode\\>\\|null given\\.$#"
-			count: 1
-			path: src/Utils/ASTDefinitionBuilder.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, array\\<GraphQL\\\\Language\\\\AST\\\\InputValueDefinitionNode\\>\\|null given\\.$#"
 			count: 1
 			path: src/Utils/ASTDefinitionBuilder.php
 
@@ -337,11 +327,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, GraphQL\\\\Language\\\\AST\\\\SchemaDefinitionNode\\|null given\\.$#"
-			count: 1
-			path: src/Utils/SchemaExtender.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<GraphQL\\\\Language\\\\AST\\\\OperationTypeDefinitionNode\\>\\|null given\\.$#"
 			count: 1
 			path: src/Utils/SchemaExtender.php
 

--- a/src/Language/AST/DirectiveDefinitionNode.php
+++ b/src/Language/AST/DirectiveDefinitionNode.php
@@ -15,12 +15,12 @@ class DirectiveDefinitionNode extends Node implements TypeSystemDefinitionNode
     /** @var StringValueNode|null */
     public $description;
 
-    /** @var InputValueDefinitionNode[] */
+    /** @var NodeList<InputValueDefinitionNode> */
     public $arguments;
 
     /** @var bool */
     public $repeatable;
 
-    /** @var NameNode[] */
+    /** @var NodeList<NameNode> */
     public $locations;
 }

--- a/src/Language/AST/DirectiveNode.php
+++ b/src/Language/AST/DirectiveNode.php
@@ -12,6 +12,6 @@ class DirectiveNode extends Node
     /** @var NameNode */
     public $name;
 
-    /** @var ArgumentNode[] */
+    /** @var NodeList<ArgumentNode> */
     public $arguments;
 }

--- a/src/Language/AST/EnumTypeDefinitionNode.php
+++ b/src/Language/AST/EnumTypeDefinitionNode.php
@@ -12,7 +12,7 @@ class EnumTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var NodeList<EnumValueDefinitionNode>|null */

--- a/src/Language/AST/EnumTypeExtensionNode.php
+++ b/src/Language/AST/EnumTypeExtensionNode.php
@@ -12,9 +12,9 @@ class EnumTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var EnumValueDefinitionNode[]|null */
+    /** @var NodeList<EnumValueDefinitionNode>|null */
     public $values;
 }

--- a/src/Language/AST/EnumValueDefinitionNode.php
+++ b/src/Language/AST/EnumValueDefinitionNode.php
@@ -12,7 +12,7 @@ class EnumValueDefinitionNode extends Node
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/FieldNode.php
+++ b/src/Language/AST/FieldNode.php
@@ -15,10 +15,10 @@ class FieldNode extends Node implements SelectionNode
     /** @var NameNode|null */
     public $alias;
 
-    /** @var ArgumentNode[]|null */
+    /** @var NodeList<ArgumentNode>|null */
     public $arguments;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
     /** @var SelectionSetNode|null */

--- a/src/Language/AST/FragmentSpreadNode.php
+++ b/src/Language/AST/FragmentSpreadNode.php
@@ -12,6 +12,6 @@ class FragmentSpreadNode extends Node implements SelectionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 }

--- a/src/Language/AST/InlineFragmentNode.php
+++ b/src/Language/AST/InlineFragmentNode.php
@@ -12,7 +12,7 @@ class InlineFragmentNode extends Node implements SelectionNode
     /** @var NamedTypeNode */
     public $typeCondition;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
     /** @var SelectionSetNode */

--- a/src/Language/AST/InputObjectTypeDefinitionNode.php
+++ b/src/Language/AST/InputObjectTypeDefinitionNode.php
@@ -12,10 +12,10 @@ class InputObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var InputValueDefinitionNode[]|null */
+    /** @var NodeList<InputValueDefinitionNode>|null */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/InputObjectTypeExtensionNode.php
+++ b/src/Language/AST/InputObjectTypeExtensionNode.php
@@ -12,9 +12,9 @@ class InputObjectTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var InputValueDefinitionNode[]|null */
+    /** @var NodeList<InputValueDefinitionNode>|null */
     public $fields;
 }

--- a/src/Language/AST/InputValueDefinitionNode.php
+++ b/src/Language/AST/InputValueDefinitionNode.php
@@ -18,7 +18,7 @@ class InputValueDefinitionNode extends Node
     /** @var VariableNode|NullValueNode|IntValueNode|FloatValueNode|StringValueNode|BooleanValueNode|EnumValueNode|ListValueNode|ObjectValueNode|null */
     public $defaultValue;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/InterfaceTypeDefinitionNode.php
+++ b/src/Language/AST/InterfaceTypeDefinitionNode.php
@@ -12,10 +12,10 @@ class InterfaceTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var FieldDefinitionNode[]|null */
+    /** @var NodeList<FieldDefinitionNode>|null */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/InterfaceTypeExtensionNode.php
+++ b/src/Language/AST/InterfaceTypeExtensionNode.php
@@ -12,9 +12,9 @@ class InterfaceTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var FieldDefinitionNode[]|null */
+    /** @var NodeList<FieldDefinitionNode>|null */
     public $fields;
 }

--- a/src/Language/AST/ObjectTypeDefinitionNode.php
+++ b/src/Language/AST/ObjectTypeDefinitionNode.php
@@ -12,13 +12,13 @@ class ObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NamedTypeNode[] */
-    public $interfaces = [];
+    /** @var NodeList<NamedTypeNode> */
+    public $interfaces;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var FieldDefinitionNode[]|null */
+    /** @var NodeList<FieldDefinitionNode>|null */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/ObjectTypeExtensionNode.php
+++ b/src/Language/AST/ObjectTypeExtensionNode.php
@@ -12,12 +12,12 @@ class ObjectTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NamedTypeNode[] */
-    public $interfaces = [];
+    /** @var NodeList<NamedTypeNode> */
+    public $interfaces;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var FieldDefinitionNode[] */
+    /** @var NodeList<FieldDefinitionNode> */
     public $fields;
 }

--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -15,10 +15,10 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
     /** @var string (oneOf 'query', 'mutation')) */
     public $operation;
 
-    /** @var VariableDefinitionNode[] */
+    /** @var NodeList<VariableDefinitionNode> */
     public $variableDefinitions;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var SelectionSetNode */

--- a/src/Language/AST/ScalarTypeDefinitionNode.php
+++ b/src/Language/AST/ScalarTypeDefinitionNode.php
@@ -12,7 +12,7 @@ class ScalarTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/ScalarTypeExtensionNode.php
+++ b/src/Language/AST/ScalarTypeExtensionNode.php
@@ -12,6 +12,6 @@ class ScalarTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 }

--- a/src/Language/AST/SchemaDefinitionNode.php
+++ b/src/Language/AST/SchemaDefinitionNode.php
@@ -9,9 +9,9 @@ class SchemaDefinitionNode extends Node implements TypeSystemDefinitionNode
     /** @var string */
     public $kind = NodeKind::SCHEMA_DEFINITION;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var OperationTypeDefinitionNode[] */
+    /** @var NodeList<OperationTypeDefinitionNode> */
     public $operationTypes;
 }

--- a/src/Language/AST/SchemaTypeExtensionNode.php
+++ b/src/Language/AST/SchemaTypeExtensionNode.php
@@ -9,9 +9,9 @@ class SchemaTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var string */
     public $kind = NodeKind::SCHEMA_EXTENSION;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
-    /** @var OperationTypeDefinitionNode[]|null */
+    /** @var NodeList<OperationTypeDefinitionNode>|null */
     public $operationTypes;
 }

--- a/src/Language/AST/SelectionSetNode.php
+++ b/src/Language/AST/SelectionSetNode.php
@@ -9,6 +9,6 @@ class SelectionSetNode extends Node
     /** @var string */
     public $kind = NodeKind::SELECTION_SET;
 
-    /** @var SelectionNode[] */
+    /** @var NodeList<SelectionNode&Node> */
     public $selections;
 }

--- a/src/Language/AST/UnionTypeDefinitionNode.php
+++ b/src/Language/AST/UnionTypeDefinitionNode.php
@@ -12,7 +12,7 @@ class UnionTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var NodeList<NamedTypeNode>|null */

--- a/src/Language/AST/UnionTypeExtensionNode.php
+++ b/src/Language/AST/UnionTypeExtensionNode.php
@@ -12,7 +12,7 @@ class UnionTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var DirectiveNode[]|null */
+    /** @var NodeList<DirectiveNode>|null */
     public $directives;
 
     /** @var NodeList<NamedTypeNode>|null */

--- a/src/Language/AST/VariableDefinitionNode.php
+++ b/src/Language/AST/VariableDefinitionNode.php
@@ -18,6 +18,6 @@ class VariableDefinitionNode extends Node implements DefinitionNode
     /** @var VariableNode|NullValueNode|IntValueNode|FloatValueNode|StringValueNode|BooleanValueNode|EnumValueNode|ListValueNode|ObjectValueNode|null */
     public $defaultValue;
 
-    /** @var DirectiveNode[] */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 }

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -331,7 +331,7 @@ class ASTDefinitionBuilder
 
     private function makeImplementedInterfaces(ObjectTypeDefinitionNode $def)
     {
-        if ($def->interfaces) {
+        if ($def->interfaces !== null) {
             // Note: While this could make early assertions to get the correctly
             // typed values, that would throw immediately while type system
             // validation with validateSchema() will produce more actionable results.
@@ -424,7 +424,7 @@ class ASTDefinitionBuilder
             'name'        => $def->name->value,
             'description' => $this->getDescription($def),
             'fields'      => function () use ($def) {
-                return $def->fields
+                return $def->fields !== null
                     ? $this->makeInputValues($def->fields)
                     : [];
             },

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -597,7 +597,7 @@ class SchemaExtender
         }
 
         foreach ($schemaExtensions as $schemaExtension) {
-            if (! $schemaExtension->operationTypes) {
+            if ($schemaExtension->operationTypes === null) {
                 continue;
             }
 


### PR DESCRIPTION
- Remove ` = []` from a couple of usages, as this is now considered invalid typing.
- Adjust a few boolean checks to explicitly check for ` === null` now
    - (the default when not set during manual construction prior to typed properties).

### Discussion:
With regard to ` = []` and/or `|null`/` = null`, what approach would you want the library to take?

If you want the library to start using `public NodeList $interfaces`, after PHP 7.4 becomes the minimum version, then attempting to access it directly would cause uninitialized errors unless it's `public ?NodeList $interfaces = null`. Ensuring it's always initialized with the expected value would allow for fluid object access. At initial glance I don't see anywhere things are _explicitly_ set to null (though I could be very wrong) so maintaining nullability doesn't seem necessary?

Direction:
- Find a way to ensure they're always initialized as NodeList during construction?
    - Extending the `__construct()` method to do something like `$this->interfaces = $this->interfaces ?? new NodeList([])` is one possibility.
- Mark _all_ of them as `|null` and default to ` = null`?
- Other?

I'd lean toward ensuring they're initialized as NodeList, but could see going some other way depending on where you see the architecture going.

Thanks!