### PR TITLE
Always throw `RequestError` with useful message when clients provide an invalid JSON body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Use native PHP types for properties of `Type` and its subclasses
 - Throw `SerializationError` over client safe `Error` when failing to serialize leaf types
 - Move debug entries in errors under `extensions` key
+- Always throw `RequestError` with useful message when clients provide an invalid JSON body
 
 ### Added
 

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -533,7 +533,7 @@ class Helper
                     : json_decode((string) $request->getBody(), true);
 
                 if ($bodyParams === null) {
-                    throw new InvariantViolation(
+                    throw new RequestError(
                         $request instanceof ServerRequestInterface
                          ? 'Expected to receive a parsed body for "application/json" PSR-7 request but got null'
                          : 'Expected to receive a JSON array in body for "application/json" PSR-7 request'

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -535,8 +535,8 @@ class Helper
                 if ($bodyParams === null) {
                     throw new RequestError(
                         $request instanceof ServerRequestInterface
-                         ? 'Expected to receive a parsed body for "application/json" PSR-7 request but got null'
-                         : 'Expected to receive a JSON array in body for "application/json" PSR-7 request'
+                         ? 'Expected to receive a parsed body for "application/json" PSR-7 request, got: null'
+                         : 'Expected to receive a JSON body for "application/json" PSR-7 request, got: null'
                     );
                 }
 

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -528,16 +528,16 @@ class Helper
             if (stripos($contentType[0], 'application/graphql') !== false) {
                 $bodyParams = ['query' => (string) $request->getBody()];
             } elseif (stripos($contentType[0], 'application/json') !== false) {
-                $bodyParams = $request instanceof ServerRequestInterface
-                    ? $request->getParsedBody()
-                    : json_decode((string) $request->getBody(), true);
-
-                if ($bodyParams === null) {
-                    throw new RequestError(
-                        $request instanceof ServerRequestInterface
-                         ? 'Expected to receive a parsed body for "application/json" PSR-7 request, got: null'
-                         : 'Expected to receive a JSON body for "application/json" PSR-7 request, got: null'
-                    );
+                if ($request instanceof ServerRequestInterface) {
+                    $bodyParams = $request->getParsedBody();
+                    if ($bodyParams === null) {
+                        throw new InvariantViolation('Expected to receive a parsed body for "application/json" PSR-7 request, got: null');
+                    }
+                } else {
+                    $bodyParams = json_decode((string) $request->getBody(), true);
+                    if ($bodyParams === null) {
+                        throw new RequestError('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
+                    }
                 }
 
                 if (! is_array($bodyParams)) {

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -410,21 +410,21 @@ class RequestParsingTest extends TestCase
         $body = 'not really{} a json';
 
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
+        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
         $this->parsePsrRequest('application/json', $body);
     }
 
     public function testFailsParsingNonPreParsedPsrRequest(): void
     {
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
+        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
         $this->parsePsrRequest('application/json', json_encode(null));
     }
 
     public function testFailsParsingInvalidEmptyJsonRequestPsr(): void
     {
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
+        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
         $this->parsePsrRequest('application/json', '');
     }
 

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -401,7 +401,7 @@ class RequestParsingTest extends TestCase
         $body = 'not really{} a json';
 
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Could not parse JSON: Syntax error');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parseRawRequest('application/json', $body);
     }
 
@@ -410,33 +410,30 @@ class RequestParsingTest extends TestCase
         $body = 'not really{} a json';
 
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parsePsrRequest('application/json', $body);
     }
 
     public function testFailsParsingNonPreParsedPsrRequest(): void
     {
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: null');
         $this->parsePsrRequest('application/json', json_encode(null));
     }
 
     public function testFailsParsingInvalidEmptyJsonRequestPsr(): void
     {
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('Expected to receive a JSON body for "application/json" PSR-7 request, got: null');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parsePsrRequest('application/json', '');
     }
 
-    /**
-     * There is no equivalent for psr request, because it should throw
-     */
     public function testFailsParsingNonArrayOrObjectJsonRequestRaw(): void
     {
         $body = '"str"';
 
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('GraphQL Server expects JSON object or array, but got "str"');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: "str"');
         $this->parseRawRequest('application/json', $body);
     }
 
@@ -445,7 +442,7 @@ class RequestParsingTest extends TestCase
         $body = '"str"';
 
         $this->expectException(RequestError::class);
-        $this->expectExceptionMessage('GraphQL Server expects JSON object or array, but got "str"');
+        $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: "str"');
         $this->parsePsrRequest('application/json', $body);
     }
 

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -425,7 +425,7 @@ class RequestParsingTest extends TestCase
     {
         $this->expectException(RequestError::class);
         $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
-        $this->parsePsrRequest('application/json', json_encode(null));
+        $this->parsePsrRequest('application/json', '');
     }
 
     /**

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -409,23 +409,23 @@ class RequestParsingTest extends TestCase
     {
         $body = 'not really{} a json';
 
-        $this->expectException(InvariantViolation::class);
+        $this->expectException(RequestError::class);
         $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
         $this->parsePsrRequest('application/json', $body);
     }
 
     public function testFailsParsingNonPreParsedPsrRequest(): void
     {
-        try {
-            $this->parsePsrRequest('application/json', json_encode(null));
-            self::fail('Expected exception not thrown');
-        } catch (InvariantViolation $e) {
-            // Expecting parsing exception to be thrown somewhere else:
-            self::assertSame(
-                'Expected to receive a JSON array in body for "application/json" PSR-7 request',
-                $e->getMessage()
-            );
-        }
+        $this->expectException(RequestError::class);
+        $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
+        $this->parsePsrRequest('application/json', json_encode(null));
+    }
+
+    public function testFailsParsingInvalidEmptyJsonRequestPsr(): void
+    {
+        $this->expectException(RequestError::class);
+        $this->expectExceptionMessage('Expected to receive a JSON array in body for "application/json" PSR-7 request');
+        $this->parsePsrRequest('application/json', json_encode(null));
     }
 
     /**


### PR DESCRIPTION
I'm seeing this error on production. When a client makes an invalid or empty request to the server it fatals. The correct behavior is that it should reply with a 400 Bad Request.

I don't understand why this was considered an InvariantViolation or why it is specifically tested against. It's a LogicException so it should not be part of the interface.