### PR TITLE
Reify AST node types and remove unneeded nullability

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -311,11 +311,6 @@ parameters:
 			path: src/Utils/ASTDefinitionBuilder.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\EnumValueDefinitionNode\\>\\|null given\\.$#"
-			count: 1
-			path: src/Utils/ASTDefinitionBuilder.php
-
-		-
 			message: "#^Only booleans are allowed in &&, array\\<bool\\>\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Utils/PairSet.php

--- a/src/Language/AST/EnumTypeDefinitionNode.php
+++ b/src/Language/AST/EnumTypeDefinitionNode.php
@@ -15,7 +15,7 @@ class EnumTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<EnumValueDefinitionNode>|null */
+    /** @var NodeList<EnumValueDefinitionNode> */
     public $values;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/EnumTypeExtensionNode.php
+++ b/src/Language/AST/EnumTypeExtensionNode.php
@@ -12,9 +12,9 @@ class EnumTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<EnumValueDefinitionNode>|null */
+    /** @var NodeList<EnumValueDefinitionNode> */
     public $values;
 }

--- a/src/Language/AST/FieldNode.php
+++ b/src/Language/AST/FieldNode.php
@@ -15,10 +15,10 @@ class FieldNode extends Node implements SelectionNode
     /** @var NameNode|null */
     public $alias;
 
-    /** @var NodeList<ArgumentNode>|null */
+    /** @var NodeList<ArgumentNode> */
     public $arguments;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var SelectionSetNode|null */

--- a/src/Language/AST/InlineFragmentNode.php
+++ b/src/Language/AST/InlineFragmentNode.php
@@ -12,7 +12,7 @@ class InlineFragmentNode extends Node implements SelectionNode
     /** @var NamedTypeNode */
     public $typeCondition;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
     /** @var SelectionSetNode */

--- a/src/Language/AST/InputObjectTypeDefinitionNode.php
+++ b/src/Language/AST/InputObjectTypeDefinitionNode.php
@@ -12,10 +12,10 @@ class InputObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<InputValueDefinitionNode>|null */
+    /** @var NodeList<InputValueDefinitionNode> */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/InputObjectTypeExtensionNode.php
+++ b/src/Language/AST/InputObjectTypeExtensionNode.php
@@ -12,9 +12,9 @@ class InputObjectTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<InputValueDefinitionNode>|null */
+    /** @var NodeList<InputValueDefinitionNode> */
     public $fields;
 }

--- a/src/Language/AST/InterfaceTypeDefinitionNode.php
+++ b/src/Language/AST/InterfaceTypeDefinitionNode.php
@@ -15,7 +15,7 @@ class InterfaceTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<InterfaceTypeDefinitionNode> */
+    /** @var NodeList<NamedTypeNode> */
     public $interfaces;
 
     /** @var NodeList<FieldDefinitionNode> */

--- a/src/Language/AST/InterfaceTypeDefinitionNode.php
+++ b/src/Language/AST/InterfaceTypeDefinitionNode.php
@@ -12,10 +12,10 @@ class InterfaceTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<FieldDefinitionNode>|null */
+    /** @var NodeList<FieldDefinitionNode> */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/InterfaceTypeExtensionNode.php
+++ b/src/Language/AST/InterfaceTypeExtensionNode.php
@@ -12,9 +12,9 @@ class InterfaceTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<FieldDefinitionNode>|null */
+    /** @var NodeList<FieldDefinitionNode> */
     public $fields;
 }

--- a/src/Language/AST/Location.php
+++ b/src/Language/AST/Location.php
@@ -30,14 +30,14 @@ class Location
     /**
      * The Token at which this Node begins.
      *
-     * @var Token
+     * @var Token|null
      */
     public $startToken;
 
     /**
      * The Token at which this Node ends.
      *
-     * @var Token
+     * @var Token|null
      */
     public $endToken;
 

--- a/src/Language/AST/ObjectTypeDefinitionNode.php
+++ b/src/Language/AST/ObjectTypeDefinitionNode.php
@@ -18,7 +18,7 @@ class ObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<FieldDefinitionNode>|null */
+    /** @var NodeList<FieldDefinitionNode> */
     public $fields;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/ScalarTypeExtensionNode.php
+++ b/src/Language/AST/ScalarTypeExtensionNode.php
@@ -12,6 +12,6 @@ class ScalarTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 }

--- a/src/Language/AST/SchemaTypeExtensionNode.php
+++ b/src/Language/AST/SchemaTypeExtensionNode.php
@@ -9,9 +9,9 @@ class SchemaTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var string */
     public $kind = NodeKind::SCHEMA_EXTENSION;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<OperationTypeDefinitionNode>|null */
+    /** @var NodeList<OperationTypeDefinitionNode> */
     public $operationTypes;
 }

--- a/src/Language/AST/StringValueNode.php
+++ b/src/Language/AST/StringValueNode.php
@@ -12,6 +12,6 @@ class StringValueNode extends Node implements ValueNode
     /** @var string */
     public $value;
 
-    /** @var bool|null */
+    /** @var bool */
     public $block;
 }

--- a/src/Language/AST/UnionTypeDefinitionNode.php
+++ b/src/Language/AST/UnionTypeDefinitionNode.php
@@ -15,7 +15,7 @@ class UnionTypeDefinitionNode extends Node implements TypeDefinitionNode
     /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<NamedTypeNode>|null */
+    /** @var NodeList<NamedTypeNode> */
     public $types;
 
     /** @var StringValueNode|null */

--- a/src/Language/AST/UnionTypeExtensionNode.php
+++ b/src/Language/AST/UnionTypeExtensionNode.php
@@ -12,9 +12,9 @@ class UnionTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NameNode */
     public $name;
 
-    /** @var NodeList<DirectiveNode>|null */
+    /** @var NodeList<DirectiveNode> */
     public $directives;
 
-    /** @var NodeList<NamedTypeNode>|null */
+    /** @var NodeList<NamedTypeNode> */
     public $types;
 }

--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -629,8 +629,9 @@ class Parser
         return new VariableDefinitionNode([
             'variable'     => $var,
             'type'         => $type,
-            'defaultValue' =>
-                ($this->skip(Token::EQUALS) ? $this->parseValueLiteral(true) : null),
+            'defaultValue' => $this->skip(Token::EQUALS)
+                ? $this->parseValueLiteral(true)
+                : null,
             'directives'   => $this->parseDirectives(true),
             'loc'          => $this->loc($start),
         ]);
@@ -1551,7 +1552,7 @@ class Parser
                 [$this, 'parseOperationTypeDefinition'],
                 Token::BRACE_R
             )
-            : [];
+            : new NodeList([]);
         if (count($directives) === 0 && count($operationTypes) === 0) {
             $this->unexpected();
         }

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -194,11 +194,11 @@ class Schema
      *
      * This operation requires full schema scan. Do not use in production environment.
      *
-     * @return Type[]
+     * @return array<string, Type>
      *
      * @api
      */
-    public function getTypeMap()
+    public function getTypeMap() : array
     {
         if (! $this->fullyLoaded) {
             $this->resolvedTypes = $this->collectAllTypes();

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -181,7 +181,7 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @param string|(Node&NamedTypeNode)|(Node&TypeDefinitionNode) $ref
+     * @param string|(Node &NamedTypeNode)|(Node&TypeDefinitionNode) $ref
      */
     public function buildType($ref) : Type
     {
@@ -193,7 +193,7 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @param (Node&NamedTypeNode)|(Node&TypeDefinitionNode)|null $typeNode
+     * @param (Node &NamedTypeNode)|(Node&TypeDefinitionNode)|null $typeNode
      *
      * @throws Error
      */

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -59,7 +59,9 @@ class ASTDefinitionBuilder
     private $cache;
 
     /**
-     * @param array<string, (Node&TypeDefinitionNode)> $typeDefinitionsMap
+     * code sniffer doesn't understand this syntax. Pr with a fix here: waiting on https://github.com/squizlabs/PHP_CodeSniffer/pull/2919
+     * phpcs:disable Squiz.Commenting.FunctionComment.SpacingAfterParamType
+     * @param array<string, Node&TypeDefinitionNode> $typeDefinitionsMap
      * @param array<string, bool> $options
      */
     public function __construct(

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -15,10 +15,13 @@ use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
 use GraphQL\Language\AST\ListTypeNode;
 use GraphQL\Language\AST\NamedTypeNode;
+use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\NonNullTypeNode;
 use GraphQL\Language\AST\ObjectTypeDefinitionNode;
 use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\TypeNode;
 use GraphQL\Language\AST\UnionTypeDefinitionNode;
 use GraphQL\Language\Token;
@@ -27,7 +30,6 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -41,28 +43,28 @@ use function sprintf;
 
 class ASTDefinitionBuilder
 {
-    /** @var Node[] */
+    /** @var array<string, Node&TypeDefinitionNode> */
     private $typeDefinitionsMap;
 
     /** @var callable */
     private $typeConfigDecorator;
 
-    /** @var bool[] */
+    /** @var array<string, bool> */
     private $options;
 
     /** @var callable */
     private $resolveType;
 
-    /** @var Type[] */
+    /** @var array<string, Type> */
     private $cache;
 
     /**
-     * @param Node[] $typeDefinitionsMap
-     * @param bool[] $options
+     * @param array<string, Node  &TypeDefinitionNode> $typeDefinitionsMap
+     * @param array<string, bool> $options
      */
     public function __construct(
         array $typeDefinitionsMap,
-        $options,
+        array $options,
         callable $resolveType,
         ?callable $typeConfigDecorator = null
     ) {
@@ -74,31 +76,32 @@ class ASTDefinitionBuilder
         $this->cache = Type::getAllBuiltInTypes();
     }
 
-    public function buildDirective(DirectiveDefinitionNode $directiveNode)
+    public function buildDirective(DirectiveDefinitionNode $directiveNode) : Directive
     {
         return new Directive([
-            'name'        => $directiveNode->name->value,
-            'description' => $this->getDescription($directiveNode),
-            'args'        => isset($directiveNode->arguments) ? FieldArgument::createMap($this->makeInputValues($directiveNode->arguments)) : null,
-            'isRepeatable'        => $directiveNode->repeatable,
-            'locations'   => Utils::map(
+            'name'         => $directiveNode->name->value,
+            'description'  => $this->getDescription($directiveNode),
+            'args'         => FieldArgument::createMap($this->makeInputValues($directiveNode->arguments)),
+            'isRepeatable' => $directiveNode->repeatable,
+            'locations'    => Utils::map(
                 $directiveNode->locations,
-                static function ($node) {
+                static function (NameNode $node) : string {
                     return $node->value;
                 }
             ),
-            'astNode'     => $directiveNode,
+            'astNode'      => $directiveNode,
         ]);
     }
 
     /**
      * Given an ast node, returns its string description.
      */
-    private function getDescription($node)
+    private function getDescription(Node $node) : ?string
     {
-        if ($node->description) {
+        if (isset($node->description)) {
             return $node->description->value;
         }
+
         if (isset($this->options['commentDescriptions'])) {
             $rawValue = $this->getLeadingCommentBlock($node);
             if ($rawValue !== null) {
@@ -109,19 +112,21 @@ class ASTDefinitionBuilder
         return null;
     }
 
-    private function getLeadingCommentBlock($node)
+    private function getLeadingCommentBlock(Node $node) : ?string
     {
         $loc = $node->loc;
-        if (! $loc || ! $loc->startToken) {
+        if ($loc === null || $loc->startToken === null) {
             return null;
         }
+
         $comments = [];
         $token    = $loc->startToken->prev;
-        while ($token &&
-            $token->kind === Token::COMMENT &&
-            $token->next && $token->prev &&
-            $token->line + 1 === $token->next->line &&
-            $token->line !== $token->prev->line
+        while ($token !== null
+            && $token->kind === Token::COMMENT
+            && $token->next !== null
+            && $token->prev !== null
+            && $token->line + 1 === $token->next->line
+            && $token->line !== $token->prev->line
         ) {
             $value      = $token->value;
             $comments[] = $value;
@@ -131,14 +136,17 @@ class ASTDefinitionBuilder
         return implode("\n", array_reverse($comments));
     }
 
-    private function makeInputValues($values)
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function makeInputValues(NodeList $values) : array
     {
         return Utils::keyValMap(
             $values,
-            static function ($value) {
+            static function (InputValueDefinitionNode $value) : string {
                 return $value->name->value;
             },
-            function ($value) : array {
+            function (InputValueDefinitionNode $value) : array {
                 // Note: While this could make assertions to get the correctly typed
                 // value, that would throw immediately while type system validation
                 // with validateSchema() will produce more actionable results.
@@ -159,16 +167,12 @@ class ASTDefinitionBuilder
         );
     }
 
-    /**
-     * @return Type|InputType
-     *
-     * @throws Error
-     */
-    private function buildWrappedType(TypeNode $typeNode)
+    private function buildWrappedType(TypeNode $typeNode) : Type
     {
         if ($typeNode instanceof ListTypeNode) {
             return Type::listOf($this->buildWrappedType($typeNode->type));
         }
+
         if ($typeNode instanceof NonNullTypeNode) {
             return Type::nonNull($this->buildWrappedType($typeNode->type));
         }
@@ -177,13 +181,9 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @param string|NamedTypeNode $ref
-     *
-     * @return Type
-     *
-     * @throws Error
+     * @param string|(Node&NamedTypeNode)|(Node&TypeDefinitionNode) $ref
      */
-    public function buildType($ref)
+    public function buildType($ref) : Type
     {
         if (is_string($ref)) {
             return $this->internalBuildType($ref);
@@ -193,14 +193,11 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @param string             $typeName
-     * @param NamedTypeNode|null $typeNode
-     *
-     * @return Type
+     * @param (Node&NamedTypeNode)|(Node&TypeDefinitionNode)|null $typeNode
      *
      * @throws Error
      */
-    private function internalBuildType($typeName, $typeNode = null)
+    private function internalBuildType(string $typeName, ?Node $typeNode = null) : Type
     {
         if (! isset($this->cache[$typeName])) {
             if (isset($this->typeDefinitionsMap[$typeName])) {
@@ -248,7 +245,7 @@ class ASTDefinitionBuilder
      *
      * @throws Error
      */
-    private function makeSchemaDef(Node $def)
+    private function makeSchemaDef(Node $def) : Type
     {
         switch (true) {
             case $def instanceof ObjectTypeDefinitionNode:
@@ -268,39 +265,43 @@ class ASTDefinitionBuilder
         }
     }
 
-    private function makeTypeDef(ObjectTypeDefinitionNode $def)
+    private function makeTypeDef(ObjectTypeDefinitionNode $def) : ObjectType
     {
-        $typeName = $def->name->value;
-
         return new ObjectType([
-            'name'        => $typeName,
+            'name'        => $def->name->value,
             'description' => $this->getDescription($def),
-            'fields'      => function () use ($def) {
+            'fields'      => function () use ($def) : array {
                 return $this->makeFieldDefMap($def);
             },
-            'interfaces'  => function () use ($def) {
+            'interfaces'  => function () use ($def) : array {
                 return $this->makeImplementedInterfaces($def);
             },
             'astNode'     => $def,
         ]);
     }
 
-    private function makeFieldDefMap($def)
+    /**
+     * @param ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode $def
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function makeFieldDefMap(Node $def) : array
     {
-        return $def->fields
-            ? Utils::keyValMap(
-                $def->fields,
-                static function ($field) {
-                    return $field->name->value;
-                },
-                function ($field) {
-                    return $this->buildField($field);
-                }
-            )
-            : [];
+        return Utils::keyValMap(
+            $def->fields,
+            static function (FieldDefinitionNode $field) : string {
+                return $field->name->value;
+            },
+            function (FieldDefinitionNode $field) : array {
+                return $this->buildField($field);
+            }
+        );
     }
 
-    public function buildField(FieldDefinitionNode $field)
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildField(FieldDefinitionNode $field) : array
     {
         return [
             // Note: While this could make assertions to get the correctly typed
@@ -308,7 +309,7 @@ class ASTDefinitionBuilder
             // with validateSchema() will produce more actionable results.
             'type'              => $this->buildWrappedType($field->type),
             'description'       => $this->getDescription($field),
-            'args'              => isset($field->arguments) ? $this->makeInputValues($field->arguments) : null,
+            'args'              => $this->makeInputValues($field->arguments),
             'deprecationReason' => $this->getDeprecationReason($field),
             'astNode'           => $field,
         ];
@@ -318,73 +319,69 @@ class ASTDefinitionBuilder
      * Given a collection of directives, returns the string value for the
      * deprecation reason.
      *
-     * @param EnumValueDefinitionNode | FieldDefinitionNode $node
-     *
-     * @return string
+     * @param EnumValueDefinitionNode|FieldDefinitionNode $node
      */
-    private function getDeprecationReason($node)
+    private function getDeprecationReason(Node $node) : ?string
     {
-        $deprecated = Values::getDirectiveValues(Directive::deprecatedDirective(), $node);
+        $deprecated = Values::getDirectiveValues(
+            Directive::deprecatedDirective(),
+            $node
+        );
 
         return $deprecated['reason'] ?? null;
     }
 
-    private function makeImplementedInterfaces(ObjectTypeDefinitionNode $def)
+    /**
+     * @return array<int, Type>
+     */
+    private function makeImplementedInterfaces(ObjectTypeDefinitionNode $def) : array
     {
-        if ($def->interfaces !== null) {
-            // Note: While this could make early assertions to get the correctly
-            // typed values, that would throw immediately while type system
-            // validation with validateSchema() will produce more actionable results.
-            return Utils::map(
-                $def->interfaces,
-                function ($iface) : Type {
-                    return $this->buildType($iface);
-                }
-            );
-        }
-
-        return null;
+        // Note: While this could make early assertions to get the correctly
+        // typed values, that would throw immediately while type system
+        // validation with validateSchema() will produce more actionable results.
+        return Utils::map(
+            $def->interfaces,
+            function (NamedTypeNode $iface) : Type {
+                return $this->buildType($iface);
+            }
+        );
     }
 
-    private function makeInterfaceDef(InterfaceTypeDefinitionNode $def)
+    private function makeInterfaceDef(InterfaceTypeDefinitionNode $def) : InterfaceType
     {
-        $typeName = $def->name->value;
-
         return new InterfaceType([
-            'name'        => $typeName,
+            'name'        => $def->name->value,
             'description' => $this->getDescription($def),
-            'fields'      => function () use ($def) {
+            'fields'      => function () use ($def) : array {
                 return $this->makeFieldDefMap($def);
             },
             'astNode'     => $def,
         ]);
     }
 
-    private function makeEnumDef(EnumTypeDefinitionNode $def)
+    private function makeEnumDef(EnumTypeDefinitionNode $def) : EnumType
     {
         return new EnumType([
             'name'        => $def->name->value,
             'description' => $this->getDescription($def),
-            'values'      => $def->values
-                ? Utils::keyValMap(
-                    $def->values,
-                    static function ($enumValue) {
-                        return $enumValue->name->value;
-                    },
-                    function ($enumValue) : array {
-                        return [
-                            'description'       => $this->getDescription($enumValue),
-                            'deprecationReason' => $this->getDeprecationReason($enumValue),
-                            'astNode'           => $enumValue,
-                        ];
-                    }
-                )
-                : [],
+            'values'      => Utils::keyValMap(
+                $def->values,
+                static function ($enumValue) {
+                    return $enumValue->name->value;
+                },
+                function ($enumValue) : array {
+                    return [
+                        'description'       => $this->getDescription($enumValue),
+                        'deprecationReason' => $this->getDeprecationReason($enumValue),
+                        'astNode'           => $enumValue,
+                    ];
+                }
+            ),
             'astNode'     => $def,
         ]);
     }
 
-    private function makeUnionDef(UnionTypeDefinitionNode $def)
+    private function makeUnionDef(UnionTypeDefinitionNode $def) : UnionType
     {
         return new UnionType([
             'name'        => $def->name->value,
@@ -392,21 +389,19 @@ class ASTDefinitionBuilder
             // Note: While this could make assertions to get the correctly typed
             // values below, that would throw immediately while type system
             // validation with validateSchema() will produce more actionable results.
-            'types'       => isset($def->types)
-                ? function () use ($def) {
-                    return Utils::map(
-                        $def->types,
-                        function ($typeNode) : Type {
-                            return $this->buildType($typeNode);
-                        }
-                    );
-                }
-                : [],
+            'types'       => function () use ($def) {
+                return Utils::map(
+                    $def->types,
+                    function ($typeNode) : Type {
+                        return $this->buildType($typeNode);
+                    }
+                );
+            },
             'astNode'     => $def,
         ]);
     }
 
-    private function makeScalarDef(ScalarTypeDefinitionNode $def)
+    private function makeScalarDef(ScalarTypeDefinitionNode $def) : CustomScalarType
     {
         return new CustomScalarType([
             'name'        => $def->name->value,
@@ -418,28 +413,26 @@ class ASTDefinitionBuilder
         ]);
     }
 
-    private function makeInputObjectDef(InputObjectTypeDefinitionNode $def)
+    private function makeInputObjectDef(InputObjectTypeDefinitionNode $def) : InputObjectType
     {
         return new InputObjectType([
             'name'        => $def->name->value,
             'description' => $this->getDescription($def),
-            'fields'      => function () use ($def) {
-                return $def->fields !== null
-                    ? $this->makeInputValues($def->fields)
-                    : [];
+            'fields'      => function () use ($def) : array {
+                return $this->makeInputValues($def->fields);
             },
             'astNode'     => $def,
         ]);
     }
 
     /**
-     * @param mixed[] $config
+     * @param array<string, mixed> $config
      *
      * @return CustomScalarType|EnumType|InputObjectType|InterfaceType|ObjectType|UnionType
      *
      * @throws Error
      */
-    private function makeSchemaDefFromConfig(Node $def, array $config)
+    private function makeSchemaDefFromConfig(Node $def, array $config) : Type
     {
         switch (true) {
             case $def instanceof ObjectTypeDefinitionNode:
@@ -460,7 +453,7 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function buildInputField(InputValueDefinitionNode $value) : array
     {
@@ -481,7 +474,7 @@ class ASTDefinitionBuilder
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function buildEnumValue(EnumValueDefinitionNode $value) : array
     {

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -389,7 +389,7 @@ class ASTDefinitionBuilder
             // Note: While this could make assertions to get the correctly typed
             // values below, that would throw immediately while type system
             // validation with validateSchema() will produce more actionable results.
-            'types'       => function () use ($def) {
+            'types'       => function () use ($def) : array {
                 return Utils::map(
                     $def->types,
                     function ($typeNode) : Type {

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -59,7 +59,7 @@ class ASTDefinitionBuilder
     private $cache;
 
     /**
-     * @param array<string, Node  &TypeDefinitionNode> $typeDefinitionsMap
+     * @param array<string, Node&TypeDefinitionNode> $typeDefinitionsMap
      * @param array<string, bool> $options
      */
     public function __construct(

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -334,9 +334,11 @@ class ASTDefinitionBuilder
     }
 
     /**
+     * @param ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode $def
+     *
      * @return array<int, Type>
      */
-    private function makeImplementedInterfaces(ObjectTypeDefinitionNode $def) : array
+    private function makeImplementedInterfaces($def) : array
     {
         // Note: While this could make early assertions to get the correctly
         // typed values, that would throw immediately while type system

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -59,7 +59,7 @@ class ASTDefinitionBuilder
     private $cache;
 
     /**
-     * @param array<string, Node&TypeDefinitionNode> $typeDefinitionsMap
+     * @param array<string, (Node&TypeDefinitionNode)> $typeDefinitionsMap
      * @param array<string, bool> $options
      */
     public function __construct(

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -33,17 +33,17 @@ class BuildSchema
     /** @var DocumentNode */
     private $ast;
 
-    /** @var TypeDefinitionNode[] */
+    /** @var array<string, TypeDefinitionNode> */
     private $nodeMap;
 
     /** @var callable|null */
     private $typeConfigDecorator;
 
-    /** @var bool[] */
+    /** @var array<string, bool> */
     private $options;
 
     /**
-     * @param bool[] $options
+     * @param array<string, bool> $options
      */
     public function __construct(DocumentNode $ast, ?callable $typeConfigDecorator = null, array $options = [])
     {
@@ -57,7 +57,7 @@ class BuildSchema
      * document.
      *
      * @param DocumentNode|Source|string $source
-     * @param bool[]                     $options
+     * @param array<string, bool>        $options
      *
      * @return Schema
      *
@@ -65,7 +65,9 @@ class BuildSchema
      */
     public static function build($source, ?callable $typeConfigDecorator = null, array $options = [])
     {
-        $doc = $source instanceof DocumentNode ? $source : Parser::parse($source);
+        $doc = $source instanceof DocumentNode
+            ? $source
+            : Parser::parse($source);
 
         return self::buildAST($doc, $typeConfigDecorator, $options);
     }
@@ -86,7 +88,7 @@ class BuildSchema
      *        Provide true to use preceding comments as the description.
      *        This option is provided to ease adoption and will be removed in v16.
      *
-     * @param bool[] $options
+     * @param array<string, bool> $options
      *
      * @return Schema
      *
@@ -111,6 +113,7 @@ class BuildSchema
         $schemaDef     = null;
         $typeDefs      = [];
         $this->nodeMap = [];
+        /** @var array<int, DirectiveDefinitionNode> $directiveDefs */
         $directiveDefs = [];
         foreach ($this->ast->definitions as $definition) {
             switch (true) {
@@ -149,7 +152,7 @@ class BuildSchema
         );
 
         $directives = array_map(
-            static function ($def) use ($DefinitionBuilder) {
+            static function (DirectiveDefinitionNode $def) use ($DefinitionBuilder) : Directive {
                 return $DefinitionBuilder->buildDirective($def);
             },
             $directiveDefs

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -474,7 +474,7 @@ class SchemaExtender
 
         return array_merge(
             $existingDirectives,
-            array_map(static function (DirectiveDefinitionNode $directive) {
+            array_map(static function (DirectiveDefinitionNode $directive) : Directive {
                 return static::$astBuilder->buildDirective($directive);
             }, $directiveDefinitions)
         );
@@ -492,20 +492,21 @@ class SchemaExtender
     }
 
     /**
-     * @param mixed[]|null $options
+     * @param array<string, bool> $options
      */
-    public static function extend(Schema $schema, DocumentNode $documentAST, ?array $options = null) : Schema
+    public static function extend(Schema $schema, DocumentNode $documentAST, array $options = []) : Schema
     {
-        if ($options === null || ! (isset($options['assumeValid']) || isset($options['assumeValidSDL']))) {
+        if (! (isset($options['assumeValid']) || isset($options['assumeValidSDL']))) {
             DocumentValidator::assertValidSDLExtension($documentAST, $schema);
         }
 
+        /** @var array<string, Node&TypeDefinitionNode> $typeDefinitionMap */
         $typeDefinitionMap         = [];
         static::$typeExtensionsMap = [];
         $directiveDefinitions      = [];
         /** @var SchemaDefinitionNode|null $schemaDef */
         $schemaDef = null;
-        /** @var SchemaTypeExtensionNode[] $schemaExtensions */
+        /** @var array<int, SchemaTypeExtensionNode> $schemaExtensions */
         $schemaExtensions = [];
 
         $definitionsCount = count($documentAST->definitions);
@@ -552,11 +553,11 @@ class SchemaExtender
             }
         }
 
-        if (count(static::$typeExtensionsMap) === 0 &&
-            count($typeDefinitionMap) === 0 &&
-            count($directiveDefinitions) === 0 &&
-            count($schemaExtensions) === 0 &&
-            $schemaDef === null
+        if (count(static::$typeExtensionsMap) === 0
+            && count($typeDefinitionMap) === 0
+            && count($directiveDefinitions) === 0
+            && count($schemaExtensions) === 0
+            && $schemaDef === null
         ) {
             return $schema;
         }
@@ -615,13 +616,13 @@ class SchemaExtender
         $types = array_merge(
             // Iterate through all types, getting the type definition for each, ensuring
             // that any type not directly referenced by a field will get created.
-            array_map(static function ($type) {
+            array_map(static function (Type $type) : Type {
                 return static::extendNamedType($type);
-            }, array_values($schema->getTypeMap())),
+            }, $schema->getTypeMap()),
             // Do the same with new types.
-            array_map(static function ($type) : Type {
+            array_map(static function (TypeDefinitionNode $type) : Type {
                 return static::$astBuilder->buildType($type);
-            }, array_values($typeDefinitionMap))
+            }, $typeDefinitionMap)
         );
 
         return new Schema([

--- a/tests/Type/ValidationTest.php
+++ b/tests/Type/ValidationTest.php
@@ -889,7 +889,10 @@ class ValidationTest extends TestCase
         | TypeB
         ');
 
-        $schema = SchemaExtender::extend($schema, Parser::parse('extend union BadUnion = Int'));
+        $schema = SchemaExtender::extend(
+            $schema,
+            Parser::parse('extend union BadUnion = Int')
+        );
 
         $this->assertMatchesValidationMessage(
             $schema->validate(),
@@ -1443,7 +1446,7 @@ class ValidationTest extends TestCase
      */
     public function testRejectsAnObjectImplementingTheExtendedInterfaceDueToMissingField()
     {
-        $schema         = BuildSchema::build('
+        $schema = BuildSchema::build('
           type Query {
             test: AnotherObject
           }
@@ -1455,6 +1458,7 @@ class ValidationTest extends TestCase
           type AnotherObject implements AnotherInterface {
             field: String
           }');
+
         $extendedSchema = SchemaExtender::extend(
             $schema,
             Parser::parse('
@@ -1467,6 +1471,7 @@ class ValidationTest extends TestCase
                 }
             ')
         );
+
         $this->assertMatchesValidationMessage(
             $extendedSchema->validate(),
             [[
@@ -1486,7 +1491,7 @@ class ValidationTest extends TestCase
      */
     public function testRejectsAnObjectImplementingTheExtendedInterfaceDueToMissingFieldArgs()
     {
-        $schema         = BuildSchema::build('
+        $schema = BuildSchema::build('
           type Query {
             test: AnotherObject
           }
@@ -1498,6 +1503,7 @@ class ValidationTest extends TestCase
           type AnotherObject implements AnotherInterface {
             field: String
           }');
+
         $extendedSchema = SchemaExtender::extend(
             $schema,
             Parser::parse('
@@ -1510,6 +1516,7 @@ class ValidationTest extends TestCase
                 }
             ')
         );
+
         $this->assertMatchesValidationMessage(
             $extendedSchema->validate(),
             [[
@@ -1528,7 +1535,7 @@ class ValidationTest extends TestCase
      */
     public function testRejectsObjectsImplementingTheExtendedInterfaceDueToMismatchingInterfaceType()
     {
-        $schema         = BuildSchema::build('
+        $schema = BuildSchema::build('
           type Query {
             test: AnotherObject
           }
@@ -1540,6 +1547,7 @@ class ValidationTest extends TestCase
           type AnotherObject implements AnotherInterface {
             field: String
           }');
+
         $extendedSchema = SchemaExtender::extend(
             $schema,
             Parser::parse('
@@ -1565,6 +1573,7 @@ class ValidationTest extends TestCase
                 }
             ')
         );
+
         $this->assertMatchesValidationMessage(
             $extendedSchema->validate(),
             [[

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -204,13 +204,14 @@ class SchemaExtenderTest extends TestCase
     }
 
     /**
-     * @param mixed[]|null $options
+     * @param array<string, bool> $options
      */
-    protected function extendTestSchema(string $sdl, ?array $options = null) : Schema
+    protected function extendTestSchema(string $sdl, array $options = []) : Schema
     {
         $originalPrint  = SchemaPrinter::doPrint($this->testSchema);
         $ast            = Parser::parse($sdl);
         $extendedSchema = SchemaExtender::extend($this->testSchema, $ast, $options);
+
         self::assertEquals(SchemaPrinter::doPrint($this->testSchema), $originalPrint);
 
         return $extendedSchema;
@@ -1190,6 +1191,7 @@ class SchemaExtenderTest extends TestCase
 
         $originalPrint  = SchemaPrinter::doPrint($mutationSchema);
         $extendedSchema = SchemaExtender::extend($mutationSchema, $ast);
+
         self::assertNotEquals($mutationSchema, $extendedSchema);
         self::assertEquals(SchemaPrinter::doPrint($mutationSchema), $originalPrint);
         self::assertEquals(SchemaPrinter::doPrint($extendedSchema), $this->dedent('


### PR DESCRIPTION
This achieves a few things:

- make the code easier to understand both by humans and static analyzers
- improve performance by eliminating unnecessary null checks
- improve usability through a clarified API