### PR TITLE
Update to shivammathur/setup-php@2.9.0

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@2.2.2
+      uses: shivammathur/setup-php@2.9.0
       with:
         php-version: 7.1
         coverage: none
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@2.2.2
+      uses: shivammathur/setup-php@2.9.0
       with:
         php-version: 7.1
         coverage: none
@@ -122,7 +122,7 @@ jobs:
         ref: ${{ github.ref }}
 
     - name: Install PHP
-      uses: shivammathur/setup-php@2.2.2
+      uses: shivammathur/setup-php@2.9.0
       with:
         php-version: 7.2
         coverage: pcov

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install PHP
-      uses: shivammathur/setup-php@2.2.2
+      uses: shivammathur/setup-php@2.9.0
       with:
         php-version: ${{ matrix.php  }}
         coverage: none


### PR DESCRIPTION
**Problem**
`set-env` and `add-path` are disabled in GitHub actions. 
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This causes the tests in all PRs to fail until resolved.

**Solution**
This requires an update to the action using those
commands. This means at least version 2.6.0 is
needed. See https://github.com/shivammathur/setup-php/pull/300

However there seem to be no breaking changes so we
can go straight to 2.9.0 instead. This also allows testing
with version 8.x of PHP.