### PR TITLE
Fix FormattedError::printVar() return type

### DIFF
--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -352,7 +352,7 @@ class FormattedError
         }
 
         if (is_scalar($var)) {
-            return $var;
+            return (string) $var;
         }
 
         if ($var === null) {

--- a/tests/Error/FormattedErrorTest.php
+++ b/tests/Error/FormattedErrorTest.php
@@ -28,7 +28,7 @@ class FormattedErrorTest extends TestCase
             [Type::string(), 'GraphQLType: String'],
             [
                 new NodeList([]),
-                'instance of GraphQL\Language\AST\NodeList(0)'
+                'instance of GraphQL\Language\AST\NodeList(0)',
             ],
             [[2], 'array(1)'],
             ['', '(empty string)'],

--- a/tests/Error/FormattedErrorTest.php
+++ b/tests/Error/FormattedErrorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Error;
+
+use GraphQL\Error\FormattedError;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\TestCase;
+
+class FormattedErrorTest extends TestCase
+{
+    /**
+     * @dataProvider printVar
+     */
+    public function testPrintVar($var, string $printed): void
+    {
+        self::assertSame($printed, FormattedError::printVar($var));
+    }
+
+    /**
+     * @return array<int, array{mixed, string}>
+     */
+    public function printVar(): array
+    {
+        return [
+            [Type::string(), 'GraphQLType: String'],
+            [
+                new NodeList([]),
+                'instance of GraphQL\Language\AST\NodeList(0)'
+            ],
+            [[2], 'array(1)'],
+            ['', '(empty string)'],
+            ["'", "'\\''"],
+            [true, 'true'],
+            [false, 'false'],
+            [1, '1'],
+            [2.3, '2.3'],
+            [null, 'null'],
+        ];
+    }
+}


### PR DESCRIPTION
```
TypeError: GraphQL\Error\FormattedError::printVar(): Return value must be of type string, int returned

/workdir/vendor/webonyx/graphql-php/src/Error/FormattedError.php:355
```