### PR TITLE
Add support for type config decorator in SchemaExtender

### DIFF
--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -506,8 +506,12 @@ class SchemaExtender
     /**
      * @param array<string, bool> $options
      */
-    public static function extend(Schema $schema, DocumentNode $documentAST, array $options = []): Schema
-    {
+    public static function extend(
+        Schema $schema,
+        DocumentNode $documentAST,
+        array $options = [],
+        ?callable $typeConfigDecorator = null
+    ): Schema {
         if (! (isset($options['assumeValid']) || isset($options['assumeValidSDL']))) {
             DocumentValidator::assertValidSDLExtension($documentAST, $schema);
         }
@@ -588,7 +592,8 @@ class SchemaExtender
                 }
 
                 throw new Error('Unknown type: "' . $typeName . '". Ensure that this type exists either in the original schema, or is added in a type definition.', [$typeName]);
-            }
+            },
+            $typeConfigDecorator
         );
 
         static::$extendTypeCache = [];

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -2039,4 +2039,55 @@ extend type Query {
 
         static::assertEquals($this->dedent($expected), SchemaPrinter::doPrint($extendedSchema));
     }
+
+    public function testSupportsTypeConfigDecorator()
+    {
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'hello' => [
+                    'type' => Type::string(),
+                ],
+            ],
+            'resolveField' => static function (): string {
+                return 'Hello World!';
+            },
+        ]);
+
+        $schema = new Schema(['query' => $queryType]);
+
+        $documentNode = Parser::parse('
+              type Foo {
+                value: String
+              }
+              extend type Query {
+                defaultValue: String
+                foo: Foo
+              }
+        ');
+
+        $typeConfigDecorator = static function ($typeConfig) {
+            switch ($typeConfig['name']) {
+                case 'Foo':
+                    $typeConfig['resolveField'] = static function (): string {
+                        return 'bar';
+                    };
+                    break;
+            }
+
+            return $typeConfig;
+        };
+
+        $extendedSchema = SchemaExtender::extend($schema, $documentNode, [], $typeConfigDecorator);
+
+        $query  = '{ 
+            hello
+            foo {
+              value
+            }
+        }';
+        $result = GraphQL::executeQuery($extendedSchema, $query);
+
+        self::assertSame(['data' => ['hello' => 'Hello World!', 'foo' => ['value' => 'bar']]], $result->toArray());
+    }
 }


### PR DESCRIPTION
This adds support for the type config decorator when merging GraphQL schema files.

I added the config decorator option at the end to keep retro compatibility even though it should be before options to remain consistent with the rest of the codebase.