### PR TITLE
Add fallback for directive.isRepeatable in BuildClientSchema

### DIFF
--- a/src/Utils/BuildClientSchema.php
+++ b/src/Utils/BuildClientSchema.php
@@ -489,7 +489,7 @@ class BuildClientSchema
             'name' => $directive['name'],
             'description' => $directive['description'],
             'args' => $this->buildInputValueDefMap($directive['args']),
-            'isRepeatable' => $directive['isRepeatable'],
+            'isRepeatable' => $directive['isRepeatable'] ?? false,
             'locations' => $directive['locations'],
         ]);
     }


### PR DESCRIPTION
I cannot use 

```
Introspection::getIntrospectionQuery([
    'directiveIsRepeatable' => true,
])
```

because server returns an error:

```json
{
  "error": {
    "errors": [
      {
        "message": "Cannot query field \"isRepeatable\" on type \"__Directive\".",
        "locations": [
          {
            "line": 21,
            "column": 7
          }
        ],
        "extensions": {
          "code": "GRAPHQL_VALIDATION_FAILED"
        }
      }
    ]
  }
}
```

So I'm trying to use `Introspection::getIntrospectionQuery()` but in this case `isRepeatable` is missed and:

```
ErrorException : Undefined array key "isRepeatable"
 /project/backend/vendor/webonyx/graphql-php/src/Utils/BuildClientSchema.php:492
 /project/backend/vendor/webonyx/graphql-php/src/Utils/BuildClientSchema.php:132
 /project/backend/vendor/webonyx/graphql-php/src/Utils/BuildClientSchema.php:84
```

This PR makes `isRepeatable` optional :)