### PR TITLE
Clean up FormattedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Removed
 
-- Removed deprecated `Type::getInternalTypes()`
+- Remove deprecated `Type::getInternalTypes()`
 - Remove deprecated `GraphQL::execute()`
 - Remove deprecated `GraphQL::executeAndReturnResult()`
-- Removed depreacted experimental CoroutineExecutor
+- Remove deprecated experimental CoroutineExecutor
+- Remove deprecated `FormattedError::create()` and `FormattedError::createFromPHPError()`
 
 ## 14.9.0
 

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -48,18 +48,15 @@ use function strlen;
  */
 class FormattedError
 {
-    /** @var string */
-    private static $internalErrorMessage = 'Internal server error';
+    private static string $internalErrorMessage = 'Internal server error';
 
     /**
      * Set default error message for internal errors formatted using createFormattedError().
      * This value can be overridden by passing 3rd argument to `createFormattedError()`.
      *
-     * @param string $msg
-     *
      * @api
      */
-    public static function setInternalErrorMessage($msg)
+    public static function setInternalErrorMessage(string $msg): void
     {
         self::$internalErrorMessage = $msg;
     }
@@ -67,10 +64,8 @@ class FormattedError
     /**
      * Prints a GraphQLError to a string, representing useful location information
      * about the error's position in the source.
-     *
-     * @return string
      */
-    public static function printError(Error $error)
+    public static function printError(Error $error): string
     {
         $printedLocations = [];
         if (count($error->nodes ?? []) !== 0) {
@@ -104,10 +99,8 @@ class FormattedError
     /**
      * Render a helpful description of the location of the error in the GraphQL
      * Source document.
-     *
-     * @return string
      */
-    private static function highlightSourceAtLocation(Source $source, SourceLocation $location)
+    private static function highlightSourceAtLocation(Source $source, SourceLocation $location): string
     {
         $line          = $location->line;
         $lineOffset    = $source->locationOffset->line - 1;
@@ -133,30 +126,19 @@ class FormattedError
         return implode("\n", array_filter($outputLines));
     }
 
-    /**
-     * @return int
-     */
-    private static function getColumnOffset(Source $source, SourceLocation $location)
+    private static function getColumnOffset(Source $source, SourceLocation $location): int
     {
-        return $location->line === 1 ? $source->locationOffset->column - 1 : 0;
+        return $location->line === 1
+            ? $source->locationOffset->column - 1
+            : 0;
     }
 
-    /**
-     * @param int $len
-     *
-     * @return string
-     */
-    private static function whitespace($len)
+    private static function whitespace(int $len): string
     {
         return str_repeat(' ', $len);
     }
 
-    /**
-     * @param int $len
-     *
-     * @return string
-     */
-    private static function lpad($len, $str)
+    private static function lpad(int $len, string $str): string
     {
         return self::whitespace($len - mb_strlen($str)) . $str;
     }
@@ -270,32 +252,35 @@ class FormattedError
 
     /**
      * Prepares final error formatter taking in account $debug flags.
-     * If initial formatter is not set, FormattedError::createFromException is used
+     *
+     * If initial formatter is not set, FormattedError::createFromException is used.
+     *
+     * @param callable(Throwable): array<string, mixed> $formatter
      */
     public static function prepareFormatter(?callable $formatter, int $debug): callable
     {
-        $formatter ??= static function ($e): array {
-            return FormattedError::createFromException($e);
-        };
+        $formatter ??= [self::class, 'createFromException'];
+
         if ($debug !== DebugFlag::NONE) {
-            $formatter = static function ($e) use ($formatter, $debug): array {
-                return FormattedError::addDebugEntries($formatter($e), $e, $debug);
-            };
+            $formatter = static fn (Throwable $e): array => self::addDebugEntries($formatter($e), $e, $debug);
         }
 
         return $formatter;
     }
 
     /**
-     * Returns error trace as serializable array
+     * Returns error trace as serializable array.
      *
-     * @param Throwable $error
-     *
-     * @return mixed[]
+     * @return array<int, array{
+     *     file: string,
+     *     line: int,
+     *     function?: string,
+     *     call?: string,
+     * }>
      *
      * @api
      */
-    public static function toSafeTrace($error)
+    public static function toSafeTrace(Throwable $error): array
     {
         $trace = $error->getTrace();
 
@@ -334,10 +319,8 @@ class FormattedError
 
     /**
      * @param mixed $var
-     *
-     * @return string
      */
-    public static function printVar($var)
+    public static function printVar($var): string
     {
         if ($var instanceof Type) {
             // FIXME: Replace with schema printer call
@@ -377,43 +360,5 @@ class FormattedError
         }
 
         return gettype($var);
-    }
-
-    /**
-     * @deprecated as of v0.8.0
-     *
-     * @param string           $error
-     * @param SourceLocation[] $locations
-     *
-     * @return mixed[]
-     */
-    public static function create($error, array $locations = [])
-    {
-        $formatted = ['message' => $error];
-
-        if (count($locations) > 0) {
-            $formatted['locations'] = array_map(
-                static fn ($loc): array => $loc->toArray(),
-                $locations
-            );
-        }
-
-        return $formatted;
-    }
-
-    /**
-     * @deprecated as of v0.10.0, use general purpose method createFromException() instead
-     *
-     * @return mixed[]
-     *
-     * @codeCoverageIgnore
-     */
-    public static function createFromPHPError(ErrorException $e)
-    {
-        return [
-            'message'  => $e->getMessage(),
-            'severity' => $e->getSeverity(),
-            'trace'    => self::toSafeTrace($e),
-        ];
     }
 }

--- a/src/Language/SourceLocation.php
+++ b/src/Language/SourceLocation.php
@@ -8,26 +8,20 @@ use JsonSerializable;
 
 class SourceLocation implements JsonSerializable
 {
-    /** @var int */
-    public $line;
+    public int $line;
 
-    /** @var int */
-    public $column;
+    public int $column;
 
-    /**
-     * @param int $line
-     * @param int $col
-     */
-    public function __construct($line, $col)
+    public function __construct(int $line, int $col)
     {
         $this->line   = $line;
         $this->column = $col;
     }
 
     /**
-     * @return int[]
+     * @return array{line: int, column: int}
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'line'   => $this->line,
@@ -36,18 +30,18 @@ class SourceLocation implements JsonSerializable
     }
 
     /**
-     * @return int[]
+     * @return array{line: int, column: int}
      */
-    public function toSerializableArray()
+    public function toSerializableArray(): array
     {
         return $this->toArray();
     }
 
     /**
-     * @return int[]
+     * @return array{line: int, column: int}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        return $this->toSerializableArray();
+        return $this->toArray();
     }
 }

--- a/tests/ErrorHelper.php
+++ b/tests/ErrorHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests;
+
+use GraphQL\Language\SourceLocation;
+
+use function array_map;
+use function count;
+
+class ErrorHelper
+{
+    /**
+     * @param array<SourceLocation> $locations
+     *
+     * @return array{
+     *     message: string,
+     *     locations?: array<int, array{line: int, column: int}>
+     * }
+     */
+    public static function create(string $error, array $locations = []): array
+    {
+        $formatted = ['message' => $error];
+
+        if (count($locations) > 0) {
+            $formatted['locations'] = array_map(
+                static fn ($loc): array => $loc->toArray(),
+                $locations
+            );
+        }
+
+        return $formatted;
+    }
+}

--- a/tests/Executor/NonNullTest.php
+++ b/tests/Executor/NonNullTest.php
@@ -8,11 +8,11 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use GraphQL\Deferred;
 use GraphQL\Error\DebugFlag;
-use GraphQL\Error\FormattedError;
 use GraphQL\Error\UserError;
 use GraphQL\Executor\Executor;
 use GraphQL\Language\Parser;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -188,7 +188,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['sync' => null],
             'errors' => [
-                FormattedError::create(
+                ErrorHelper::create(
                     $this->syncError->getMessage(),
                     [new SourceLocation(3, 9)]
                 ),
@@ -213,7 +213,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['promise' => null],
             'errors' => [
-                FormattedError::create(
+                ErrorHelper::create(
                     $this->promiseError->getMessage(),
                     [new SourceLocation(3, 9)]
                 ),
@@ -242,7 +242,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['syncNest' => null],
             'errors' => [
-                FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(4, 11)]),
+                ErrorHelper::create($this->syncNonNullError->getMessage(), [new SourceLocation(4, 11)]),
             ],
         ];
         self::assertArraySubset(
@@ -266,7 +266,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['syncNest' => null],
             'errors' => [
-                FormattedError::create($this->promiseNonNullError->getMessage(), [new SourceLocation(4, 11)]),
+                ErrorHelper::create($this->promiseNonNullError->getMessage(), [new SourceLocation(4, 11)]),
             ],
         ];
 
@@ -291,7 +291,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['promiseNest' => null],
             'errors' => [
-                FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(4, 11)]),
+                ErrorHelper::create($this->syncNonNullError->getMessage(), [new SourceLocation(4, 11)]),
             ],
         ];
 
@@ -316,7 +316,7 @@ class NonNullTest extends TestCase
         $expected = [
             'data'   => ['promiseNest' => null],
             'errors' => [
-                FormattedError::create($this->promiseNonNullError->getMessage(), [new SourceLocation(4, 11)]),
+                ErrorHelper::create($this->promiseNonNullError->getMessage(), [new SourceLocation(4, 11)]),
             ],
         ];
 
@@ -390,18 +390,18 @@ class NonNullTest extends TestCase
                 ],
             ],
             'errors' => [
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(4, 11)]),
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(7, 13)]),
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(11, 13)]),
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(16, 11)]),
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(19, 13)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(5, 11)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(8, 13)]),
-                FormattedError::create($this->syncError->getMessage(), [new SourceLocation(23, 13)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(12, 13)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(17, 11)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(20, 13)]),
-                FormattedError::create($this->promiseError->getMessage(), [new SourceLocation(24, 13)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(4, 11)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(7, 13)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(11, 13)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(16, 11)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(19, 13)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(5, 11)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(8, 13)]),
+                ErrorHelper::create($this->syncError->getMessage(), [new SourceLocation(23, 13)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(12, 13)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(17, 11)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(20, 13)]),
+                ErrorHelper::create($this->promiseError->getMessage(), [new SourceLocation(24, 13)]),
             ],
         ];
 
@@ -487,10 +487,10 @@ class NonNullTest extends TestCase
                 'anotherPromiseNest' => null,
             ],
             'errors' => [
-                FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(8, 19)]),
-                FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(19, 19)]),
-                FormattedError::create($this->promiseNonNullError->getMessage(), [new SourceLocation(30, 19)]),
-                FormattedError::create($this->promiseNonNullError->getMessage(), [new SourceLocation(41, 19)]),
+                ErrorHelper::create($this->syncNonNullError->getMessage(), [new SourceLocation(8, 19)]),
+                ErrorHelper::create($this->syncNonNullError->getMessage(), [new SourceLocation(19, 19)]),
+                ErrorHelper::create($this->promiseNonNullError->getMessage(), [new SourceLocation(30, 19)]),
+                ErrorHelper::create($this->promiseNonNullError->getMessage(), [new SourceLocation(41, 19)]),
             ],
         ];
 
@@ -804,7 +804,7 @@ class NonNullTest extends TestCase
 
         $expected = [
             'errors' => [
-                FormattedError::create($this->syncNonNullError->getMessage(), [new SourceLocation(2, 17)]),
+                ErrorHelper::create($this->syncNonNullError->getMessage(), [new SourceLocation(2, 17)]),
             ],
         ];
         $actual   = Executor::execute($this->schema, Parser::parse($doc), $this->throwingData)->toArray();
@@ -1005,7 +1005,7 @@ class NonNullTest extends TestCase
 
         $expected = [
             'errors' => [
-                FormattedError::create($this->promiseNonNullError->getMessage(), [new SourceLocation(2, 17)]),
+                ErrorHelper::create($this->promiseNonNullError->getMessage(), [new SourceLocation(2, 17)]),
             ],
         ];
 

--- a/tests/Type/IntrospectionTest.php
+++ b/tests/Type/IntrospectionTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace GraphQL\Tests\Type;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use GraphQL\Error\FormattedError;
 use GraphQL\GraphQL;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
@@ -1465,7 +1465,7 @@ class IntrospectionTest extends TestCase
     ';
         $expected = [
             'errors' => [
-                FormattedError::create(
+                ErrorHelper::create(
                     ProvidedRequiredArguments::missingFieldArgMessage('__type', 'name', 'String!'),
                     [new SourceLocation(3, 9)]
                 ),

--- a/tests/Validator/DisableIntrospectionTest.php
+++ b/tests/Validator/DisableIntrospectionTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\DisableIntrospection;
 
 class DisableIntrospectionTest extends ValidatorTestCase
@@ -34,7 +34,7 @@ class DisableIntrospectionTest extends ValidatorTestCase
 
     private function error($line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             DisableIntrospection::introspectionDisabledMessage(),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/ExecutableDefinitionsTest.php
+++ b/tests/Validator/ExecutableDefinitionsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\ExecutableDefinitions;
 
 class ExecutableDefinitionsTest extends ValidatorTestCase
@@ -82,7 +82,7 @@ class ExecutableDefinitionsTest extends ValidatorTestCase
 
     private function nonExecutableDefinition($defName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ExecutableDefinitions::nonExecutableDefinitionMessage($defName),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/FieldsOnCorrectTypeTest.php
+++ b/tests/Validator/FieldsOnCorrectTypeTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\FieldsOnCorrectType;
 
 class FieldsOnCorrectTypeTest extends ValidatorTestCase
@@ -129,7 +129,7 @@ class FieldsOnCorrectTypeTest extends ValidatorTestCase
 
     private function undefinedField($field, $type, $suggestedTypes, $suggestedFields, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             FieldsOnCorrectType::undefinedFieldMessage($field, $type, $suggestedTypes, $suggestedFields),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/FragmentsOnCompositeTypesTest.php
+++ b/tests/Validator/FragmentsOnCompositeTypesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\FragmentsOnCompositeTypes;
 
 class FragmentsOnCompositeTypesTest extends ValidatorTestCase
@@ -126,7 +126,7 @@ class FragmentsOnCompositeTypesTest extends ValidatorTestCase
 
     private function error($fragName, $typeName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             FragmentsOnCompositeTypes::fragmentOnNonCompositeErrorMessage($fragName, $typeName),
             [new SourceLocation($line, $column)]
         );
@@ -179,7 +179,7 @@ class FragmentsOnCompositeTypesTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     FragmentsOnCompositeTypes::inlineFragmentOnNonCompositeErrorMessage('String'),
                     [new SourceLocation(3, 16)]
                 ),

--- a/tests/Validator/KnownArgumentNamesTest.php
+++ b/tests/Validator/KnownArgumentNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\Rules\KnownArgumentNames;
 use GraphQL\Validator\Rules\KnownArgumentNamesOnDirectives;
@@ -148,7 +148,7 @@ class KnownArgumentNamesTest extends ValidatorTestCase
 
     private function unknownDirectiveArg($argName, $directiveName, $suggestedArgs, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownArgumentNamesOnDirectives::unknownDirectiveArgMessage($argName, $directiveName, $suggestedArgs),
             [new SourceLocation($line, $column)]
         );
@@ -192,7 +192,7 @@ class KnownArgumentNamesTest extends ValidatorTestCase
 
     private function unknownArg($argName, $fieldName, $typeName, $suggestedArgs, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownArgumentNames::unknownArgMessage($argName, $fieldName, $typeName, $suggestedArgs),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/KnownDirectivesTest.php
+++ b/tests/Validator/KnownDirectivesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\Rules\KnownDirectives;
@@ -99,7 +99,7 @@ class KnownDirectivesTest extends ValidatorTestCase
 
     private function unknownDirective($directiveName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownDirectives::unknownDirectiveMessage($directiveName),
             [new SourceLocation($line, $column)]
         );
@@ -322,7 +322,7 @@ class KnownDirectivesTest extends ValidatorTestCase
 
     private function misplacedDirective($directiveName, $placement, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownDirectives::misplacedDirectiveMessage($directiveName, $placement),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/KnownFragmentNamesTest.php
+++ b/tests/Validator/KnownFragmentNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\KnownFragmentNames;
 
 class KnownFragmentNamesTest extends ValidatorTestCase
@@ -73,7 +73,7 @@ class KnownFragmentNamesTest extends ValidatorTestCase
 
     private function undefFrag($fragName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownFragmentNames::unknownFragmentMessage($fragName),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/KnownTypeNamesTest.php
+++ b/tests/Validator/KnownTypeNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\KnownTypeNames;
 
 class KnownTypeNamesTest extends ValidatorTestCase
@@ -60,7 +60,7 @@ class KnownTypeNamesTest extends ValidatorTestCase
 
     private function unknownType($typeName, $suggestedTypes, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             KnownTypeNames::unknownTypeMessage($typeName, $suggestedTypes),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/LoneAnonymousOperationTest.php
+++ b/tests/Validator/LoneAnonymousOperationTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\LoneAnonymousOperation;
 
 class LoneAnonymousOperationTest extends ValidatorTestCase
@@ -103,7 +103,7 @@ class LoneAnonymousOperationTest extends ValidatorTestCase
 
     private function anonNotAlone($line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             LoneAnonymousOperation::anonOperationNotAloneMessage(),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/LoneSchemaDefinitionTest.php
+++ b/tests/Validator/LoneSchemaDefinitionTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\Rules\LoneSchemaDefinition;
 
@@ -18,7 +18,7 @@ class LoneSchemaDefinitionTest extends ValidatorTestCase
 
     private function schemaDefinitionNotAlone($line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             LoneSchemaDefinition::schemaDefinitionNotAloneMessage(),
             [new SourceLocation($line, $column)]
         );
@@ -26,7 +26,7 @@ class LoneSchemaDefinitionTest extends ValidatorTestCase
 
     private function canNotDefineSchemaWithinExtension($line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             LoneSchemaDefinition::canNotDefineSchemaWithinExtensionMessage(),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/NoFragmentCyclesTest.php
+++ b/tests/Validator/NoFragmentCyclesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\NoFragmentCycles;
 
 class NoFragmentCyclesTest extends ValidatorTestCase
@@ -109,7 +109,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
 
     private function cycleError($fargment, $spreadNames, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             NoFragmentCycles::cycleErrorMessage($fargment, $spreadNames),
             [new SourceLocation($line, $column)]
         );
@@ -163,7 +163,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragB on Dog { ...fragA }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragB']),
                     [new SourceLocation(2, 31), new SourceLocation(3, 31)]
                 ),
@@ -183,7 +183,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragA on Dog { ...fragB }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragB', ['fragA']),
                     [new SourceLocation(2, 31), new SourceLocation(3, 31)]
                 ),
@@ -211,7 +211,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragB']),
                     [new SourceLocation(4, 11), new SourceLocation(9, 11)]
                 ),
@@ -237,7 +237,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragP on Dog { ...fragA, ...fragX }
     ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragB', 'fragC', 'fragO', 'fragP']),
                     [
                         new SourceLocation(2, 31),
@@ -247,7 +247,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
                         new SourceLocation(9, 31),
                     ]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragO', ['fragP', 'fragX', 'fragY', 'fragZ']),
                     [
                         new SourceLocation(8, 31),
@@ -274,11 +274,11 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragC on Dog { ...fragA }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragB']),
                     [new SourceLocation(2, 31), new SourceLocation(3, 31)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragC']),
                     [new SourceLocation(2, 41), new SourceLocation(4, 31)]
                 ),
@@ -299,11 +299,11 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragC on Dog { ...fragA, ...fragB }
     ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragC']),
                     [new SourceLocation(2, 31), new SourceLocation(4, 31)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragC', ['fragB']),
                     [new SourceLocation(4, 41), new SourceLocation(3, 31)]
                 ),
@@ -324,11 +324,11 @@ class NoFragmentCyclesTest extends ValidatorTestCase
       fragment fragC on Dog { ...fragA, ...fragB }
     ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragB', []),
                     [new SourceLocation(3, 31)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragA', ['fragB', 'fragC']),
                     [
                         new SourceLocation(2, 31),
@@ -336,7 +336,7 @@ class NoFragmentCyclesTest extends ValidatorTestCase
                         new SourceLocation(4, 31),
                     ]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     NoFragmentCycles::cycleErrorMessage('fragB', ['fragC']),
                     [new SourceLocation(3, 41), new SourceLocation(4, 41)]
                 ),

--- a/tests/Validator/NoUndefinedVariablesTest.php
+++ b/tests/Validator/NoUndefinedVariablesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\NoUndefinedVariables;
 
 class NoUndefinedVariablesTest extends ValidatorTestCase
@@ -189,7 +189,7 @@ class NoUndefinedVariablesTest extends ValidatorTestCase
             $locs[] = new SourceLocation($l2, $c2);
         }
 
-        return FormattedError::create(
+        return ErrorHelper::create(
             NoUndefinedVariables::undefinedVarMessage($varName, $opName),
             $locs
         );

--- a/tests/Validator/NoUnusedFragmentsTest.php
+++ b/tests/Validator/NoUnusedFragmentsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\NoUnusedFragments;
 
 class NoUnusedFragmentsTest extends ValidatorTestCase
@@ -118,7 +118,7 @@ class NoUnusedFragmentsTest extends ValidatorTestCase
 
     private function unusedFrag($fragName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             NoUnusedFragments::unusedFragMessage($fragName),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/NoUnusedVariablesTest.php
+++ b/tests/Validator/NoUnusedVariablesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\NoUnusedVariables;
 
 class NoUnusedVariablesTest extends ValidatorTestCase
@@ -161,7 +161,7 @@ class NoUnusedVariablesTest extends ValidatorTestCase
 
     private function unusedVar($varName, $opName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             NoUnusedVariables::unusedVariableMessage($varName, $opName),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/OverlappingFieldsCanBeMergedTest.php
+++ b/tests/Validator/OverlappingFieldsCanBeMergedTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -145,7 +145,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'fido',
                         'name and nickname are different fields'
@@ -192,7 +192,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'name',
                         'nickname and name are different fields'
@@ -217,7 +217,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'doesKnowCommand',
                         'they have differing arguments'
@@ -242,7 +242,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'doesKnowCommand',
                         'they have differing arguments'
@@ -267,7 +267,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'doesKnowCommand',
                         'they have differing arguments'
@@ -320,7 +320,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage('x', 'a and b are different fields'),
                     [new SourceLocation(7, 9), new SourceLocation(10, 9)]
                 ),
@@ -359,15 +359,15 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
     ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage('x', 'a and b are different fields'),
                     [new SourceLocation(18, 9), new SourceLocation(21, 9)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage('x', 'c and a are different fields'),
                     [new SourceLocation(14, 11), new SourceLocation(18, 9)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage('x', 'c and b are different fields'),
                     [new SourceLocation(14, 11), new SourceLocation(21, 9)]
                 ),
@@ -393,7 +393,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'field',
                         [['x', 'a and b are different fields']]
@@ -429,7 +429,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'field',
                         [
@@ -472,7 +472,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'field',
                         [['deepField', [['x', 'a and b are different fields']]]]
@@ -515,7 +515,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'deepField',
                         [['x', 'a and b are different fields']]
@@ -564,7 +564,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'deeperField',
                         [['x', 'a and b are different fields']]
@@ -612,7 +612,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'field',
                         [
@@ -682,7 +682,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'scalar',
                         'they return conflicting types Int and String!'
@@ -861,7 +861,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'scalar',
                         'they return conflicting types Int and String'
@@ -928,7 +928,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'other',
                         [['scalar', 'scalar and unrelatedField are different fields']]
@@ -965,7 +965,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'scalar',
                         'they return conflicting types String! and String'
@@ -1004,7 +1004,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'box',
                         'they return conflicting types [StringBox] and StringBox'
@@ -1037,7 +1037,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'box',
                         'they return conflicting types StringBox and [StringBox]'
@@ -1075,7 +1075,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         ',
             [
 
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'val',
                         'scalar and unrelatedField are different fields'
@@ -1114,7 +1114,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'box',
                         [['scalar', 'they return conflicting types String and Int']]
@@ -1224,7 +1224,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
         }
       ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'edges',
                         [['node', [['id', 'name and id are different fields']]]]
@@ -1334,7 +1334,7 @@ class OverlappingFieldsCanBeMergedTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     OverlappingFieldsCanBeMerged::fieldsConflictMessage(
                         'fido',
                         'name and nickname are different fields'

--- a/tests/Validator/PossibleFragmentSpreadsTest.php
+++ b/tests/Validator/PossibleFragmentSpreadsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\PossibleFragmentSpreads;
 
 class PossibleFragmentSpreadsTest extends ValidatorTestCase
@@ -195,7 +195,7 @@ class PossibleFragmentSpreadsTest extends ValidatorTestCase
 
     private function error($fragName, $parentType, $fragType, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             PossibleFragmentSpreads::typeIncompatibleSpreadMessage($fragName, $parentType, $fragType),
             [new SourceLocation($line, $column)]
         );
@@ -219,7 +219,7 @@ class PossibleFragmentSpreadsTest extends ValidatorTestCase
 
     private function errorAnon($parentType, $fragType, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             PossibleFragmentSpreads::typeIncompatibleAnonSpreadMessage($parentType, $fragType),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/ProvidedRequiredArgumentsTest.php
+++ b/tests/Validator/ProvidedRequiredArgumentsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\Rules\ProvidedRequiredArguments;
 use GraphQL\Validator\Rules\ProvidedRequiredArgumentsOnDirectives;
@@ -243,7 +243,7 @@ class ProvidedRequiredArgumentsTest extends ValidatorTestCase
 
     private function missingFieldArg($fieldName, $argName, $typeName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ProvidedRequiredArguments::missingFieldArgMessage($fieldName, $argName, $typeName),
             [new SourceLocation($line, $column)]
         );
@@ -464,7 +464,7 @@ class ProvidedRequiredArgumentsTest extends ValidatorTestCase
 
     private function missingDirectiveArg($directiveName, $argName, $typeName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ProvidedRequiredArgumentsOnDirectives::missingDirectiveArgMessage($directiveName, $argName, $typeName),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/QuerySecurityTestCase.php
+++ b/tests/Validator/QuerySecurityTestCase.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace GraphQL\Tests\Validator;
 
 use GraphQL\Error\Error;
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\Parser;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Type\Introspection;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QuerySecurityRule;
@@ -72,7 +72,7 @@ abstract class QuerySecurityTestCase extends TestCase
 
     protected function createFormattedError($max, $count, $locations = [])
     {
-        return FormattedError::create($this->getErrorMessage($max, $count), $locations);
+        return ErrorHelper::create($this->getErrorMessage($max, $count), $locations);
     }
 
     /**

--- a/tests/Validator/ScalarLeafsTest.php
+++ b/tests/Validator/ScalarLeafsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\ScalarLeafs;
 
 class ScalarLeafsTest extends ValidatorTestCase
@@ -45,7 +45,7 @@ class ScalarLeafsTest extends ValidatorTestCase
 
     private function missingObjSubselection($field, $type, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ScalarLeafs::requiredSubselectionMessage($field, $type),
             [new SourceLocation($line, $column)]
         );
@@ -100,7 +100,7 @@ class ScalarLeafsTest extends ValidatorTestCase
 
     private function noScalarSubselection($field, $type, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ScalarLeafs::noSubselectionAllowedMessage($field, $type),
             [new SourceLocation($line, $column)]
         );

--- a/tests/Validator/SingleFieldSubscriptionsTest.php
+++ b/tests/Validator/SingleFieldSubscriptionsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\SingleFieldSubscription;
 
 use function array_map;
@@ -182,7 +182,7 @@ class SingleFieldSubscriptionsTest extends ValidatorTestCase
      */
     private function multipleFieldsInOperation(?string $operationName, array ...$locations)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             SingleFieldSubscription::multipleFieldsInOperation($operationName),
             array_map(static function (array $location): SourceLocation {
                 [$line, $column] = $location;

--- a/tests/Validator/UniqueArgumentNamesTest.php
+++ b/tests/Validator/UniqueArgumentNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\UniqueArgumentNames;
 
 class UniqueArgumentNamesTest extends ValidatorTestCase
@@ -166,7 +166,7 @@ class UniqueArgumentNamesTest extends ValidatorTestCase
 
     private function duplicateArg($argName, $l1, $c1, $l2, $c2)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             UniqueArgumentNames::duplicateArgMessage($argName),
             [new SourceLocation($l1, $c1), new SourceLocation($l2, $c2)]
         );

--- a/tests/Validator/UniqueFragmentNamesTest.php
+++ b/tests/Validator/UniqueFragmentNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\UniqueFragmentNames;
 
 class UniqueFragmentNamesTest extends ValidatorTestCase
@@ -134,7 +134,7 @@ class UniqueFragmentNamesTest extends ValidatorTestCase
 
     private function duplicateFrag($fragName, $l1, $c1, $l2, $c2)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             UniqueFragmentNames::duplicateFragmentNameMessage($fragName),
             [new SourceLocation($l1, $c1), new SourceLocation($l2, $c2)]
         );

--- a/tests/Validator/UniqueInputFieldNamesTest.php
+++ b/tests/Validator/UniqueInputFieldNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\UniqueInputFieldNames;
 
 class UniqueInputFieldNamesTest extends ValidatorTestCase
@@ -98,7 +98,7 @@ class UniqueInputFieldNamesTest extends ValidatorTestCase
 
     private function duplicateField($name, $l1, $c1, $l2, $c2)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             UniqueInputFieldNames::duplicateInputFieldMessage($name),
             [new SourceLocation($l1, $c1), new SourceLocation($l2, $c2)]
         );

--- a/tests/Validator/UniqueOperationNamesTest.php
+++ b/tests/Validator/UniqueOperationNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\UniqueOperationNames;
 
 class UniqueOperationNamesTest extends ValidatorTestCase
@@ -138,7 +138,7 @@ class UniqueOperationNamesTest extends ValidatorTestCase
 
     private function duplicateOp($opName, $l1, $c1, $l2, $c2)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             UniqueOperationNames::duplicateOperationNameMessage($opName),
             [new SourceLocation($l1, $c1), new SourceLocation($l2, $c2)]
         );

--- a/tests/Validator/UniqueVariableNamesTest.php
+++ b/tests/Validator/UniqueVariableNamesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\UniqueVariableNames;
 
 class UniqueVariableNamesTest extends ValidatorTestCase
@@ -49,7 +49,7 @@ class UniqueVariableNamesTest extends ValidatorTestCase
 
     private function duplicateVariable($name, $l1, $c1, $l2, $c2)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             UniqueVariableNames::duplicateVariableMessage($name),
             [new SourceLocation($l1, $c1), new SourceLocation($l2, $c2)]
         );

--- a/tests/Validator/ValuesOfCorrectTypeTest.php
+++ b/tests/Validator/ValuesOfCorrectTypeTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\ValuesOfCorrectType;
 
 class ValuesOfCorrectTypeTest extends ValidatorTestCase
@@ -249,7 +249,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
 
     private function badValue($typeName, $value, $line, $column, $message = null)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ValuesOfCorrectType::badValueMessage(
                 $typeName,
                 $value,
@@ -261,7 +261,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
 
     private function badValueWithMessage($message, $line, $column)
     {
-        return FormattedError::create($message, [new SourceLocation($line, $column)]);
+        return ErrorHelper::create($message, [new SourceLocation($line, $column)]);
     }
 
     /**
@@ -1302,7 +1302,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
 
     private function requiredField($typeName, $fieldName, $fieldTypeName, $line, $column)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ValuesOfCorrectType::requiredFieldMessage(
                 $typeName,
                 $fieldName,
@@ -1398,7 +1398,7 @@ class ValuesOfCorrectTypeTest extends ValidatorTestCase
 
     private function unknownField($typeName, $fieldName, $line, $column, $message = null)
     {
-        return FormattedError::create(
+        return ErrorHelper::create(
             ValuesOfCorrectType::unknownFieldMessage(
                 $typeName,
                 $fieldName,

--- a/tests/Validator/VariablesAreInputTypesTest.php
+++ b/tests/Validator/VariablesAreInputTypesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\VariablesAreInputTypes;
 
 class VariablesAreInputTypesTest extends ValidatorTestCase
@@ -40,15 +40,15 @@ class VariablesAreInputTypesTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesAreInputTypes::nonInputTypeOnVarMessage('a', 'Dog'),
                     [new SourceLocation(2, 21)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesAreInputTypes::nonInputTypeOnVarMessage('b', '[[CatOrDog!]]!'),
                     [new SourceLocation(2, 30)]
                 ),
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesAreInputTypes::nonInputTypeOnVarMessage('c', 'Pet'),
                     [new SourceLocation(2, 50)]
                 ),

--- a/tests/Validator/VariablesInAllowedPositionTest.php
+++ b/tests/Validator/VariablesInAllowedPositionTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 
-use GraphQL\Error\FormattedError;
 use GraphQL\Language\SourceLocation;
+use GraphQL\Tests\ErrorHelper;
 use GraphQL\Validator\Rules\VariablesInAllowedPosition;
 
 class VariablesInAllowedPositionTest extends ValidatorTestCase
@@ -249,7 +249,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('intArg', 'Int', 'Int!'),
                     [new SourceLocation(2, 19), new SourceLocation(4, 45)]
                 ),
@@ -276,7 +276,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('intArg', 'Int', 'Int!'),
                     [new SourceLocation(6, 19), new SourceLocation(3, 43)]
                 ),
@@ -309,7 +309,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('intArg', 'Int', 'Int!'),
                     [new SourceLocation(10, 19), new SourceLocation(7, 43)]
                 ),
@@ -332,7 +332,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('stringVar', 'String', 'Boolean'),
                     [new SourceLocation(2, 19), new SourceLocation(4, 39)]
                 ),
@@ -355,7 +355,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('stringVar', 'String', '[String]'),
                     [new SourceLocation(2, 19), new SourceLocation(4, 45)]
                 ),
@@ -376,7 +376,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('boolVar', 'Boolean', 'Boolean!'),
                     [new SourceLocation(2, 19), new SourceLocation(3, 26)]
                 ),
@@ -398,7 +398,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('stringVar', 'String', 'Boolean!'),
                     [new SourceLocation(2, 19), new SourceLocation(3, 26)]
                 ),
@@ -422,7 +422,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
       }
         ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('stringListVar', '[String]', '[String!]'),
                     [new SourceLocation(2, 19), new SourceLocation(5, 59)]
                 ),
@@ -447,7 +447,7 @@ class VariablesInAllowedPositionTest extends ValidatorTestCase
         }
             ',
             [
-                FormattedError::create(
+                ErrorHelper::create(
                     VariablesInAllowedPosition::badVarPosMessage('intVar', 'Int', 'Int!'),
                     [new SourceLocation(2, 21), new SourceLocation(4, 47)]
                 ),


### PR DESCRIPTION
- Remove deprecated `FormattedError::create()` and `FormattedError::createFromPHPError()`
- Use actual type hints
- Clean up collaborator `SourceLocation`