### PR TITLE
Fix `extend()` to preserve `repeatable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Allow directives on variable definitions
 - Handle `null` parent of list in `ValuesOfCorrectType::getVisitor`
 - Allow sending both `query` and `queryId`, ignore `queryId` in that case
+- Fix `extend()` to preserve `repeatable` (#931)
 
 ### Removed
 

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -502,6 +502,7 @@ class SchemaExtender
             'locations' => $directive->locations,
             'args' => static::extendArgs($directive->args),
             'astNode' => $directive->astNode,
+            'isRepeatable' => $directive->isRepeatable,
         ]);
     }
 

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -2040,6 +2040,22 @@ extend type Query {
         static::assertEquals($this->dedent($expected), SchemaPrinter::doPrint($extendedSchema));
     }
 
+    /**
+     * @see https://github.com/webonyx/graphql-php/pull/929
+     */
+    public function testPreservesRepeatableInDirective(): void
+    {
+        $schema = BuildSchema::build('
+            directive @test(arg: Int) repeatable on FIELD | SCALAR
+        ');
+
+        self::assertTrue($schema->getDirective('test')->isRepeatable);
+
+        $extendedSchema = SchemaExtender::extend($schema, Parser::parse('scalar Foo'));
+
+        self::assertTrue($extendedSchema->getDirective('test')->isRepeatable);
+    }
+
     public function testSupportsTypeConfigDecorator(): void
     {
         $queryType = new ObjectType([


### PR DESCRIPTION
Fixes a problem identified in #929 when the `repeatable` flag on a directive from the original schema wasn't copied over to the new extended schema.