### PR TITLE
Add API Platform to Integrations (tools)

### DIFF
--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -7,6 +7,7 @@
 * [OverblogGraphQLBundle](https://github.com/overblog/GraphQLBundle) – Bundle for Symfony
 * [WP-GraphQL](https://github.com/wp-graphql/wp-graphql) - GraphQL API for WordPress
 * [Siler](https://github.com/leocavalcante/siler) - Straightforward way to map GraphQL SDL to resolver callables, also built-in support for Swoole
+* [API Platform](https://api-platform.com/docs/core/graphql) - Creates a GraphQL API from PHP models
 
 # GraphQL PHP Tools
 


### PR DESCRIPTION
[API Platform](https://api-platform.com/) is based on graphql-php for its [GraphQL support](https://api-platform.com/docs/core/graphql).

Thank you!