### PR TITLE
Validation messages translation

### DIFF
--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -300,7 +300,7 @@ class DocumentValidator
         $emptyDoc    = new DocumentNode(['definitions' => []]);
         $typeInfo    = new TypeInfo($emptySchema, $type);
         $context     = new ValidationContext($emptySchema, $emptyDoc, $typeInfo);
-        $validator   = new ValuesOfCorrectType();
+        $validator   = self::getRule(ValuesOfCorrectType::class);
         $visitor     = $validator->getVisitor($context);
         Visitor::visit($valueNode, Visitor::visitWithTypeInfo($typeInfo, $visitor));
 

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -300,7 +300,7 @@ class DocumentValidator
         $emptyDoc    = new DocumentNode(['definitions' => []]);
         $typeInfo    = new TypeInfo($emptySchema, $type);
         $context     = new ValidationContext($emptySchema, $emptyDoc, $typeInfo);
-        $validator   = self::getRule(ValuesOfCorrectType::class);
+        $validator   = self::getRule(ValuesOfCorrectType::class) ?? new ValuesOfCorrectType();
         $visitor     = $validator->getVisitor($context);
         Visitor::visit($valueNode, Visitor::visitWithTypeInfo($typeInfo, $visitor));
 

--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -64,7 +64,7 @@ class ValuesOfCorrectType extends ValidationRule
 
                 $context->reportError(
                     new Error(
-                        self::getBadValueMessage((string) $type, Printer::doPrint($node), null, $context, $fieldName),
+                        static::getBadValueMessage((string) $type, Printer::doPrint($node), null, $context, $fieldName),
                         $node
                     )
                 );
@@ -111,7 +111,7 @@ class ValuesOfCorrectType extends ValidationRule
 
                     $context->reportError(
                         new Error(
-                            self::requiredFieldMessage($type->name, $fieldName, (string) $fieldType),
+                            static::requiredFieldMessage($type->name, $fieldName, (string) $fieldType),
                             $node
                         )
                     );
@@ -135,7 +135,7 @@ class ValuesOfCorrectType extends ValidationRule
 
                 $context->reportError(
                     new Error(
-                        self::unknownFieldMessage($parentType->name, $node->name->value, $didYouMean),
+                        static::unknownFieldMessage($parentType->name, $node->name->value, $didYouMean),
                         $node
                     )
                 );
@@ -147,7 +147,7 @@ class ValuesOfCorrectType extends ValidationRule
                 } elseif (! $type->getValue($node->value)) {
                     $context->reportError(
                         new Error(
-                            self::getBadValueMessage(
+                            static::getBadValueMessage(
                                 $type->name,
                                 Printer::doPrint($node),
                                 $this->enumTypeSuggestion($type, $node),
@@ -198,7 +198,7 @@ class ValuesOfCorrectType extends ValidationRule
         if (! $type instanceof ScalarType) {
             $context->reportError(
                 new Error(
-                    self::getBadValueMessage(
+                    static::getBadValueMessage(
                         (string) $locationType,
                         Printer::doPrint($node),
                         $this->enumTypeSuggestion($type, $node),
@@ -220,7 +220,7 @@ class ValuesOfCorrectType extends ValidationRule
             // Ensure a reference to the original error is maintained.
             $context->reportError(
                 new Error(
-                    self::getBadValueMessage(
+                    static::getBadValueMessage(
                         (string) $locationType,
                         Printer::doPrint($node),
                         $error->getMessage(),
@@ -279,10 +279,10 @@ class ValuesOfCorrectType extends ValidationRule
         if ($context) {
             $arg = $context->getArgument();
             if ($arg) {
-                return self::badArgumentValueMessage($typeName, $valueName, $fieldName, $arg->name, $message);
+                return static::badArgumentValueMessage($typeName, $valueName, $fieldName, $arg->name, $message);
             }
         }
 
-        return self::badValueMessage($typeName, $valueName, $message);
+        return static::badValueMessage($typeName, $valueName, $message);
     }
 }

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -1651,9 +1651,6 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
         self::assertTrue($errors[0]->isClientSafe());
     }
 
-    /**
-     * @see it('error messages can be overwriten')
-     */
     public function testOverwriting() : void
     {
         DocumentValidator::addRule(


### PR DESCRIPTION
Probably the most simple solution :)

1) Add

```php
<?php declare(strict_types = 1);

namespace App\GraphQL;

use GraphQL\Validator\Rules\ValuesOfCorrectType;

use function sprintf;

class ValuesOfCorrectTypeTranslated extends ValuesOfCorrectType {
    public function getName() {
        return ValuesOfCorrectType::class;
    }

    public static function badArgumentValueMessage($typeName, $valueName, $fieldName, $argName, $message = null) {
        return sprintf('Свойство "%s" аргумент "%s" должен быть %s, но передан %s', $fieldName, $argName, $typeName, $valueName);
    }
}

```

2) Add rule

```php
DocumentValidator::addRule(new ValuesOfCorrectTypeTranslated());
```

3) For lighthouse:

```php
<?php declare(strict_types = 1);

namespace App\GraphQL;

use GraphQL\Validator\Rules\ValuesOfCorrectType;
use Nuwave\Lighthouse\Execution\ValidationRulesProvider;

class ProvidesValidationRulesTranslated extends ValidationRulesProvider {
    public function validationRules(): ?array {
        return [
                ValuesOfCorrectType::class => new ValuesOfCorrectTypeTranslated(),
            ] + parent::validationRules();
    }
}
```

And in AppServiceProvider:

```php
$this->app->bind(ProvidesValidationRules::class, ProvidesValidationRulesTranslated::class);
```

Voila 
![image](https://user-images.githubusercontent.com/1329824/112493375-88d46400-8d9b-11eb-9369-2ff024484a8e.png)


Closes #711, overrides #713 and #718