### PR TITLE
Lazy field definitions

### DIFF
--- a/benchmarks/Utils/QueryGenerator.php
+++ b/benchmarks/Utils/QueryGenerator.php
@@ -41,7 +41,7 @@ class QueryGenerator
                 continue;
             }
 
-            $totalFields += count($type->getFields());
+            $totalFields += count($type->getFieldNames());
         }
 
         $this->maxLeafFields     = max(1, (int) round($totalFields * $percentOfLeafFields));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,11 +176,6 @@ parameters:
 			path: src/Type/SchemaValidationContext.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<GraphQL\\\\Type\\\\Definition\\\\FieldDefinition\\> given\\.$#"
-			count: 1
-			path: src/Type/SchemaValidationContext.php
-
-		-
 			message: "#^Only booleans are allowed in a ternary operator condition, GraphQL\\\\Language\\\\AST\\\\FieldDefinitionNode\\|null given\\.$#"
 			count: 1
 			path: src/Type/SchemaValidationContext.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -481,11 +481,6 @@ parameters:
 			path: src/Validator/Rules/ProvidedRequiredArgumentsOnDirectives.php
 
 		-
-			message: "#^Only booleans are allowed in &&, GraphQL\\\\Type\\\\Definition\\\\Type\\|null given on the left side\\.$#"
-			count: 1
-			path: src/Validator/Rules/QuerySecurityRule.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, GraphQL\\\\Language\\\\AST\\\\FragmentDefinitionNode\\|null given\\.$#"
 			count: 1
 			path: src/Validator/Rules/QuerySecurityRule.php

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -619,9 +619,7 @@ class ReferenceExecutor implements ExecutorImplementation
             return $typeNameMetaFieldDef;
         }
 
-        $tmp = $parentType->getFields();
-
-        return $tmp[$fieldName] ?? null;
+        return $parentType->tryGetField($fieldName);
     }
 
     /**

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -619,7 +619,7 @@ class ReferenceExecutor implements ExecutorImplementation
             return $typeNameMetaFieldDef;
         }
 
-        return $parentType->tryGetField($fieldName);
+        return $parentType->findField($fieldName);
     }
 
     /**

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQL\Type\Definition;
 
+use Closure;
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Error\Warning;
@@ -128,6 +129,8 @@ class FieldDefinition
                 $fieldDef = self::create($field);
             } elseif ($field instanceof self) {
                 $fieldDef = $field;
+            } elseif ($field instanceof Closure) {
+                $fieldDef = new UnresolvedFieldDefinition($type, $name, $field);
             } else {
                 if (! is_string($name) || ! $field) {
                     throw new InvariantViolation(
@@ -143,7 +146,7 @@ class FieldDefinition
                 $fieldDef = self::create(['name' => $name, 'type' => $field]);
             }
 
-            $map[$fieldDef->name] = $fieldDef;
+            $map[$fieldDef->getName()] = $fieldDef;
         }
 
         return $map;
@@ -179,6 +182,11 @@ class FieldDefinition
         }
 
         return null;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
     }
 
     public function getType(): Type

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -130,6 +130,15 @@ class FieldDefinition
             } elseif ($field instanceof self) {
                 $fieldDef = $field;
             } elseif ($field instanceof Closure) {
+                if (! is_string($name)) {
+                    throw new InvariantViolation(
+                        sprintf(
+                            '%s lazy fields must be an associative array with field names as keys.',
+                            $type->name
+                        )
+                    );
+                }
+
                 $fieldDef = new UnresolvedFieldDefinition($type, $name, $field);
             } else {
                 if (! is_string($name) || ! $field) {

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GraphQL\Type\Definition;
 
-use Closure;
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Error\Warning;
@@ -129,7 +128,7 @@ class FieldDefinition
                 $fieldDef = self::create($field);
             } elseif ($field instanceof self) {
                 $fieldDef = $field;
-            } elseif ($field instanceof Closure) {
+            } elseif (is_callable($field)) {
                 if (! is_string($name)) {
                     throw new InvariantViolation(
                         sprintf(

--- a/src/Type/Definition/HasFieldsType.php
+++ b/src/Type/Definition/HasFieldsType.php
@@ -15,7 +15,7 @@ interface HasFieldsType
 
     public function hasField(string $name): bool;
 
-    public function tryGetField(string $name): ?FieldDefinition;
+    public function findField(string $name): ?FieldDefinition;
 
     /**
      * @return array<string, FieldDefinition>

--- a/src/Type/Definition/HasFieldsType.php
+++ b/src/Type/Definition/HasFieldsType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Type\Definition;
+
+use GraphQL\Error\InvariantViolation;
+
+interface HasFieldsType
+{
+    /**
+     * @throws InvariantViolation
+     */
+    public function getField(string $name): FieldDefinition;
+
+    public function hasField(string $name): bool;
+
+    public function tryGetField(string $name): ?FieldDefinition;
+
+    /**
+     * @return FieldDefinition[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFields(): array;
+
+    /**
+     * @return string[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFieldNames(): array;
+}

--- a/src/Type/Definition/HasFieldsType.php
+++ b/src/Type/Definition/HasFieldsType.php
@@ -25,7 +25,7 @@ interface HasFieldsType
     public function getFields(): array;
 
     /**
-     * @return string[]
+     * @return array<int, string>
      *
      * @throws InvariantViolation
      */

--- a/src/Type/Definition/HasFieldsType.php
+++ b/src/Type/Definition/HasFieldsType.php
@@ -18,7 +18,7 @@ interface HasFieldsType
     public function tryGetField(string $name): ?FieldDefinition;
 
     /**
-     * @return FieldDefinition[]
+     * @return array<string, FieldDefinition>
      *
      * @throws InvariantViolation
      */

--- a/src/Type/Definition/HasFieldsTypeImpl.php
+++ b/src/Type/Definition/HasFieldsTypeImpl.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Type\Definition;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Utils\Utils;
+
+use function array_keys;
+
+trait HasFieldsTypeImpl
+{
+    /**
+     * Lazily initialized.
+     *
+     * @var FieldDefinition[]|null
+     */
+    private $fields;
+
+    /**
+     * @throws InvariantViolation
+     */
+    public function getField(string $name): FieldDefinition
+    {
+        Utils::invariant($this->hasField($name), 'Field "%s" is not defined for type "%s"', $name, $this->name);
+
+        return $this->tryGetField($name);
+    }
+
+    public function tryGetField(string $name): ?FieldDefinition
+    {
+        $this->initializeFields();
+
+        if (! isset($this->fields[$name])) {
+            return null;
+        }
+
+        if ($this->fields[$name] instanceof UnresolvedFieldDefinition) {
+            $this->fields[$name] = $this->fields[$name]->resolve();
+        }
+
+        return $this->fields[$name];
+    }
+
+    public function hasField(string $name): bool
+    {
+        $this->initializeFields();
+
+        return isset($this->fields[$name]);
+    }
+
+    /**
+     * @return FieldDefinition[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFields(): array
+    {
+        $this->initializeFields();
+
+        foreach ($this->fields as $name => $field) {
+            if (! ($field instanceof UnresolvedFieldDefinition)) {
+                continue;
+            }
+
+            $this->fields[$name] = $field->resolve();
+        }
+
+        return $this->fields;
+    }
+
+    /**
+     * @return string[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFieldNames(): array
+    {
+        $this->initializeFields();
+
+        return array_keys($this->fields);
+    }
+
+    protected function initializeFields(): void
+    {
+        if ($this->fields !== null) {
+            return;
+        }
+
+        $fields       = $this->config['fields'] ?? [];
+        $this->fields = FieldDefinition::defineFieldMap($this, $fields);
+    }
+}

--- a/src/Type/Definition/HasFieldsTypeImpl.php
+++ b/src/Type/Definition/HasFieldsTypeImpl.php
@@ -14,9 +14,9 @@ trait HasFieldsTypeImpl
     /**
      * Lazily initialized.
      *
-     * @var FieldDefinition[]|null
+     * @var array<string, FieldDefinition>|null
      */
-    private $fields;
+    private ?array $fields;
 
     /**
      * @throws InvariantViolation
@@ -51,7 +51,7 @@ trait HasFieldsTypeImpl
     }
 
     /**
-     * @return FieldDefinition[]
+     * @return array<string, FieldDefinition>
      *
      * @throws InvariantViolation
      */
@@ -84,7 +84,7 @@ trait HasFieldsTypeImpl
 
     protected function initializeFields(): void
     {
-        if ($this->fields !== null) {
+        if (isset($this->fields)) {
             return;
         }
 

--- a/src/Type/Definition/HasFieldsTypeImpl.php
+++ b/src/Type/Definition/HasFieldsTypeImpl.php
@@ -14,9 +14,9 @@ trait HasFieldsTypeImpl
     /**
      * Lazily initialized.
      *
-     * @var array<string, FieldDefinition>|null
+     * @var array<string, FieldDefinition>
      */
-    private ?array $fields;
+    private array $fields;
 
     /**
      * @throws InvariantViolation
@@ -71,7 +71,7 @@ trait HasFieldsTypeImpl
     }
 
     /**
-     * @return string[]
+     * @return array<int, string>
      *
      * @throws InvariantViolation
      */

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -16,20 +16,15 @@ use function is_callable;
 use function is_string;
 use function sprintf;
 
-class InterfaceType extends Type implements AbstractType, OutputType, CompositeType, NullableType, NamedType, ImplementingType
+class InterfaceType extends Type implements AbstractType, OutputType, CompositeType, NullableType, NamedType, ImplementingType, HasFieldsType
 {
+    use HasFieldsTypeImpl;
+
     /** @var InterfaceTypeDefinitionNode|null */
     public $astNode;
 
     /** @var array<int, InterfaceTypeExtensionNode> */
     public $extensionASTNodes;
-
-    /**
-     * Lazily initialized.
-     *
-     * @var array<string, FieldDefinition>
-     */
-    private $fields;
 
     /**
      * Lazily initialized.
@@ -78,44 +73,6 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
         );
 
         return $type;
-    }
-
-    public function getField(string $name): FieldDefinition
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        Utils::invariant(isset($this->fields[$name]), 'Field "%s" is not defined for type "%s"', $name, $this->name);
-
-        return $this->fields[$name];
-    }
-
-    public function hasField(string $name): bool
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        return isset($this->fields[$name]);
-    }
-
-    /**
-     * @return FieldDefinition[]
-     */
-    public function getFields(): array
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        return $this->fields;
-    }
-
-    protected function initializeFields(): void
-    {
-        $fields       = $this->config['fields'] ?? [];
-        $this->fields = FieldDefinition::defineFieldMap($this, $fields);
     }
 
     public function implementsInterface(InterfaceType $interfaceType): bool

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -16,10 +16,8 @@ use function is_callable;
 use function is_string;
 use function sprintf;
 
-class InterfaceType extends Type implements AbstractType, OutputType, CompositeType, NullableType, NamedType, ImplementingType, HasFieldsType
+class InterfaceType extends TypeWithFields implements AbstractType, OutputType, CompositeType, NullableType, NamedType, ImplementingType
 {
-    use HasFieldsTypeImpl;
-
     /** @var InterfaceTypeDefinitionNode|null */
     public $astNode;
 

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -56,8 +56,10 @@ use function sprintf;
  *        }
  *     ]);
  */
-class ObjectType extends Type implements OutputType, CompositeType, NullableType, NamedType, ImplementingType
+class ObjectType extends Type implements OutputType, CompositeType, NullableType, NamedType, ImplementingType, HasFieldsType
 {
+    use HasFieldsTypeImpl;
+
     /** @var ObjectTypeDefinitionNode|null */
     public $astNode;
 
@@ -66,13 +68,6 @@ class ObjectType extends Type implements OutputType, CompositeType, NullableType
 
     /** @var ?callable */
     public $resolveFieldFn;
-
-    /**
-     * Lazily initialized.
-     *
-     * @var FieldDefinition[]
-     */
-    private $fields;
 
     /**
      * Lazily initialized.
@@ -122,49 +117,6 @@ class ObjectType extends Type implements OutputType, CompositeType, NullableType
         );
 
         return $type;
-    }
-
-    /**
-     * @throws InvariantViolation
-     */
-    public function getField(string $name): FieldDefinition
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        Utils::invariant(isset($this->fields[$name]), 'Field "%s" is not defined for type "%s"', $name, $this->name);
-
-        return $this->fields[$name];
-    }
-
-    public function hasField(string $name): bool
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        return isset($this->fields[$name]);
-    }
-
-    /**
-     * @return FieldDefinition[]
-     *
-     * @throws InvariantViolation
-     */
-    public function getFields(): array
-    {
-        if (! isset($this->fields)) {
-            $this->initializeFields();
-        }
-
-        return $this->fields;
-    }
-
-    protected function initializeFields(): void
-    {
-        $fields       = $this->config['fields'] ?? [];
-        $this->fields = FieldDefinition::defineFieldMap($this, $fields);
     }
 
     public function implementsInterface(InterfaceType $interfaceType): bool

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -56,10 +56,8 @@ use function sprintf;
  *        }
  *     ]);
  */
-class ObjectType extends Type implements OutputType, CompositeType, NullableType, NamedType, ImplementingType, HasFieldsType
+class ObjectType extends TypeWithFields implements OutputType, CompositeType, NullableType, NamedType, ImplementingType
 {
-    use HasFieldsTypeImpl;
-
     /** @var ObjectTypeDefinitionNode|null */
     public $astNode;
 

--- a/src/Type/Definition/TypeWithFields.php
+++ b/src/Type/Definition/TypeWithFields.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GraphQL\Type\Definition;
 
-use GraphQL\Error\InvariantViolation;
 use GraphQL\Utils\Utils;
 
 use function array_keys;
@@ -28,9 +27,6 @@ abstract class TypeWithFields extends Type implements HasFieldsType
         $this->fields = FieldDefinition::defineFieldMap($this, $fields);
     }
 
-    /**
-     * @throws InvariantViolation
-     */
     public function getField(string $name): FieldDefinition
     {
         Utils::invariant($this->hasField($name), 'Field "%s" is not defined for type "%s"', $name, $this->name);
@@ -60,11 +56,7 @@ abstract class TypeWithFields extends Type implements HasFieldsType
         return isset($this->fields[$name]);
     }
 
-    /**
-     * @return array<string, FieldDefinition>
-     *
-     * @throws InvariantViolation
-     */
+    /** @inheritDoc */
     public function getFields(): array
     {
         $this->initializeFields();
@@ -80,11 +72,7 @@ abstract class TypeWithFields extends Type implements HasFieldsType
         return $this->fields;
     }
 
-    /**
-     * @return array<int, string>
-     *
-     * @throws InvariantViolation
-     */
+    /** @inheritDoc */
     public function getFieldNames(): array
     {
         $this->initializeFields();

--- a/src/Type/Definition/TypeWithFields.php
+++ b/src/Type/Definition/TypeWithFields.php
@@ -9,7 +9,7 @@ use GraphQL\Utils\Utils;
 
 use function array_keys;
 
-trait HasFieldsTypeImpl
+abstract class TypeWithFields extends Type implements HasFieldsType
 {
     /**
      * Lazily initialized.
@@ -18,6 +18,16 @@ trait HasFieldsTypeImpl
      */
     private array $fields;
 
+    private function initializeFields(): void
+    {
+        if (isset($this->fields)) {
+            return;
+        }
+
+        $fields       = $this->config['fields'] ?? [];
+        $this->fields = FieldDefinition::defineFieldMap($this, $fields);
+    }
+
     /**
      * @throws InvariantViolation
      */
@@ -25,10 +35,10 @@ trait HasFieldsTypeImpl
     {
         Utils::invariant($this->hasField($name), 'Field "%s" is not defined for type "%s"', $name, $this->name);
 
-        return $this->tryGetField($name);
+        return $this->findField($name);
     }
 
-    public function tryGetField(string $name): ?FieldDefinition
+    public function findField(string $name): ?FieldDefinition
     {
         $this->initializeFields();
 
@@ -80,15 +90,5 @@ trait HasFieldsTypeImpl
         $this->initializeFields();
 
         return array_keys($this->fields);
-    }
-
-    protected function initializeFields(): void
-    {
-        if (isset($this->fields)) {
-            return;
-        }
-
-        $fields       = $this->config['fields'] ?? [];
-        $this->fields = FieldDefinition::defineFieldMap($this, $fields);
     }
 }

--- a/src/Type/Definition/UnresolvedFieldDefinition.php
+++ b/src/Type/Definition/UnresolvedFieldDefinition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Type\Definition;
+
+use Closure;
+use GraphQL\Error\InvariantViolation;
+
+use function is_array;
+use function sprintf;
+
+class UnresolvedFieldDefinition
+{
+    private Type $type;
+
+    private string $name;
+
+    private Closure $resolver;
+
+    public function __construct(Type $type, string $name, Closure $resolver)
+    {
+        $this->type     = $type;
+        $this->name     = $name;
+        $this->resolver = $resolver;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function resolve(): FieldDefinition
+    {
+        $field = ($this->resolver)();
+
+        if (! is_array($field)) {
+            return FieldDefinition::create(['name' => $this->name, 'type' => $field]);
+        }
+
+        if (! isset($field['name'])) {
+            $field['name'] = $this->name;
+        } elseif ($field['name'] !== $this->name) {
+            throw new InvariantViolation(
+                sprintf('%s.%s should not dynamically change it\'s name when resolved lazily.', $this->type->name, $this->name)
+            );
+        }
+
+        if (isset($field['args']) && ! is_array($field['args'])) {
+            throw new InvariantViolation(
+                sprintf('%s.%s args must be an array.', $this->type->name, $this->name)
+            );
+        }
+
+        return FieldDefinition::create($field);
+    }
+}

--- a/src/Type/Definition/UnresolvedFieldDefinition.php
+++ b/src/Type/Definition/UnresolvedFieldDefinition.php
@@ -15,11 +15,11 @@ class UnresolvedFieldDefinition
 
     private string $name;
 
-    /** @var (callable(): FieldDefinition|array<string, mixed>|Type) $resolver */
+    /** @var callable(): (FieldDefinition|array<string, mixed>|Type) $resolver */
     private $resolver;
 
     /**
-     * @param (callable(): FieldDefinition|array<string, mixed>|Type) $resolver
+     * @param callable(): (FieldDefinition|array<string, mixed>|Type) $resolver
      */
     public function __construct(Type $type, string $name, callable $resolver)
     {

--- a/src/Type/Definition/UnresolvedFieldDefinition.php
+++ b/src/Type/Definition/UnresolvedFieldDefinition.php
@@ -42,7 +42,7 @@ class UnresolvedFieldDefinition
             $field['name'] = $this->name;
         } elseif ($field['name'] !== $this->name) {
             throw new InvariantViolation(
-                sprintf('%s.%s should not dynamically change it\'s name when resolved lazily.', $this->type->name, $this->name)
+                sprintf('%s.%s should not dynamically change its name when resolved lazily.', $this->type->name, $this->name)
             );
         }
 

--- a/src/Type/Definition/UnresolvedFieldDefinition.php
+++ b/src/Type/Definition/UnresolvedFieldDefinition.php
@@ -21,7 +21,7 @@ class UnresolvedFieldDefinition
     /**
      * @param (callable(): FieldDefinition|array<string, mixed>|Type) $resolver
      */
-    public function __construct(Type $type, string $name, $resolver)
+    public function __construct(Type $type, string $name, callable $resolver)
     {
         $this->type     = $type;
         $this->name     = $name;

--- a/src/Type/SchemaValidationContext.php
+++ b/src/Type/SchemaValidationContext.php
@@ -440,7 +440,7 @@ class SchemaValidationContext
         $fieldMap = $type->getFields();
 
         // Objects and Interfaces both must define one or more fields.
-        if (! $fieldMap) {
+        if (count($fieldMap) === 0) {
             $this->reportError(
                 sprintf('Type %s must define one or more fields.', $type->name),
                 $this->getAllNodes($type)

--- a/src/Type/SchemaValidationContext.php
+++ b/src/Type/SchemaValidationContext.php
@@ -440,7 +440,7 @@ class SchemaValidationContext
         $fieldMap = $type->getFields();
 
         // Objects and Interfaces both must define one or more fields.
-        if (count($fieldMap) === 0) {
+        if ($fieldMap === []) {
             $this->reportError(
                 sprintf('Type %s must define one or more fields.', $type->name),
                 $this->getAllNodes($type)

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -25,6 +25,7 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\HasFieldsType;
 use GraphQL\Type\Definition\ImplementingType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
@@ -204,8 +205,8 @@ class TypeInfo
             $nestedTypes = array_merge($nestedTypes, $type->getInterfaces());
         }
 
-        if ($type instanceof ObjectType || $type instanceof InterfaceType) {
-            foreach ($type->getFields() as $fieldName => $field) {
+        if ($type instanceof HasFieldsType) {
+            foreach ($type->getFields() as $field) {
                 if (count($field->args) > 0) {
                     $fieldArgTypes = array_map(
                         static function (FieldArgument $arg): Type {
@@ -222,7 +223,7 @@ class TypeInfo
         }
 
         if ($type instanceof InputObjectType) {
-            foreach ($type->getFields() as $fieldName => $field) {
+            foreach ($type->getFields() as $field) {
                 $nestedTypes[] = $field->getType();
             }
         }
@@ -437,7 +438,7 @@ class TypeInfo
             $parentType instanceof ObjectType ||
             $parentType instanceof InterfaceType
         ) {
-            return $parentType->tryGetField($name);
+            return $parentType->findField($name);
         }
 
         return null;

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -437,9 +437,7 @@ class TypeInfo
             $parentType instanceof ObjectType ||
             $parentType instanceof InterfaceType
         ) {
-            $fields = $parentType->getFields();
-
-            return $fields[$name] ?? null;
+            return $parentType->tryGetField($name);
         }
 
         return null;

--- a/src/Validator/Rules/FieldsOnCorrectType.php
+++ b/src/Validator/Rules/FieldsOnCorrectType.php
@@ -93,8 +93,7 @@ class FieldsOnCorrectType extends ValidationRule
                 // This object type defines this field.
                 $suggestedObjectTypes[] = $possibleType->name;
                 foreach ($possibleType->getInterfaces() as $possibleInterface) {
-                    $fields = $possibleInterface->getFields();
-                    if (! isset($fields[$fieldName])) {
+                    if (! $possibleInterface->hasField($fieldName)) {
                         continue;
                     }
 

--- a/src/Validator/Rules/FieldsOnCorrectType.php
+++ b/src/Validator/Rules/FieldsOnCorrectType.php
@@ -86,8 +86,7 @@ class FieldsOnCorrectType extends ValidationRule
             $interfaceUsageCount  = [];
 
             foreach ($schema->getPossibleTypes($type) as $possibleType) {
-                $fields = $possibleType->getFields();
-                if (! isset($fields[$fieldName])) {
+                if (! $possibleType->hasField($fieldName)) {
                     continue;
                 }
 
@@ -131,7 +130,7 @@ class FieldsOnCorrectType extends ValidationRule
     protected function getSuggestedFieldNames(Schema $schema, $type, $fieldName)
     {
         if ($type instanceof ObjectType || $type instanceof InterfaceType) {
-            $possibleFieldNames = array_keys($type->getFields());
+            $possibleFieldNames = $type->getFieldNames();
 
             return Utils::suggestionList($fieldName, $possibleFieldNames);
         }

--- a/src/Validator/Rules/OverlappingFieldsCanBeMerged.php
+++ b/src/Validator/Rules/OverlappingFieldsCanBeMerged.php
@@ -251,9 +251,8 @@ class OverlappingFieldsCanBeMerged extends ValidationRule
                         $parentType instanceof ObjectType ||
                         $parentType instanceof InterfaceType
                     ) {
-                        $tmp = $parentType->getFields();
-                        if (isset($tmp[$fieldName])) {
-                            $fieldDef = $tmp[$fieldName];
+                        if ($parentType->hasField($fieldName)) {
+                            $fieldDef = $parentType->getField($fieldName);
                         }
                     }
 

--- a/src/Validator/Rules/QuerySecurityRule.php
+++ b/src/Validator/Rules/QuerySecurityRule.php
@@ -10,6 +10,8 @@ use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\SelectionSetNode;
+use GraphQL\Type\Definition\HasFieldsType;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Introspection;
 use GraphQL\Utils\TypeInfo;
@@ -17,7 +19,6 @@ use GraphQL\Validator\ValidationContext;
 use InvalidArgumentException;
 
 use function class_alias;
-use function method_exists;
 use function sprintf;
 
 abstract class QuerySecurityRule extends ValidationRule
@@ -118,8 +119,7 @@ abstract class QuerySecurityRule extends ValidationRule
                 case $selection instanceof FieldNode:
                     $fieldName = $selection->name->value;
                     $fieldDef  = null;
-                    if ($parentType && method_exists($parentType, 'getFields')) {
-                        $tmp                  = $parentType->getFields();
+                    if ($parentType instanceof HasFieldsType || $parentType instanceof InputObjectType) {
                         $schemaMetaFieldDef   = Introspection::schemaMetaFieldDef();
                         $typeMetaFieldDef     = Introspection::typeMetaFieldDef();
                         $typeNameMetaFieldDef = Introspection::typeNameMetaFieldDef();
@@ -130,8 +130,8 @@ abstract class QuerySecurityRule extends ValidationRule
                             $fieldDef = $typeMetaFieldDef;
                         } elseif ($fieldName === $typeNameMetaFieldDef->name) {
                             $fieldDef = $typeNameMetaFieldDef;
-                        } elseif (isset($tmp[$fieldName])) {
-                            $fieldDef = $tmp[$fieldName];
+                        } elseif ($parentType->hasField($fieldName)) {
+                            $fieldDef = $parentType->getField($fieldName);
                         }
                     }
 

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -1879,12 +1879,4 @@ class DefinitionTest extends TestCase
         ]);
         $schema->assertValid();
     }
-
-    public function objectWithIsTypeOf(): ObjectType
-    {
-        return new ObjectType([
-            'name'   => 'ObjectWithIsTypeOf',
-            'fields' => ['f' => ['type' => Type::string()]],
-        ]);
-    }
 }

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -1952,4 +1952,70 @@ class DefinitionTest extends TestCase
         self::assertSame(Type::string(), $objType->getField('f')->getType());
         self::assertSame(2, $resolvedCount);
     }
+
+    /**
+     * @see it('does throw when lazy loaded field definition changes its name')
+     */
+    public function testThrowsWhenLazyLoadedFieldDefinitionChangesItsName(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                'f' => static function (): array {
+                    return ['name' => 'foo', 'type' => Type::string()];
+                },
+            ],
+        ]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage(
+            'SomeObject.f should not dynamically change its name when resolved lazily.'
+        );
+
+        $objType->assertValid();
+    }
+
+    /**
+     * @see it('does throw when lazy loaded field definition has no keys for field names')
+     */
+    public function testThrowsWhenLazyLoadedFieldDefinitionHasNoKeysForFieldNames(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                static function (): array {
+                    return ['type' => Type::string()];
+                },
+            ],
+        ]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage(
+            'SomeObject lazy fields must be an associative array with field names as keys.'
+        );
+
+        $objType->assertValid();
+    }
+
+    /**
+     * @see it('does throw when lazy loaded field definition has invalid args')
+     */
+    public function testThrowsWhenLazyLoadedFieldHasInvalidArgs(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                'f' => static function (): array {
+                    return ['args' => 'invalid', 'type' => Type::string()];
+                },
+            ],
+        ]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage(
+            'SomeObject.f args must be an array.'
+        );
+
+        $objType->assertValid();
+    }
 }

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -1883,6 +1883,9 @@ class DefinitionTest extends TestCase
 
     // Lazy Fields
 
+    /**
+     * @see it('allows a type to define it\'s fields as closures to be lazy loaded')
+     */
     public function testAllowsTypeWhichDefinesItFieldsAsClosure(): void
     {
         $objType = new ObjectType([
@@ -1899,6 +1902,9 @@ class DefinitionTest extends TestCase
         self::assertSame(Type::string(), $objType->getField('f')->getType());
     }
 
+    /**
+     * @see it('does not resolve field definitions if they are not accessed')
+     */
     public function testFieldClosureNotExecutedIfNotAccessed(): void
     {
         $resolvedCount = 0;
@@ -1922,6 +1928,9 @@ class DefinitionTest extends TestCase
         self::assertSame(1, $resolvedCount);
     }
 
+    /**
+     * @see it('does resolve all field definitions when validating the type')
+     */
     public function testAllUnresolvedFieldsAreResolvedWhenValidatingType(): void
     {
         $resolvedCount = 0;
@@ -1936,13 +1945,11 @@ class DefinitionTest extends TestCase
             'fields' => [
                 'f' => $fieldCallback,
                 'o' => $fieldCallback,
-                'b' => $fieldCallback,
-                'r' => $fieldCallback,
             ],
         ]);
         $objType->assertValid();
 
         self::assertSame(Type::string(), $objType->getField('f')->getType());
-        self::assertSame(4, $resolvedCount);
+        self::assertSame(2, $resolvedCount);
     }
 }

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -1884,15 +1884,56 @@ class DefinitionTest extends TestCase
     // Lazy Fields
 
     /**
-     * @see it('allows a type to define it\'s fields as closures to be lazy loaded')
+     * @see it('allows a type to define its fields as closure returning array field definition to be lazy loaded')
      */
-    public function testAllowsTypeWhichDefinesItFieldsAsClosure(): void
+    public function testAllowsTypeWhichDefinesItFieldsAsClosureReturningFieldDefinitionAsArray(): void
     {
         $objType = new ObjectType([
             'name'   => 'SomeObject',
             'fields' => [
                 'f' => static function (): array {
                     return ['type' => Type::string()];
+                },
+            ],
+        ]);
+
+        $objType->assertValid();
+
+        self::assertSame(Type::string(), $objType->getField('f')->getType());
+    }
+
+    /**
+     * @see it('allows a type to define its fields as closure returning object field definition to be lazy loaded')
+     */
+    public function testAllowsTypeWhichDefinesItFieldsAsClosureReturningFieldDefinitionAsObject(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                'f' => static function (): FieldDefinition {
+                    return FieldDefinition::create(['name' => 'f', 'type' => Type::string()]);
+                },
+            ],
+        ]);
+
+        $objType->assertValid();
+
+        self::assertSame(Type::string(), $objType->getField('f')->getType());
+    }
+
+    /**
+     * @see it('allows a type to define its fields as invokable class returning array field definition to be lazy loaded')
+     */
+    public function testAllowsTypeWhichDefinesItFieldsAsInvokableClassReturningFieldDefinitionAsArray(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                'f' => new class {
+                    public function __invoke(): array
+                    {
+                        return ['type' => Type::string()];
+                    }
                 },
             ],
         ]);
@@ -1954,15 +1995,37 @@ class DefinitionTest extends TestCase
     }
 
     /**
-     * @see it('does throw when lazy loaded field definition changes its name')
+     * @see it('does throw when lazy loaded array field definition changes its name')
      */
-    public function testThrowsWhenLazyLoadedFieldDefinitionChangesItsName(): void
+    public function testThrowsWhenLazyLoadedArrayFieldDefinitionChangesItsName(): void
     {
         $objType = new ObjectType([
             'name'   => 'SomeObject',
             'fields' => [
                 'f' => static function (): array {
                     return ['name' => 'foo', 'type' => Type::string()];
+                },
+            ],
+        ]);
+
+        $this->expectException(InvariantViolation::class);
+        $this->expectExceptionMessage(
+            'SomeObject.f should not dynamically change its name when resolved lazily.'
+        );
+
+        $objType->assertValid();
+    }
+
+    /**
+     * @see it('does throw when lazy loaded object field definition changes its name')
+     */
+    public function testThrowsWhenLazyLoadedObjectFieldDefinitionChangesItsName(): void
+    {
+        $objType = new ObjectType([
+            'name'   => 'SomeObject',
+            'fields' => [
+                'f' => static function (): FieldDefinition {
+                    return FieldDefinition::create(['name' => 'foo', 'type' => Type::string()]);
                 },
             ],
         ]);


### PR DESCRIPTION
This PR aims to allow field definitions to be provided as a callable allowing them to defer any processing to resolve a field to as late as possible (or just in time).

Within Laravel Lighthouse for example this has huge performance improvements (especially on larger schema's) because the process of resolving a field can be quite some work and there is a potential huge cost to be paid for each field. Allowing them to be loaded just in time solves that by paying the cost only when needed instead of always on every query.

This feature is completely optional by the implementor of course no functionality has actually changed except for that now a callable is a valid type for a field definition which allows the implementor to lazily resolve the field config if required.