### PR TITLE
Fix examples/03-standard-server - Notice: Trying to access array offset on value of type null

### DIFF
--- a/examples/03-standard-server/graphql.php
+++ b/examples/03-standard-server/graphql.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+use GraphQL\Error\DebugFlag;
 use GraphQL\Server\StandardServer;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -57,7 +58,10 @@ try {
 
     // See docs on server options:
     // https://webonyx.github.io/graphql-php/executing-queries/#server-configuration-options
-    $server = new StandardServer(['schema' => $schema]);
+    $server = new StandardServer([
+        'schema' => $schema,
+        'debugFlag' => DebugFlag::INCLUDE_DEBUG_MESSAGE,
+    ]);
 
     $server->handleRequest();
 } catch (Throwable $e) {

--- a/examples/03-standard-server/graphql.php
+++ b/examples/03-standard-server/graphql.php
@@ -26,7 +26,7 @@ try {
                     'message' => ['type' => Type::string()],
                 ],
                 'resolve' => static function ($rootValue, array $args): string {
-                    return $rootValue['prefix'] . $args['message'];
+                    return $args['message'];
                 },
             ],
         ],


### PR DESCRIPTION
Removed $rootValue['prefix'] variable from field "echo" resolve function because $rootValue is always null.

```
"text": "<br />\n<b>Notice</b>:  Trying to access array offset on value of type null in <b>.../examples/03-standard-server/graphql.php</b> on line <b>30</b><br />\n{\"data\":{\"echo\":\"Hello world\"}}"
```

To reproduce this notice message run:
```
curl -d '{"query": "query { echo(message: \"Hello World\") }" }' -H "Content-Type: application/json" http://localhost:8080
```