### PR TITLE
Implement Utils::getOperationAST

### DIFF
--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -612,10 +612,9 @@ class AST
     }
 
     /**
-     * Returns the operation given a document and operation name.
+     * Returns the operation within a document by name.
      *
-     * If a name is not provided, an operation is only returned if only one is
-     * provided in the document.
+     * If a name is not provided, an operation is only returned if the document has exactly one.
      *
      * @api
      */
@@ -628,9 +627,7 @@ class AST
             }
 
             if ($operationName === null) {
-                // If no operation name was provided, only return an Operation if there
-                // is one defined in the document. Upon encountering the second, return
-                // null.
+                // We found a second operation, so we bail instead of returning an ambiguous result.
                 if ($operation !== null) {
                     return null;
                 }

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -584,6 +584,8 @@ class AST
     }
 
     /**
+     * @deprecated use getOperationAST instead.
+     *
      * Returns operation type ("query", "mutation" or "subscription") given a document and operation name
      *
      * @param string $operationName
@@ -607,5 +609,37 @@ class AST
         }
 
         return false;
+    }
+
+    /**
+     * Returns the operation given a document and operation name.
+     *
+     * If a name is not provided, an operation is only returned if only one is
+     * provided in the document.
+     *
+     * @api
+     */
+    public static function getOperationAST(DocumentNode $document, ?string $operationName = null) : ?OperationDefinitionNode
+    {
+        $operation = null;
+        foreach ($document->definitions->getIterator() as $node) {
+            if (! $node instanceof OperationDefinitionNode) {
+                continue;
+            }
+
+            if ($operationName === null) {
+                // If no operation name was provided, only return an Operation if there
+                // is one defined in the document. Upon encountering the second, return
+                // null.
+                if ($operation !== null) {
+                    return null;
+                }
+                $operation = $node;
+            } elseif ($node->name instanceof NameNode && $node->name->value === $operationName) {
+                return $node;
+            }
+        }
+
+        return $operation;
     }
 }

--- a/tests/Utils/AstGetOperationAstTest.php
+++ b/tests/Utils/AstGetOperationAstTest.php
@@ -18,7 +18,10 @@ class AstGetOperationAstTest extends TestCase
     public function testGetsAnOperationFromASimpleDocument() : void
     {
         $doc = Parser::parse('{ field }');
-        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+        self::assertEquals(
+            AST::getOperationAST($doc),
+            $doc->definitions->offsetGet(0)
+        );
     }
 
     /**

--- a/tests/Utils/AstGetOperationAstTest.php
+++ b/tests/Utils/AstGetOperationAstTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Utils;
+
+use GraphQL\Language\Parser;
+use GraphQL\Utils\AST;
+use PHPUnit\Framework\TestCase;
+
+class AstGetOperationAstTest extends TestCase
+{
+    // Describe: getOperationAST
+
+    /**
+     * @see it('Gets an operation from a simple document')
+     */
+    public function testGetsAnOperationFromASimpleDocument() : void
+    {
+        $doc = Parser::parse('{ field }');
+        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+    }
+
+    /**
+     * @see it('Gets an operation from a document with named op (mutation)')
+     */
+    public function testGetsAnOperationFromADcoumentWithNamedOpMutation() : void
+    {
+        $doc = Parser::parse('mutation Test { field }');
+        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+    }
+
+    /**
+     * @see it('Gets an operation from a document with named op (subscription)')
+     */
+    public function testGetsAnOperationFromADcoumentWithNamedOpSubscription() : void
+    {
+        $doc = Parser::parse('subscription Test { field }');
+        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+    }
+
+    /**
+     * @see it('Does not get missing operation')
+     */
+    public function testDoesNotGetMissingOperation() : void
+    {
+        $doc = Parser::parse('type Foo { field: String }');
+        self::assertEquals(AST::getOperationAST($doc), null);
+    }
+
+    /**
+     * @see it('Does not get ambiguous unnamed operation')
+     */
+    public function testDoesNotGetAmbiguousUnnamedOperation() : void
+    {
+        $doc = Parser::parse('
+          { field }
+          mutation Test { field }
+          subscription TestSub { field }
+        ');
+        self::assertEquals(AST::getOperationAST($doc), null);
+    }
+
+    /**
+     * @see it('Does not get ambiguous named operation')
+     */
+    public function testDoesNotGetAmbiguousNamedOperation() : void
+    {
+        $doc = Parser::parse('
+          query TestQ { field }
+          mutation TestM { field }
+          subscription TestS { field }
+        ');
+        self::assertEquals(AST::getOperationAST($doc), null);
+    }
+
+    /**
+     * @see it('Does not get misnamed operation')
+     */
+    public function testDoesNotGetMisnamedOperation() : void
+    {
+        $doc = Parser::parse('
+          { field }
+          query TestQ { field }
+          mutation TestM { field }
+          subscription TestS { field }
+        ');
+        self::assertEquals(AST::getOperationAST($doc, 'Unknown'), null);
+    }
+
+    /**
+     * @see it('Gets named operation')
+     */
+    public function testGetsNamedOperation() : void
+    {
+        $doc = Parser::parse('
+          query TestQ { field }
+          mutation TestM { field }
+          subscription TestS { field }
+        ');
+        self::assertEquals(AST::getOperationAST($doc, 'TestQ'), $doc->definitions->offsetGet(0));
+        self::assertEquals(AST::getOperationAST($doc, 'TestM'), $doc->definitions->offsetGet(1));
+        self::assertEquals(AST::getOperationAST($doc, 'TestS'), $doc->definitions->offsetGet(2));
+    }
+}


### PR DESCRIPTION
This follows the getOperationAST from graphql-js and adds the related
test suite. `getOperation` is deprecated in favor of using
`getOperationAST` and getting the name from a non-null result.

Source version: https://github.com/graphql/graphql-js/blob/7b3241329e1ff49fb647b043b80568f0cf9e1a7c/src/utilities/getOperationAST.js
Tests version: https://github.com/graphql/graphql-js/blob/7b3241329e1ff49fb647b043b80568f0cf9e1a7c/src/utilities/__tests__/getOperationAST-test.js

Fixes #754