### PR TITLE
Allow pushing nodes to NodeList via []=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Unreleased
 
+Fix:
+- Allow pushing nodes to `NodeList` via `[]=` (#767)
+
 #### 14.4.0
 
 Fix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Fix:
 - Allow pushing nodes to `NodeList` via `[]=` (#767)
+- Fix signature of `Error\FormattedError::prepareFormatter()` to address PHP8 deprecation (#742)
 
 #### 14.4.0
 
@@ -12,7 +13,6 @@ Fix:
 - Parse `DirectiveDefinitionNode->locations` as `NodeList<NamedNode>` (fixes AST::fromArray conversion) (#723)
 - Parse `Parser::implementsInterfaces` as `NodeList<NamedTypeNode>` (fixes AST::fromArray conversion)
 - Fix signature of `Parser::unionMemberTypes` to match actual `NodeList<NamedTypeNode>`
-- Fix signature of `Error\FormattedError::prepareFormatter()` to address PHP8 deprecation (#742)
 
 #### v14.3.0
 

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -95,6 +95,7 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
             $value = AST::fromArray($value);
         }
 
+        // Happens when a Node is pushed via []=
         if ($offset === null) {
             $this->nodes[] = $value;
 

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -91,17 +91,14 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
     public function offsetSet($offset, $value) : void
     {
         if (is_array($value)) {
-            if (isset($value['kind'])) {
-                /** @phpstan-var T $node */
-                $node                 = AST::fromArray($value);
-                $this->nodes[$offset] = $node;
+            /** @phpstan-var T $value */
+            $value = AST::fromArray($value);
+        }
 
-                return;
-            }
+        if ($offset === null) {
+            $this->nodes[] = $value;
 
-            throw new InvalidArgumentException(
-                'Expected array value to be valid node data structure, missing key "kind"'
-            );
+            return;
         }
 
         $this->nodes[$offset] = $value;

--- a/tests/Language/NodeListTest.php
+++ b/tests/Language/NodeListTest.php
@@ -10,7 +10,7 @@ use GraphQL\Language\AST\NodeList;
 use PHPUnit\Framework\TestCase;
 use function get_class;
 
-class NodeListTest extends TestCase
+final class NodeListTest extends TestCase
 {
     public function testConvertArrayToASTNode() : void
     {

--- a/tests/Language/NodeListTest.php
+++ b/tests/Language/NodeListTest.php
@@ -19,26 +19,26 @@ class NodeListTest extends TestCase
         $nameNode        = new NameNode(['value' => 'foo']);
         $nodeList['foo'] = $nameNode->toArray();
 
-        $this->assertInstanceOf(get_class($nameNode), $nodeList['foo']);
+        self::assertInstanceOf(get_class($nameNode), $nodeList['foo']);
     }
 
     public function testThrowsOnInvalidArrays() : void
     {
         $nodeList = new NodeList([]);
 
-        $this->expectException(InvariantViolation::class);
+        self::expectException(InvariantViolation::class);
         $nodeList[] = ['not a valid array representation of an AST node'];
     }
 
     public function testPushNodes() : void
     {
         $nodeList = new NodeList([]);
-        $this->assertCount(0, $nodeList);
+        self::assertCount(0, $nodeList);
 
         $nodeList[] = new NameNode(['value' => 'foo']);
-        $this->assertCount(1, $nodeList);
+        self::assertCount(1, $nodeList);
 
         $nodeList[] = new NameNode(['value' => 'bar']);
-        $this->assertCount(2, $nodeList);
+        self::assertCount(2, $nodeList);
     }
 }

--- a/tests/Language/NodeListTest.php
+++ b/tests/Language/NodeListTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Language;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
+use PHPUnit\Framework\TestCase;
+use function get_class;
+
+class NodeListTest extends TestCase
+{
+    public function testConvertArrayToASTNode() : void
+    {
+        $nodeList = new NodeList([]);
+
+        $nameNode        = new NameNode(['value' => 'foo']);
+        $nodeList['foo'] = $nameNode->toArray();
+
+        $this->assertInstanceOf(get_class($nameNode), $nodeList['foo']);
+    }
+
+    public function testThrowsOnInvalidArrays() : void
+    {
+        $nodeList = new NodeList([]);
+
+        $this->expectException(InvariantViolation::class);
+        $nodeList[] = ['not a valid array representation of an AST node'];
+    }
+
+    public function testPushNodes() : void
+    {
+        $nodeList = new NodeList([]);
+        $this->assertCount(0, $nodeList);
+
+        $nodeList[] = new NameNode(['value' => 'foo']);
+        $this->assertCount(1, $nodeList);
+
+        $nodeList[] = new NameNode(['value' => 'bar']);
+        $this->assertCount(2, $nodeList);
+    }
+}


### PR DESCRIPTION
This can come up when manipulating the AST programmatically.
When pushing to a `NodeList` using `[]=`, the first argument
to `offsetExists` is `null`.

Thus, the element is set into the internal array with `(string) null === ""`.
Now, additional pushes replace the node at key `""` instead of appending as expected.