### PR TITLE
Improve performance of subtype checks

### DIFF
--- a/benchmarks/StarWarsBench.php
+++ b/benchmarks/StarWarsBench.php
@@ -91,6 +91,29 @@ class StarWarsBench
         );
     }
 
+    public function benchQueryWithInterfaceFragment(): void
+    {
+        $q = '
+        query UseInterfaceFragment {
+          luke: human(id: "1000") {
+            ...CharacterFragment
+          }
+          leia: human(id: "1003") {
+            ...CharacterFragment
+          }
+        }
+
+        fragment CharacterFragment on Character {
+          name
+        }
+        ';
+
+        GraphQL::executeQuery(
+            StarWarsSchema::build(),
+            $q
+        );
+    }
+
     public function benchStarWarsIntrospectionQuery(): void
     {
         GraphQL::executeQuery(

--- a/benchmarks/shim.php
+++ b/benchmarks/shim.php
@@ -25,4 +25,5 @@ $b->benchSchema();
 $b->benchHeroQuery();
 $b->benchNestedQuery();
 $b->benchQueryWithFragment();
+$b->benchQueryWithInterfaceFragment();
 $b->benchStarWarsIntrospectionQuery();

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -20,9 +20,11 @@ use GraphQL\Type\Definition\UnionType;
 use GraphQL\Utils\InterfaceImplementations;
 use GraphQL\Utils\TypeInfo;
 use GraphQL\Utils\Utils;
+use InvalidArgumentException;
 use Traversable;
 
 use function array_map;
+use function get_class;
 use function implode;
 use function is_array;
 use function is_callable;
@@ -525,7 +527,7 @@ class Schema
             return $abstractType->isPossibleType($maybeSubType);
         }
 
-        return false;
+        throw new InvalidArgumentException(sprintf('$abstractType must be of type UnionType|InterfaceType got: %s.', get_class($abstractType)));
     }
 
     /**

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -524,7 +524,7 @@ class Schema
      */
     public function isSubType(AbstractType $abstractType, ImplementingType $maybeSubType): bool
     {
-        if ($abstractType instanceof InterfaceType && $maybeSubType instanceof ImplementingType) {
+        if ($abstractType instanceof InterfaceType) {
             return $maybeSubType->implementsInterface($abstractType);
         }
 

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -524,6 +524,10 @@ class Schema
      */
     public function isSubType(AbstractType $abstractType, ImplementingType $maybeSubType): bool
     {
+        if ($abstractType instanceof InterfaceType && $maybeSubType instanceof ImplementingType) {
+            return $maybeSubType->implementsInterface($abstractType);
+        }
+
         if (! isset($this->subTypeMap[$abstractType->name])) {
             $this->subTypeMap[$abstractType->name] = [];
 

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -526,24 +526,20 @@ class Schema
     {
         if ($abstractType instanceof InterfaceType && $maybeSubType instanceof ImplementingType) {
             return $maybeSubType->implementsInterface($abstractType);
+        } elseif ($abstractType instanceof UnionType) {
+            return $abstractType->isPossibleType($maybeSubType);
         }
 
         if (! isset($this->subTypeMap[$abstractType->name])) {
             $this->subTypeMap[$abstractType->name] = [];
 
-            if ($abstractType instanceof UnionType) {
-                foreach ($abstractType->getTypes() as $type) {
-                    $this->subTypeMap[$abstractType->name][$type->name] = true;
-                }
-            } else {
-                $implementations = $this->getImplementations($abstractType);
-                foreach ($implementations->objects() as $type) {
-                    $this->subTypeMap[$abstractType->name][$type->name] = true;
-                }
+            $implementations = $this->getImplementations($abstractType);
+            foreach ($implementations->objects() as $type) {
+                $this->subTypeMap[$abstractType->name][$type->name] = true;
+            }
 
-                foreach ($implementations->interfaces() as $type) {
-                    $this->subTypeMap[$abstractType->name][$type->name] = true;
-                }
+            foreach ($implementations->interfaces() as $type) {
+                $this->subTypeMap[$abstractType->name][$type->name] = true;
             }
         }
 

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -526,7 +526,9 @@ class Schema
     {
         if ($abstractType instanceof InterfaceType && $maybeSubType instanceof ImplementingType) {
             return $maybeSubType->implementsInterface($abstractType);
-        } elseif ($abstractType instanceof UnionType) {
+        }
+
+        if ($abstractType instanceof UnionType) {
             return $abstractType->isPossibleType($maybeSubType);
         }
 

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -61,13 +61,6 @@ class Schema
     private $resolvedTypes = [];
 
     /**
-     * Lazily initialized.
-     *
-     * @var array<string, array<string, ObjectType|UnionType>>
-     */
-    private $subTypeMap;
-
-    /**
      * Lazily initialised.
      *
      * @var array<string, InterfaceImplementations>
@@ -532,20 +525,7 @@ class Schema
             return $abstractType->isPossibleType($maybeSubType);
         }
 
-        if (! isset($this->subTypeMap[$abstractType->name])) {
-            $this->subTypeMap[$abstractType->name] = [];
-
-            $implementations = $this->getImplementations($abstractType);
-            foreach ($implementations->objects() as $type) {
-                $this->subTypeMap[$abstractType->name][$type->name] = true;
-            }
-
-            foreach ($implementations->interfaces() as $type) {
-                $this->subTypeMap[$abstractType->name][$type->name] = true;
-            }
-        }
-
-        return isset($this->subTypeMap[$abstractType->name][$maybeSubType->name]);
+        return false;
     }
 
     /**

--- a/tests/Type/LazyTypeLoaderTest.php
+++ b/tests/Type/LazyTypeLoaderTest.php
@@ -296,11 +296,6 @@ final class LazyTypeLoaderTest extends TestCase
                 'Node',
                 'Content',
                 'PostStoryMutationInput',
-                'Query.fields',
-                'Content.fields',
-                'Node.fields',
-                'Mutation.fields',
-                'BlogStory.fields',
             ],
             $this->calls
         );

--- a/tests/Type/SchemaTest.php
+++ b/tests/Type/SchemaTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace GraphQL\Tests\Type;
 
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\AbstractType;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class SchemaTest extends TestCase
@@ -129,5 +132,27 @@ class SchemaTest extends TestCase
         $typeMap = $this->schema->getTypeMap();
         self::assertArrayHasKey('DirInput', $typeMap);
         self::assertArrayHasKey('WrappedDirInput', $typeMap);
+    }
+
+    // Sub Type
+
+    /**
+     * @see it('validates argument to isSubType to be of the correct type')
+     */
+    public function testThrowsInvalidArgumentExceptionWhenInvalidTypeIsPassedToIsSubType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $anonymousAbstractType = new class implements AbstractType {
+            public function resolveType($objectValue, $context, ResolveInfo $info)
+            {
+                return null;
+            }
+        };
+
+        $this->schema->isSubType(
+            $anonymousAbstractType,
+            new InterfaceType(['name' => 'Interface'])
+        );
     }
 }

--- a/tests/Type/TypeLoaderTest.php
+++ b/tests/Type/TypeLoaderTest.php
@@ -244,11 +244,6 @@ class TypeLoaderTest extends TestCase
                 'Node',
                 'Content',
                 'PostStoryMutationInput',
-                'Query.fields',
-                'Content.fields',
-                'Node.fields',
-                'Mutation.fields',
-                'BlogStory.fields',
             ],
             $this->calls
         );


### PR DESCRIPTION
When using a fragment on a interface like:

```graphql
interface Character {
  name: String!
}

fragment CharacterFragment on Character {
  name
}
```

The check in `Schema::isSubType` uses `Schema::getImplementations` which is rightly so marked `This operations requires full schema scan. Do not use in production environment.`...

This PR adds a quick short circuit to check on a `ImplementingType` object if it implements the interface which is also cached within the `ImplementingType` to prevent calling the very costly `Schema::getImplementations` preventing a full schema scan for a simple check.

Even the tests needed a little changes because less code was executed 😄 

This (in my rough tests) on a large schema (200+ types) and with a broadly used interface (20+ implementors) improved performance 4x (using Laravel Lighthouse). Using `composer bench` (reading the avg times before and after changes) I saw 5 to 10% performance gains.