### PR TITLE
Do not add errors key when empty

### DIFF
--- a/src/Executor/ExecutionResult.php
+++ b/src/Executor/ExecutionResult.php
@@ -148,7 +148,7 @@ class ExecutionResult implements JsonSerializable
             );
 
             // While we know that there were errors initially, they might have been discarded
-            if ($handledErrors) {
+            if ($handledErrors !== []) {
                 $result['errors'] = $handledErrors;
             }
         }

--- a/src/Executor/ExecutionResult.php
+++ b/src/Executor/ExecutionResult.php
@@ -142,10 +142,14 @@ class ExecutionResult implements JsonSerializable
                 return array_map($formatter, $errors);
             };
 
-            $result['errors'] = $errorsHandler(
+            $formattedErrors = $errorsHandler(
                 $this->errors,
                 FormattedError::prepareFormatter($this->errorFormatter, $debug)
             );
+
+            if ($formattedErrors) {
+                $result['errors'] = $formattedErrors;
+            }
         }
 
         if ($this->data !== null) {

--- a/src/Executor/ExecutionResult.php
+++ b/src/Executor/ExecutionResult.php
@@ -142,13 +142,14 @@ class ExecutionResult implements JsonSerializable
                 return array_map($formatter, $errors);
             };
 
-            $formattedErrors = $errorsHandler(
+            $handledErrors = $errorsHandler(
                 $this->errors,
                 FormattedError::prepareFormatter($this->errorFormatter, $debug)
             );
 
-            if ($formattedErrors) {
-                $result['errors'] = $formattedErrors;
+            // While we know that there were errors initially, they might have been discarded
+            if ($handledErrors) {
+                $result['errors'] = $handledErrors;
             }
         }
 

--- a/tests/Executor/ExecutionResultTest.php
+++ b/tests/Executor/ExecutionResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Executor;
 
+use GraphQL\Error\Error;
 use GraphQL\Executor\ExecutionResult;
 use PHPUnit\Framework\TestCase;
 
@@ -25,5 +26,17 @@ class ExecutionResultTest extends TestCase
         $executionResult->extensions = ['bar' => 'foo'];
 
         self::assertEquals(['extensions' => ['bar' => 'foo']], $executionResult->toArray());
+    }
+
+    public function testNoEmptyErrors() : void
+    {
+        $executionResult = new ExecutionResult(null, [new Error()]);
+        $executionResult->setErrorsHandler(
+            static function () : array {
+                return [];
+            }
+        );
+
+        self::assertEquals([], $executionResult->toArray());
     }
 }

--- a/tests/Executor/ExecutionResultTest.php
+++ b/tests/Executor/ExecutionResultTest.php
@@ -14,18 +14,18 @@ class ExecutionResultTest extends TestCase
     {
         $executionResult = new ExecutionResult();
 
-        self::assertEquals([], $executionResult->toArray());
+        self::assertSame([], $executionResult->toArray());
     }
 
     public function testToArrayExtensions() : void
     {
         $executionResult = new ExecutionResult(null, [], ['foo' => 'bar']);
 
-        self::assertEquals(['extensions' => ['foo' => 'bar']], $executionResult->toArray());
+        self::assertSame(['extensions' => ['foo' => 'bar']], $executionResult->toArray());
 
         $executionResult->extensions = ['bar' => 'foo'];
 
-        self::assertEquals(['extensions' => ['bar' => 'foo']], $executionResult->toArray());
+        self::assertSame(['extensions' => ['bar' => 'foo']], $executionResult->toArray());
     }
 
     public function testNoEmptyErrors() : void
@@ -37,6 +37,6 @@ class ExecutionResultTest extends TestCase
             }
         );
 
-        self::assertEquals([], $executionResult->toArray());
+        self::assertSame([], $executionResult->toArray());
     }
 }


### PR DESCRIPTION
If the error handler filters out all the errors so that none remains, we should not add the errors key to the result.