### PR TITLE
Drop Licence badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ![CI](https://github.com/webonyx/graphql-php/workflows/CI/badge.svg)
 [![Coverage Status](https://codecov.io/gh/webonyx/graphql-php/branch/master/graph/badge.svg)](https://codecov.io/gh/webonyx/graphql-php/branch/master)
 [![Latest Stable Version](https://poser.pugx.org/webonyx/graphql-php/version)](https://packagist.org/packages/webonyx/graphql-php)
-[![License](https://poser.pugx.org/webonyx/graphql-php/license)](https://packagist.org/packages/webonyx/graphql-php)
 
 This is a PHP implementation of the GraphQL [specification](https://github.com/facebook/graphql)
 based on the [reference implementation in JavaScript](https://github.com/graphql/graphql-js).


### PR DESCRIPTION
It's useless as every decent UI shows Licence by default

Github:

![image](https://user-images.githubusercontent.com/327717/112898044-a2014b80-90e0-11eb-8f05-b611e4cbdd84.png)

Packagist:

![image](https://user-images.githubusercontent.com/327717/112898076-ad547700-90e0-11eb-97a1-160944098a1b.png)
