### PR TITLE
Avoid QueryPlan crash when multiple $fieldNodes are present

### DIFF
--- a/src/Type/Definition/QueryPlan.php
+++ b/src/Type/Definition/QueryPlan.php
@@ -20,7 +20,6 @@ use function array_intersect_key;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
-use function array_merge_recursive;
 use function array_unique;
 use function array_values;
 use function count;
@@ -138,7 +137,7 @@ class QueryPlan
                 array_keys($subfields)
             ));
 
-            $queryPlan = array_merge_recursive(
+            $queryPlan = $this->arrayMergeDeep(
                 $queryPlan,
                 $subfields
             );

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -1060,6 +1060,7 @@ GRAPHQL;
 
         self::assertTrue($hasCalled);
         self::assertSame(['data' => ['entity' => null]], $result);
-        self::assertEquals($expectedQueryPlan, $queryPlan->queryPlan());
+        self::assertInstanceOf(QueryPlan::class, $queryPlan);
+        self::assertSame($expectedQueryPlan, $queryPlan->queryPlan());
     }
 }

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -974,4 +974,91 @@ final class QueryPlanTest extends TestCase
         self::assertEquals($expectedItemSubFields, $queryPlan->subFields('Item'));
         self::assertEquals($expectedBuildingSubFields, $queryPlan->subFields('Building'));
     }
+
+    public function testQueryPlanForMultipleFieldNodes(): void
+    {
+        $entity = null;
+
+        $subEntity = new ObjectType([
+            'name'   => 'SubEntity',
+            'fields' => static function () use (&$entity): array {
+                return [
+                    'id'            => ['type' => Type::string()],
+                    'entity' => ['type' => $entity],
+                ];
+            },
+        ]);
+
+        $entity = new ObjectType([
+            'name'   => 'Entity',
+            'fields' => [
+                'subEntity' => ['type' => $subEntity],
+            ],
+        ]);
+
+        $doc = /** @lang GraphQL */ <<<GRAPHQL
+query Test {
+    entity {
+        subEntity {
+            id
+        }
+    }
+    entity {
+        subEntity {
+            id
+        }
+    }
+}
+GRAPHQL;
+
+        $expectedQueryPlan = [
+            'subEntity'  => [
+                'type' => $subEntity,
+                'args' => [],
+                'fields' => [
+                    'id' => [
+                        'type' => Type::string(),
+                        'args' => [],
+                        'fields' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $hasCalled = false;
+        /** @var QueryPlan $queryPlan */
+        $queryPlan = null;
+
+        $query = new ObjectType(
+            [
+                'name'   => 'Query',
+                'fields' => [
+                    'entity' => [
+                        'type'    => $entity,
+                        'resolve' => static function (
+                            $value,
+                            $args,
+                            $context,
+                            ResolveInfo $info
+                        ) use (
+                            &$hasCalled,
+                            &$queryPlan
+                        ) {
+                            $hasCalled = true;
+                            $queryPlan = $info->lookAhead();
+
+                            return null;
+                        },
+                    ],
+                ],
+            ]
+        );
+
+        $schema = new Schema(['query' => $query]);
+        $result = GraphQL::executeQuery($schema, $doc)->toArray();
+
+        self::assertTrue($hasCalled);
+        self::assertEquals(['data' => ['entity' => null]], $result);
+        self::assertEquals($expectedQueryPlan, $queryPlan->queryPlan());
+    }
 }

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -1026,7 +1026,7 @@ GRAPHQL;
         ];
 
         $hasCalled = false;
-        /** @var QueryPlan $queryPlan */
+        /** @var QueryPlan|null $queryPlan */
         $queryPlan = null;
 
         $query = new ObjectType(

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -977,6 +977,7 @@ final class QueryPlanTest extends TestCase
 
     public function testQueryPlanForMultipleFieldNodes(): void
     {
+        /** @var ObjectType|null $entity */
         $entity = null;
 
         $subEntity = new ObjectType([

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -1061,6 +1061,6 @@ GRAPHQL;
         self::assertTrue($hasCalled);
         self::assertSame(['data' => ['entity' => null]], $result);
         self::assertInstanceOf(QueryPlan::class, $queryPlan);
-        self::assertSame($expectedQueryPlan, $queryPlan->queryPlan());
+        self::assertEquals($expectedQueryPlan, $queryPlan->queryPlan());
     }
 }

--- a/tests/Type/QueryPlanTest.php
+++ b/tests/Type/QueryPlanTest.php
@@ -1059,7 +1059,7 @@ GRAPHQL;
         $result = GraphQL::executeQuery($schema, $doc)->toArray();
 
         self::assertTrue($hasCalled);
-        self::assertEquals(['data' => ['entity' => null]], $result);
+        self::assertSame(['data' => ['entity' => null]], $result);
         self::assertEquals($expectedQueryPlan, $queryPlan->queryPlan());
     }
 }


### PR DESCRIPTION
`Type::standardTypes` is shared across Type instances (same reference) so when it's tried to be merged recursively it crashes. 

`array_merge_recursive() -> Recursion detected`.