### PR TITLE
Increase docs readability and remove outdated PHP version range

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -3,7 +3,7 @@ GraphQL is data-centric. On the very top level it is built around three major co
 **Schema**, **Query** and **Mutation**.
  
 You are expected to express your application as a **Schema** (aka Type System) and expose it
-with single a HTTP endpoint (e.g. using our [standard server](executing-queries.md#using-server)). 
+as a single HTTP endpoint (e.g. using our [standard server](executing-queries.md#using-server)). 
 Application clients (e.g. web or mobile clients) send **Queries** 
 to this endpoint to request structured data and **Mutations** to perform changes (usually with HTTP POST method).
  

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,8 +2,8 @@
 GraphQL is data-centric. On the very top level it is built around three major concepts: 
 **Schema**, **Query** and **Mutation**.
  
-You are expected to express your application as **Schema** (aka Type System) and expose it
-with single HTTP endpoint (e.g. using our [standard server](executing-queries.md#using-server)). 
+You are expected to express your application as a **Schema** (aka Type System) and expose it
+with single a HTTP endpoint (e.g. using our [standard server](executing-queries.md#using-server)). 
 Application clients (e.g. web or mobile clients) send **Queries** 
 to this endpoint to request structured data and **Mutations** to perform changes (usually with HTTP POST method).
  
@@ -21,7 +21,7 @@ Queries are expressed in simple language that resembles JSON:
 }
 ```
  
-It was designed to mirror the structure of expected response:
+It was designed to mirror the structure of the expected response:
 ```json
 {
   "hero": {
@@ -34,9 +34,9 @@ It was designed to mirror the structure of expected response:
   }
 }
 ```
-**graphql-php** runtime parses Queries, makes sure that they are valid for given Type System 
+The **graphql-php** runtime parses Queries, makes sure that they are valid for a given Type System 
 and executes using [data fetching tools](data-fetching.md) provided by you 
-as a part of integration. Queries are supposed to be idempotent.
+as part of the integration. Queries are supposed to be idempotent.
 
 ## Mutations
 Mutations are root fields that are allowed to have side effects, such as creating, updating or deleting data.
@@ -51,7 +51,7 @@ mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
   }
 }
 ```
-Variables `$ep` and `$review` are sent alongside with mutation. Full HTTP request might look like this:
+Variables `$ep` and `$review` are sent alongside with the mutation. A full HTTP request might look like this:
 ```json
 // POST /graphql-endpoint
 // Content-Type: application/javascript
@@ -68,10 +68,10 @@ Variables `$ep` and `$review` are sent alongside with mutation. Full HTTP reques
 }
 ```
 As you see variables may include complex objects and they will be correctly validated by 
-**graphql-php** runtime.
+the **graphql-php** runtime.
 
 Another nice feature of GraphQL mutations is that they also hold the query for data to be 
-returned after mutation. In our example mutation will return:
+returned after mutation. In our example the mutation will return:
 ```
 {
   "createReview": {
@@ -82,7 +82,7 @@ returned after mutation. In our example mutation will return:
 ```
 
 # Type System
-Conceptually GraphQL type is a collection of fields. Each field in turn
+Conceptually a GraphQL type is a collection of fields. Each field in turn
 has its own type which allows building complex hierarchies.
 
 Quick example on pseudo-language:
@@ -100,9 +100,9 @@ type User {
 }
 ```
 
-Type system is a heart of GraphQL integration. That's where **graphql-php** comes into play.
+The type system is at the heart of GraphQL integration. That's where **graphql-php** comes into play.
  
-It provides following tools and primitives to describe your App as hierarchy of types:
+It provides the following tools and primitives to describe your App as a hierarchy of types:
 
  * Primitives for defining **objects** and **interfaces**
  * Primitives for defining **enumerations** and **unions**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ Alternatively, you can follow instructions on [the GraphiQL](https://github.com/
 page and install it locally.
 
 # Hello World
-Let's create a type system that will be capable to process following simple query:
+Let's create a type system that will be capable to process the following simple query:
 ```
 query {
   echo(message: "Hello World")
@@ -64,12 +64,12 @@ $queryType = new ObjectType([
 
 (Note: type definition can be expressed in [different styles](type-definitions/index.md#definition-styles))
 
-The interesting piece here is **resolve** option of field definition. It is responsible for returning 
-a value of our field. Values of **scalar** fields will be directly included in response while values of 
+The interesting piece here is the **resolve** option of the field definition. It is responsible for returning 
+a value of our field. Values of **scalar** fields will be directly included in the response while values of 
 **composite** fields (objects, interfaces, unions) will be passed down to nested field resolvers 
 (not in this example though).
 
-Now when our type is ready, let's create GraphQL endpoint file for it **graphql.php**:
+Now when our type is ready, let's create a GraphQL endpoint file for it **graphql.php**:
 
 ```php
 <?php

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ All of them equally apply to this PHP implementation.
 
 # About graphql-php
 
-**graphql-php** is a feature-complete implementation of GraphQL specification in PHP (5.5+, 7.0+). 
+**graphql-php** is a feature-complete implementation of GraphQL specification in PHP (5.5+, 7.0+, 8.0). 
 It was originally inspired by [reference JavaScript implementation](https://github.com/graphql/graphql-js) 
 published by Facebook.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ All of them equally apply to this PHP implementation.
 
 # About graphql-php
 
-**graphql-php** is a feature-complete implementation of GraphQL specification in PHP (5.5+, 7.0+, 8.0). 
+**graphql-php** is a feature-complete implementation of GraphQL specification in PHP. 
 It was originally inspired by [reference JavaScript implementation](https://github.com/graphql/graphql-js) 
 published by Facebook.
 

--- a/docs/schema-definition.md
+++ b/docs/schema-definition.md
@@ -78,8 +78,8 @@ Field names of Mutation type are usually verbs and they almost always have argum
 with complex input values (see [Mutations and Input Types](type-definitions/inputs.md) for details).
 
 # Configuration Options
-Schema constructor expects an instance of [`GraphQL\Type\SchemaConfig`](class-reference.md#graphqltypeschemaconfig) 
-or an array with following options:
+The schema constructor expects an instance of [`GraphQL\Type\SchemaConfig`](class-reference.md#graphqltypeschemaconfig) 
+or an array with the following options:
 
 Option       | Type     | Notes
 ------------ | -------- | -----
@@ -87,11 +87,11 @@ query        | `ObjectType` | **Required.** Object type (usually named "Query") 
 mutation     | `ObjectType` | Object type (usually named "Mutation") containing root-level fields of your write API
 subscription     | `ObjectType` | Reserved for future subscriptions implementation. Currently presented for compatibility with introspection query of **graphql-js**, used by various clients (like Relay or GraphiQL)
 directives  | `array<Directive>` | A full list of [directives](type-definitions/directives.md) supported by your schema. By default, contains built-in **@skip** and **@include** directives.<br><br> If you pass your own directives and still want to use built-in directives - add them explicitly. For example:<br><br> *array_merge(GraphQL::getStandardDirectives(), [$myCustomDirective]);*
-types     | `array<ObjectType>` | List of object types which cannot be detected by **graphql-php** during static schema analysis.<br><br>Most often it happens when the object type is never referenced in fields directly but is still a part of a schema because it implements an interface which resolves to this object type in its **resolveType** callable. <br><br> Note that you are not required to pass all of your types here - it is simply a workaround for concrete use-case.
-typeLoader     | `callable(string $name): Type` | Expected to return type instance given the name. Must always return the same instance if called multiple times, see [lazy loading](#lazy-loading-of-types). See section below on lazy type loading.
+types     | `array<ObjectType>` | List of object types which cannot be detected by **graphql-php** during static schema analysis.<br><br>Most often this happens when the object type is never referenced in fields directly but is still a part of a schema because it implements an interface which resolves to this object type in its **resolveType** callable. <br><br> Note that you are not required to pass all of your types here - it is simply a workaround for concrete a use-case.
+typeLoader     | `callable(string $name): Type` | Expected to return a type instance given the name. Must always return the same instance if called multiple times, see [lazy loading](#lazy-loading-of-types). See section below on lazy type loading.
 
 # Using config class
-If you prefer fluid interface for config with auto-completion in IDE and static time validation, 
+If you prefer a fluid interface for the config with auto-completion in IDE and static time validation, 
 use [`GraphQL\Type\SchemaConfig`](class-reference.md#graphqltypeschemaconfig) instead of an array:
 
 ```php
@@ -110,10 +110,10 @@ $schema = new Schema($config);
 By default, the schema will scan all of your type, field and argument definitions to serve GraphQL queries. 
 It may cause performance overhead when there are many types in the schema. 
 
-In this case, it is recommended to pass **typeLoader** option to schema constructor and define all 
+In this case, it is recommended to pass the **typeLoader** option to the schema constructor and define all 
 of your object **fields** as callbacks.
 
-Type loading concept is very similar to PHP class loading, but keep in mind that **typeLoader** must
+Type loading is very similar to PHP class loading, but keep in mind that the **typeLoader** must
 always return the same instance of a type. A good way to ensure this is to use a type registry:
 
 ```php
@@ -160,17 +160,17 @@ $schema = new Schema([
 ]);
 ```
 
-You can automate this registry as you wish to reduce boilerplate or even
-introduce Dependency Injection Container if your types have other dependencies.
+You can automate this registry if you wish to reduce boilerplate or even
+introduce a Dependency Injection Container if your types have other dependencies.
 
 Alternatively, all methods of the registry could be static - then there is no need
 to pass it in the constructor - instead use **TypeRegistry::myAType()** in your type definitions.
 
 # Schema Validation
 By default, the schema is created with only shallow validation of type and field definitions  
-(because validation requires full schema scan and is very costly on bigger schemas).
+(because validation requires a full schema scan and is very costly on bigger schemas).
 
-There is a special method **assertValid()** on schema instance which throws 
+There is a special method **assertValid()** on the schema instance which throws 
 `GraphQL\Error\InvariantViolation` exception when it encounters any error, like:
 
 - Invalid types used for fields/arguments
@@ -178,7 +178,7 @@ There is a special method **assertValid()** on schema instance which throws
 - Invalid interface implementations
 - Other schema errors...
 
-Schema validation is supposed to be used in CLI commands or during build step of your app.
+Schema validation is supposed to be used in CLI commands or during a build step of your app.
 Don't call it in web requests in production. 
 
 Usage example:


### PR DESCRIPTION
This MR contains two commits.

The first commit adds PHP 8 to the list of supported PHP versions in the docs. I assume this was missed when the PHP 8 support was added and not a deliberate choice? Also I didn't remove `5.5+` from the list of supported versions since it's technically still supported with older versions, but maybe it should be removed for brevity?

The second commit contains some slight changes to wording in the docs in an attempt to improve readability. But then I'm not a native speaker. Is this OK or should I drop it?