### PR TITLE
Fix examples/01-blog - fix wrong type for ID at findStories

### DIFF
--- a/examples/01-blog/Blog/Data/DataSource.php
+++ b/examples/01-blog/Blog/Data/DataSource.php
@@ -181,7 +181,7 @@ class DataSource
     /**
      * @return array<int, Story>
      */
-    public static function findStories(int $limit, ?int $afterId = null): array
+    public static function findStories(int $limit, $afterId = null): array
     {
         $start = $afterId !== null
             ? (int) array_search($afterId, array_keys(self::$stories), true) + 1

--- a/examples/01-blog/graphql.php
+++ b/examples/01-blog/graphql.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+use GraphQL\Error\DebugFlag;
 use GraphQL\Examples\Blog\AppContext;
 use GraphQL\Examples\Blog\Data\DataSource;
 use GraphQL\Examples\Blog\Type\QueryType;
@@ -32,7 +33,10 @@ try {
 
     // See docs on server options:
     // https://webonyx.github.io/graphql-php/executing-queries/#server-configuration-options
-    $server = new StandardServer(['schema' => $schema]);
+    $server = new StandardServer([
+        'schema' => $schema,
+        'debugFlag' => DebugFlag::INCLUDE_DEBUG_MESSAGE,
+    ]);
 
     $server->handleRequest();
 } catch (Throwable $error) {


### PR DESCRIPTION
This is just a quick fix(to have a working example) with a cast into int type at findStories() function like is already at https://github.com/webonyx/graphql-php/blob/bf110702e4e74ef0c7afbf255c914f22cc0ed199/examples/01-blog/Blog/Type/QueryType.php#L78

```
"debugMessage": "Argument 2 passed to GraphQL\\Examples\\Blog\\Data\\DataSource::findStories() must be of the type int or null, string given, called in .../graphql-php/graphql-php/examples/01-blog/Blog/Type/QueryType.php on line 98",
```

To reproduce this error run:
```
{
  viewer {
    id
    email
  }
  user(id: 2) {
    id
    email
  }
  stories(after: 1) {
    id
    body
    comments {
      ...CommentView
    }
  }
  lastStoryPosted {
    id
    hasViewerLiked
    author {
      id
      photo(size: ICON) {
        id
        url
        type
        size
        width
        height
        # Uncomment following line to see validation error:
        # nonExistingField
        
        # Uncomment to see error reporting for fields with exceptions thrown in resolvers
        # fieldWithError
        # nonNullFieldWithError
      }
      lastStoryPosted {
        id
      }
    }
    body(format: HTML, maxLength: 10)
  }
}

fragment CommentView on Comment {
  id
  body
  totalReplyCount
  replies {
    id
    body
  }
}
```


