### PR TITLE
propagate PHP errors

### DIFF
--- a/examples/01-blog/Blog/Type/Scalar/EmailType.php
+++ b/examples/01-blog/Blog/Type/Scalar/EmailType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace GraphQL\Examples\Blog\Type\Scalar;
 
 use GraphQL\Error\Error;
@@ -26,7 +29,7 @@ class EmailType extends CustomScalarType
     public static function s_serialize($value)
     {
         // Assuming internal representation of email is always correct:
-        return $value;
+        return number_format($value);
 
         // If it might be incorrect and you want to make sure that only correct values are included in response -
         // use following line instead:

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -911,8 +911,8 @@ class ReferenceExecutor implements ExecutorImplementation
     {
         try {
             return $returnType->serialize($result);
-        } catch (TypeError $error) {
-            throw $error;
+        //} catch (TypeError $error) {
+        //    throw $error;
         } catch (Throwable $error) {
             throw new InvariantViolation(
                 'Expected a value of type "' . Utils::printSafe($returnType) . '" but received: ' . Utils::printSafe($result),

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -41,6 +41,7 @@ use SplObjectStorage;
 use stdClass;
 use Throwable;
 use Traversable;
+use TypeError;
 use function array_keys;
 use function array_merge;
 use function array_reduce;
@@ -910,6 +911,8 @@ class ReferenceExecutor implements ExecutorImplementation
     {
         try {
             return $returnType->serialize($result);
+        } catch (TypeError $error) {
+            throw $error;
         } catch (Throwable $error) {
             throw new InvariantViolation(
                 'Expected a value of type "' . Utils::printSafe($returnType) . '" but received: ' . Utils::printSafe($result),


### PR DESCRIPTION
When I use `serialize` on custom scalar type with an type error inside (wrong number of arguments or wrong argument type - `\ArgumentCountError` or `\TypeError`) the original error message is supressed and changed to hardcoded one (`Expected a value of type * but received: instance of *`). Much better for developing or debugging would be to know the real error.

e.g.:

```php
// in custom scalar type
public static serialize(): string
{
    return static::customScalarTypeSerialize(/*any args*/);
}

public static function customScalarTypeSerialize(/*any args*/): string
{
    return number_format('string value'); // first argument must be float when defined declare(strict_types=1), otherwise \TypeError is thrown
}
```

Maybe this is the only one of many similar troubles.

---

I am not really sure whenever my solutions is OK but this issue really borthers me. If you give me some hints about better solution or how this change should be tested I will try to give it more time to get this done.