### PR TITLE
Fix examples/02-schema - schema is not configured for mutations

### DIFF
--- a/examples/02-schema-definition-language/graphql.php
+++ b/examples/02-schema-definition-language/graphql.php
@@ -18,6 +18,9 @@ try {
     $schema    = BuildSchema::build(/** @lang GraphQL */ '
     type Query {
       echo(message: String!): String!
+    }
+    
+    type Mutation {
       sum(x: Int!, y: Int!): Int!
     }
     ');


### PR DESCRIPTION
Fixed wrong schema definition for mutations.

To reproduce this error run:
```
curl -d '{"query": "mutation { sum(x: 2, y: 2) }" }' -H "Content-Type: application/json" http://localhost:8080
```