### PR TITLE
Fix examples/01-blog - updated README query example

### DIFF
--- a/examples/01-blog/README.md
+++ b/examples/01-blog/README.md
@@ -58,7 +58,6 @@ Copy the following query to your GraphQL client and send the request:
       photo(size: ICON) {
         id
         url
-        type
         size
         width
         height


### PR DESCRIPTION
This is just a quick fix so that the query example in README will work.

```
"message": "Cannot query field \"type\" on type \"Image\".",
```

I don't know why the field `type` was removed in this PR https://github.com/webonyx/graphql-php/pull/856/files#diff-096d05ac01bb4e793b599b29b4578e00f1e9207b695f5d425d8fc06b7e6c9266L18-L24
