### PR TITLE
Fix object input field shortcut as callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Deprecates:
 Refactoring:
 - Reify AST node types and remove unneeded nullability (#751)
 
+Fix:
+- Fix Input Object field shortcut definition with callable (#773)
+
 #### 14.4.1
 
 Fix:

--- a/src/Type/Definition/InputObjectType.php
+++ b/src/Type/Definition/InputObjectType.php
@@ -87,7 +87,7 @@ class InputObjectType extends Type implements InputType, NullableType, NamedType
         }
 
         foreach ($fields as $name => $field) {
-            if ($field instanceof Type) {
+            if ($field instanceof Type || is_callable($field)) {
                 $field = ['type' => $field];
             }
             $field                      = new InputObjectField($field + ['name' => $name]);

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -1609,6 +1609,23 @@ class DefinitionTest extends TestCase
     }
 
     /**
+     * @see it('accepts an Input Object type with a field type function')
+     */
+    public function testAcceptsAnInputObjectTypeWithAFieldTypeFunction() : void
+    {
+        $inputObjType = new InputObjectType([
+            'name'   => 'SomeInputObject',
+            'fields' => [
+                'f' => static function () : Type {
+                    return Type::string();
+                },
+            ],
+        ]);
+        $inputObjType->assertValid();
+        self::assertSame(Type::string(), $inputObjType->getField('f')->getType());
+    }
+
+    /**
      * @see it('rejects an Input Object type with incorrect fields')
      */
     public function testRejectsAnInputObjectTypeWithIncorrectFields() : void


### PR DESCRIPTION
Fix error when using a callable as Input objects field type shortcut like this:

```php
$inputObjType = new InputObjectType([
    'name'   => 'SomeInputObject',
    'fields' => [
        'f' => static function () : Type {
            return Type::string();
        },
    ],
]);
```