### PR TITLE
Drop PHP 7.3 support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
         env: [
           'EXECUTOR= DEPENDENCIES=--prefer-lowest',
           'EXECUTOR=coroutine DEPENDENCIES=--prefer-lowest',
@@ -68,7 +68,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.9.0
       with:
-        php-version: 7.3
+        php-version: 7.4
         coverage: none
         extensions: json, mbstring
 
@@ -99,7 +99,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.9.0
       with:
-        php-version: 7.3
+        php-version: 7.4
         coverage: none
         extensions: json, mbstring
 
@@ -132,7 +132,7 @@ jobs:
     - name: Install PHP
       uses: shivammathur/setup-php@2.9.0
       with:
-        php-version: 7.3
+        php-version: 7.4
         coverage: pcov
         extensions: json, mbstring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 #### Unreleased
-- PHP version required: 7.3+
+- PHP version required: 7.4+
 
 #### 14.5.1
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "API"
   ],
   "require": {
-    "php": "^7.3||^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "ext-mbstring": "*"
   },


### PR DESCRIPTION
Same as https://github.com/webonyx/graphql-php/pull/744 but for PHP 7.3

_This will sit here for a while I guess, but EOL is in 5 days_