### PR TITLE
Update Type.php

### DIFF
--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -32,7 +32,7 @@ abstract class Type implements JsonSerializable
     public const FLOAT   = 'Float';
     public const ID      = 'ID';
 
-    /** @var array<string, ScalarType>> */
+    /** @var array<string, ScalarType> */
     protected static $standardTypes;
 
     /** @var Type[] */
@@ -58,7 +58,7 @@ abstract class Type implements JsonSerializable
      */
     public static function id() : ScalarType
     {
-        if ((static::$standardTypes[self::ID] ?? null) === null) {
+        if (!isset(static::$standardTypes[self::ID])) {
             static::$standardTypes[self::ID] = new IDType();
         }
 
@@ -70,7 +70,7 @@ abstract class Type implements JsonSerializable
      */
     public static function string() : ScalarType
     {
-        if ((static::$standardTypes[self::STRING] ?? null) === null) {
+        if (!isset(static::$standardTypes[self::STRING])) {
             static::$standardTypes[self::STRING] = new StringType();
         }
 
@@ -82,7 +82,7 @@ abstract class Type implements JsonSerializable
      */
     public static function boolean() : ScalarType
     {
-        if ((static::$standardTypes[self::BOOLEAN] ?? null) === null) {
+        if (!isset(static::$standardTypes[self::BOOLEAN])) {
             static::$standardTypes[self::BOOLEAN] = new BooleanType();
         }
 
@@ -94,7 +94,7 @@ abstract class Type implements JsonSerializable
      */
     public static function int() : ScalarType
     {
-        if ((static::$standardTypes[self::INT] ?? null) === null) {
+        if (!isset(static::$standardTypes[self::INT])) {
             static::$standardTypes[self::INT] = new IntType();
         }
 
@@ -106,7 +106,7 @@ abstract class Type implements JsonSerializable
      */
     public static function float() : ScalarType
     {
-        if ((static::$standardTypes[self::FLOAT] ?? null) === null) {
+        if (!isset(static::$standardTypes[self::FLOAT])) {
             static::$standardTypes[self::FLOAT] = new FloatType();
         }
 

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -58,7 +58,7 @@ abstract class Type implements JsonSerializable
      */
     public static function id() : ScalarType
     {
-        if (!isset(static::$standardTypes[self::ID])) {
+        if (! isset(static::$standardTypes[self::ID])) {
             static::$standardTypes[self::ID] = new IDType();
         }
 
@@ -70,7 +70,7 @@ abstract class Type implements JsonSerializable
      */
     public static function string() : ScalarType
     {
-        if (!isset(static::$standardTypes[self::STRING])) {
+        if (! isset(static::$standardTypes[self::STRING])) {
             static::$standardTypes[self::STRING] = new StringType();
         }
 
@@ -82,7 +82,7 @@ abstract class Type implements JsonSerializable
      */
     public static function boolean() : ScalarType
     {
-        if (!isset(static::$standardTypes[self::BOOLEAN])) {
+        if (! isset(static::$standardTypes[self::BOOLEAN])) {
             static::$standardTypes[self::BOOLEAN] = new BooleanType();
         }
 
@@ -94,7 +94,7 @@ abstract class Type implements JsonSerializable
      */
     public static function int() : ScalarType
     {
-        if (!isset(static::$standardTypes[self::INT])) {
+        if (! isset(static::$standardTypes[self::INT])) {
             static::$standardTypes[self::INT] = new IntType();
         }
 
@@ -106,7 +106,7 @@ abstract class Type implements JsonSerializable
      */
     public static function float() : ScalarType
     {
-        if (!isset(static::$standardTypes[self::FLOAT])) {
+        if (! isset(static::$standardTypes[self::FLOAT])) {
             static::$standardTypes[self::FLOAT] = new FloatType();
         }
 


### PR DESCRIPTION
Is there a reason to do this weird double check:
```php
if ((static::$standardTypes[self::ID] ?? null) === null)
```
instead of just this:
```php
if (!isset(static::$standardTypes[self::ID]))
```

`$value ?? $anotherValue` is just a sugar syntax for `isset($value) ? $value : $anotherValue`