### PR TITLE
Fix PHP 8 deprecation: Required parameters after optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Fix:
 - Parse `DirectiveDefinitionNode->locations` as `NodeList<NamedNode>` (fixes AST::fromArray conversion) (#723)
 - Parse `Parser::implementsInterfaces` as `NodeList<NamedTypeNode>` (fixes AST::fromArray conversion)
 - Fix signature of `Parser::unionMemberTypes` to match actual `NodeList<NamedTypeNode>`
+- Fix signature of `Error\FormattedError::prepareFormatter()` to address PHP8 deprecation (#742)
 
 #### v14.3.0
 

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -277,7 +277,7 @@ class FormattedError
      * Prepares final error formatter taking in account $debug flags.
      * If initial formatter is not set, FormattedError::createFromException is used
      */
-    public static function prepareFormatter(?callable $formatter = null, int $debug) : callable
+    public static function prepareFormatter(?callable $formatter, int $debug) : callable
     {
         $formatter = $formatter ?? static function ($e) : array {
             return FormattedError::createFromException($e);


### PR DESCRIPTION
PHP8 produces a deprecation notice when required parameters are defined following optional parameters. This PR addresses this concern in `Error\FormatteError::prepareFormatter()`, the only place I identified the issue occurring in my tests.

Fixes: #742 