### PR TITLE
Fix examples/01-blog - app context is always null

### DIFF
--- a/examples/01-blog/graphql.php
+++ b/examples/01-blog/graphql.php
@@ -32,7 +32,10 @@ try {
 
     // See docs on server options:
     // https://webonyx.github.io/graphql-php/executing-queries/#server-configuration-options
-    $server = new StandardServer(['schema' => $schema]);
+    $server = new StandardServer([
+        'schema' => $schema,
+        'context' => $appContext,
+    ]);
 
     $server->handleRequest();
 } catch (Throwable $error) {


### PR DESCRIPTION
Fix for error app context is always null at https://github.com/webonyx/graphql-php/blob/master/examples/01-blog/Blog/Type/QueryType.php#L66

```
"debugMessage": "Argument 3 passed to GraphQL\\Examples\\Blog\\Type\\QueryType::viewer() must be an instance of GraphQL\\Examples\\Blog\\AppContext, null given, called in .../graphql-php/graphql-php/examples/01-blog/Blog/Type/QueryType.php on line 67
```

To reproduce the error run query:
```
query{
  viewer{
    id
  }
}
``` 