### PR TITLE
Introduce reusable test utility `dedent()`

### DIFF
--- a/tests/TestUtils/Str.php
+++ b/tests/TestUtils/Str.php
@@ -14,7 +14,7 @@ class Str
      * Fixes indentation. Also removes leading newlines
      * and trailing spaces and tabs, but keeps trailing newlines.
      *
-     * Example usage:
+     * @example
      * $str = Str::dedent('
      *   {
      *     test

--- a/tests/TestUtils/Str.php
+++ b/tests/TestUtils/Str.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\TestUtils;
+
+use function preg_match;
+use function preg_replace;
+use function trim;
+
+class Str
+{
+    /**
+     * Fixes indentation. Also removes leading newlines
+     * and trailing spaces and tabs, but keeps trailing newlines.
+     *
+     * Example usage:
+     * $str = Str::dedent('
+     *   {
+     *     test
+     *   }
+     * ');
+     * $str === "{\n  test\n}\n";
+     */
+    public static function dedent(string $string): string
+    {
+        $trimmedString = trim($string, "\n");
+        $trimmedString = preg_replace('/[ \t]*$/', '', $trimmedString);
+        preg_match('/^[ \t]*/', $trimmedString, $indentMatch);
+        $indent = $indentMatch[0];
+
+        return preg_replace('/^' . $indent . '/m', '', $trimmedString);
+    }
+}

--- a/tests/TestUtils/StrTest.php
+++ b/tests/TestUtils/StrTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\TestUtils;
+
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+
+class StrTest extends TestCase
+{
+    // describe('dedent')
+
+    /**
+     * @see it('removes indentation in typical usage')
+     */
+    public function testRemovesIndentationInTypicalUsage(): void
+    {
+        $output = Str::dedent('
+          type Query {
+            me: User
+          }
+
+          type User {
+            id: ID
+            name: String
+          }
+        ');
+        self::assertEquals(
+            implode(
+                "\n",
+                [
+                    'type Query {',
+                    '  me: User',
+                    '}',
+                    '',
+                    'type User {',
+                    '  id: ID',
+                    '  name: String',
+                    '}',
+                    '',
+                ]
+            ),
+            $output
+        );
+    }
+
+    /**
+     * @see it('removes only the first level of indentation')
+     */
+    public function testRemovesOnlyTheFirstLevelOfIndentation(): void
+    {
+        $output = Str::dedent('
+            first
+              second
+                third
+                  fourth
+        ');
+        self::assertEquals(
+            implode("\n", ['first', '  second', '    third', '      fourth', '']),
+            $output
+        );
+    }
+
+    /**
+     * @see it('does not escape special characters')
+     */
+    public function testDoesNotEscapeSpecialCharacters(): void
+    {
+        $output = Str::dedent("
+          type Root {
+            field(arg: String = \"wi\th de\fault\"): String
+          }
+        ");
+        self::assertEquals(
+            implode(
+                "\n",
+                [
+                    'type Root {',
+                    "  field(arg: String = \"wi\th de\fault\"): String",
+                    '}',
+                    '',
+                ]
+            ),
+            $output
+        );
+    }
+
+    /**
+     * @see it('also removes indentation using tabs')
+     */
+    public function testAlsoRemovesIndentationUsingTabs(): void
+    {
+        $output = Str::dedent("
+            \t\t    type Query {
+            \t\t      me: User
+            \t\t    }
+        ");
+        self::assertEquals(implode("\n", ['type Query {', '  me: User', '}', '']), $output);
+    }
+
+    /**
+     * @see it('removes leading newlines')
+     */
+    public function testRemovesLeadingNewlines(): void
+    {
+        $output = Str::dedent('
+
+
+          type Query {
+            me: User
+          }');
+        self::assertEquals(implode("\n", ['type Query {', '  me: User', '}']), $output);
+    }
+
+    /**
+     * @see it('does not remove trailing newlines')
+     */
+    public function testDoesNotRemoveTrailingNewlines(): void
+    {
+        $output = Str::dedent('
+          type Query {
+            me: User
+          }
+
+         ');
+        self::assertEquals(implode("\n", ['type Query {', '  me: User', '}', '', '']), $output);
+    }
+
+    /**
+     * @see it('removes all trailing spaces and tabs')
+     */
+    public function testRemovesAllTrailingSpacesAndTabs(): void
+    {
+        $output = Str::dedent("
+          type Query {
+            me: User
+          }
+              \t\t  \t ");
+        self::assertEquals(implode("\n", ['type Query {', '  me: User', '}', '']), $output);
+    }
+
+    /**
+     * @see it('works on text without leading newline')
+     */
+    public function testWorksOnTextWithoutLeadingNewline(): void
+    {
+        $output = Str::dedent('          type Query {
+            me: User
+          }');
+        self::assertEquals(implode("\n", ['type Query {', '  me: User', '}']), $output);
+    }
+}


### PR DESCRIPTION
Equivalent of [`dedent()`](https://github.com/graphql/graphql-js/blob/99d6079434/src/__testUtils__/dedent.js) test utility function from `graphql-js`.

Its behaviour matches `graphql-js` v15 (v16 version trims trailing newlines).

Introduced in reaction to https://github.com/webonyx/graphql-php/pull/930#pullrequestreview-747366447

It lives in `tests/TestUtils` directory, where I later intend to move other testing utilities and fixtures (similarly to `graphql-js`'s [`__testUtils__`](https://github.com/graphql/graphql-js/tree/99d6079434e2353ce042fd6df93bb8076c59d47f/src/__testUtils__)).

Personally, I would prefer to have the utility as a function, rather than a static method. But that wouldn't quite fit into the current codebase. 

Compare these two snippets:
```php
$sdl = TestUtils::dedent('
    type Query {
      field(in: Input): String
    }
');
```
```php
$sdl = dedent('
    type Query {
      field(in: Input): String
    }
');
```

`TestUtils::` is completely unnecessary noise that doesn't add any additional information about `dedent()`. And it also further complicates already difficult diffing with `graphql-js`.

To keep the code consistent with the current "static methods for everything" approach, I went with `Str::dedent()`. It's at least short and has the meaning of "dedent is a function operating on a string".

However, if you would like to give it a go, I'm happy to refactor the method to a function. There are more static methods that could be changed to functions and I believe the codebase could benefit from it.