### PR TITLE
Only report Codecov status on pulls

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        only_pulls: true
+comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,4 +3,3 @@ coverage:
     project:
       default:
         only_pulls: true
-comment: false

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /tests export-ignore
 /examples export-ignore
 /tools export-ignore
+.codecov.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 CONTRIBUTING.md export-ignore


### PR DESCRIPTION
Otherwise, it makes the repository page look really bad.