### PR TITLE
Test on PHP 8

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,14 @@ jobs:
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
 
+    - name: Remove dependencies not used in this job for PHP 8 compatibility
+      run: |
+        composer remove --dev --no-update phpbench/phpbench
+        composer remove --dev --no-update phpstan/phpstan
+        composer remove --dev --no-update phpstan/phpstan-phpunit
+        composer remove --dev --no-update phpstan/phpstan-strict-rules
+        composer remove --dev --no-update doctrine/coding-standard
+
     - name: Install Dependencies
       run: composer update ${DEPENDENCIES}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,14 +40,6 @@ jobs:
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
 
-    - name: Remove dependencies not used in this job for PHP 8 compatibility
-      run: |
-        composer remove --dev --no-update phpbench/phpbench
-        composer remove --dev --no-update phpstan/phpstan
-        composer remove --dev --no-update phpstan/phpstan-phpunit
-        composer remove --dev --no-update phpstan/phpstan-strict-rules
-        composer remove --dev --no-update doctrine/coding-standard
-
     - name: Install Dependencies
       run: composer update ${DEPENDENCIES}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
 
     - name: Install Dependencies
-      run: composer update ${DEPENDENCIES}
+      run: composer update ${DEPENDENCIES} --ignore-platform-req=php
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,14 @@ jobs:
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
 
+    - name: Remove dependencies not used in this job for PHP 8 compatibility
+      run: |
+        composer remove --dev --no-update phpbench/phpbench
+        composer remove --dev --no-update phpstan/phpstan
+        composer remove --dev --no-update phpstan/phpstan-phpunit
+        composer remove --dev --no-update phpstan/phpstan-strict-rules
+        composer remove --dev --no-update doctrine/coding-standard
+
     - name: Install Dependencies
       run: composer install ${DEPENDENCIES}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -49,7 +49,7 @@ jobs:
         composer remove --dev --no-update doctrine/coding-standard
 
     - name: Install Dependencies
-      run: composer install ${DEPENDENCIES}
+      run: composer update ${DEPENDENCIES}
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
 
     - name: Install Dependencies
-      run: composer update ${DEPENDENCIES} --ignore-platform-req=php
+      run: composer update ${DEPENDENCIES}
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
         env: [
           'EXECUTOR= DEPENDENCIES=--prefer-lowest',
           'EXECUTOR=coroutine DEPENDENCIES=--prefer-lowest',


### PR DESCRIPTION
Evaluating what it takes to make things run on PHP 8.

Turns out most dev dependencies, which are not used in the actual unit test matrix, are not needed and by removing them there, we can at run the test suite on PHP 7.1 to PHP 8.0