### PR TITLE
Fix keys ordering in input object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Unreleased
 
+Fix:
+- Keep object input keys order
+
 #### 14.5.0
 
 Feat:

--- a/src/Executor/Values.php
+++ b/src/Executor/Values.php
@@ -44,6 +44,7 @@ use stdClass;
 use Throwable;
 use function array_key_exists;
 use function array_map;
+use function array_merge;
 use function count;
 use function sprintf;
 
@@ -141,7 +142,7 @@ class Values
             return [$errors, null];
         }
 
-        return [null, $coercedValues];
+        return [null, array_merge($inputs, $coercedValues)];
     }
 
     /**

--- a/src/Utils/Value.php
+++ b/src/Utils/Value.php
@@ -213,7 +213,7 @@ class Value
                 );
             }
 
-            return $errors ? self::ofErrors($errors) : self::ofValue($coercedValue);
+            return $errors ? self::ofErrors($errors) : self::ofValue(array_merge($value, $coercedValue));
         }
 
         throw new Error(sprintf('Unexpected type %s', $type->name));

--- a/tests/Executor/ValuesTest.php
+++ b/tests/Executor/ValuesTest.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use PHPUnit\Framework\TestCase;
+use function array_keys;
 use function count;
 use function var_export;
 
@@ -138,6 +139,18 @@ class ValuesTest extends TestCase
         $this->expectInputVariablesMatchOutputVariables(['floatInput' => 1]);
         $this->expectInputVariablesMatchOutputVariables(['floatInput' => 0]);
         $this->expectInputVariablesMatchOutputVariables(['floatInput' => 1e3]);
+    }
+
+    public function testVariableFieldsOrder() : void
+    {
+        $variables = [
+            'stringInput' => 'string',
+            'idInput' => '1',
+        ];
+
+        $result = $this->runTestCase($variables)[1];
+
+        self::assertEquals(array_keys($variables), array_keys($result));
     }
 
     public function testBooleanForIDVariableThrowsError() : void


### PR DESCRIPTION
Little fix to keep same keys ordering in object inputs and to not be based on fields order in schema definition.