### PR TITLE
Specify 'subscription' as valid $operation value

### DIFF
--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -12,7 +12,7 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
     /** @var NameNode|null */
     public $name;
 
-    /** @var string (oneOf 'query', 'mutation')) */
+    /** @var string (oneOf 'query', 'mutation', 'subscription')) */
     public $operation;
 
     /** @var NodeList<VariableDefinitionNode> */


### PR DESCRIPTION
`Parser::parseOperationDefinition` will create a `OperationDefinitionNode`
and propagate the `operation` type it finds. In `::parseExecutableDefinition`
the function is called with `query`, `mutation`, or `subscription`. This means
`OperationDefinitionNode` can exist where `$operation` is `subscription`.

The property type annotation doesn't currently match with this possible 
behaviour so we should update it :)