### PR TITLE
Align `BlockString::dedentValue()` with `graphql-js` v15.5

### DIFF
--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQL\Utils;
+namespace GraphQL\Language;
 
 use function array_pop;
 use function array_shift;

--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -21,7 +21,7 @@ class BlockString
      *
      * This implements the GraphQL spec's BlockStringValue() static algorithm.
      */
-    public static function value($rawString)
+    public static function dedentValue(string $rawString): string
     {
         // Expand a block string's raw value into independent lines.
         $lines = preg_split("/\\r\\n|[\\n\\r]/", $rawString);

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GraphQL\Language;
 
 use GraphQL\Error\SyntaxError;
-use GraphQL\Utils\BlockString;
 use GraphQL\Utils\Utils;
 
 use function chr;

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -613,7 +613,7 @@ class Lexer
                         $line,
                         $col,
                         $prev,
-                        BlockString::value($value)
+                        BlockString::dedentValue($value)
                     );
                 }
 

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -23,6 +23,7 @@ use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\TypeNode;
 use GraphQL\Language\AST\UnionTypeDefinitionNode;
+use GraphQL\Language\BlockString;
 use GraphQL\Language\Token;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -108,7 +108,7 @@ class ASTDefinitionBuilder
         if (isset($this->options['commentDescriptions'])) {
             $rawValue = $this->getLeadingCommentBlock($node);
             if ($rawValue !== null) {
-                return BlockString::value("\n" . $rawValue);
+                return BlockString::dedentValue("\n" . $rawValue);
             }
         }
 

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Language;
+
+use GraphQL\Language\BlockString;
+use PHPUnit\Framework\TestCase;
+
+use function implode;
+
+class BlockStringTest extends TestCase
+{
+    private static function joinLines(string ...$args): string
+    {
+        return implode("\n", $args);
+    }
+
+    // describe('dedentBlockStringValue')
+
+    /**
+     * @see it('removes uniform indentation from a string')
+     */
+    public function testRemovesUniformIndentationFromAString(): void
+    {
+        $rawValue = self::joinLines(
+            '',
+            '    Hello,',
+            '      World!',
+            '',
+            '    Yours,',
+            '      GraphQL.',
+        );
+        self::assertEquals(
+            self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
+            BlockString::dedentValue($rawValue)
+        );
+    }
+
+    /**
+     * @see it('removes empty leading and trailing lines')
+     */
+    public function testRemovesEmptyLeadingAndTrailingLines(): void
+    {
+        $rawValue = self::joinLines(
+            '',
+            '',
+            '    Hello,',
+            '      World!',
+            '',
+            '    Yours,',
+            '      GraphQL.',
+            '',
+            '',
+        );
+        self::assertEquals(
+            self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
+            BlockString::dedentValue($rawValue)
+        );
+    }
+
+    /**
+     * @see it('removes blank leading and trailing lines')
+     */
+    public function testRemovesBlankLeadingAndTrailingLines(): void
+    {
+        $rawValue = self::joinLines(
+            '  ',
+            '        ',
+            '    Hello,',
+            '      World!',
+            '',
+            '    Yours,',
+            '      GraphQL.',
+            '        ',
+            '  ',
+        );
+        self::assertEquals(
+            self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
+            BlockString::dedentValue($rawValue)
+        );
+    }
+
+    /**
+     * @see it('retains indentation from first line')
+     */
+    public function testRetainsIndentationFromFirstLine(): void
+    {
+        $rawValue = self::joinLines(
+            '    Hello,',
+            '      World!',
+            '',
+            '    Yours,',
+            '      GraphQL.',
+        );
+        self::assertEquals(
+            self::joinLines('    Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
+            BlockString::dedentValue($rawValue)
+        );
+    }
+
+    /**
+     * @see it('does not alter trailing spaces')
+     */
+    public function testDoesNotAlterTrailingSpaces(): void
+    {
+        $rawValue = self::joinLines(
+            '               ',
+            '    Hello,     ',
+            '      World!   ',
+            '               ',
+            '    Yours,     ',
+            '      GraphQL. ',
+            '               ',
+        );
+        self::assertEquals(
+            self::joinLines(
+                'Hello,     ',
+                '  World!   ',
+                '           ',
+                'Yours,     ',
+                '  GraphQL. ',
+            ),
+            BlockString::dedentValue($rawValue)
+        );
+    }
+}

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -124,4 +124,54 @@ class BlockStringTest extends TestCase
             BlockString::dedentValue($rawValue)
         );
     }
+
+    // describe('getBlockStringIndentation')
+
+    /**
+     * @see it('returns zero for an empty string')
+     */
+    public function testReturnsZeroForAnEmptyString(): void
+    {
+        self::assertEquals(0, BlockString::getIndentation(''));
+    }
+
+    /**
+     * @see it('do not take first line into account')
+     */
+    public function testDoNotTakeFirstLineIntoAccount(): void
+    {
+        self::assertEquals(0, BlockString::getIndentation('  a'));
+        self::assertEquals(2, BlockString::getIndentation(" a\n  b"));
+    }
+
+    /**
+     * @see it('returns minimal indentation length')
+     */
+    public function testReturnsMinimalIndentationLength(): void
+    {
+        self::assertEquals(1, BlockString::getIndentation("\n a\n  b"));
+        self::assertEquals(1, BlockString::getIndentation("\n  a\n b"));
+        self::assertEquals(0, BlockString::getIndentation("\n  a\n b\nc"));
+    }
+
+    /**
+     * @see it('count both tab and space as single character')
+     */
+    public function testCountBothTabAndSpaceAsSingleCharacter(): void
+    {
+        self::assertEquals(1, BlockString::getIndentation("\n\ta\n          b"));
+        self::assertEquals(2, BlockString::getIndentation("\n\t a\n          b"));
+        self::assertEquals(3, BlockString::getIndentation("\n \t a\n          b"));
+    }
+
+    /**
+     * @see it('do not take empty lines into account')
+     */
+    public function testDoNotTakeEmptyLinesIntoAccount(): void
+    {
+        self::assertEquals(0, BlockString::getIndentation("a\n "));
+        self::assertEquals(0, BlockString::getIndentation("a\n\t"));
+        self::assertEquals(1, BlockString::getIndentation("a\n\n b"));
+        self::assertEquals(2, BlockString::getIndentation("a\n \n  b"));
+    }
 }


### PR DESCRIPTION
This brings `BlockString::dedentValue()` to parity with [`dedentBlockStringValue()`](https://github.com/graphql/graphql-js/blob/99d6079434/src/language/blockString.js#L9) from `graphql-js` v15.5 and adds missing tests.

Relevant changes in `graphql-js`:
- https://github.com/graphql/graphql-js/commit/280edb6836d2885820d339db752c42117b4153cb
- https://github.com/graphql/graphql-js/commit/b83a9fe79a04f619b6bf07d63f9c839648d8366e

The newly introduced `BlockString::getIndentation()` could be used to implement currently missing `stripIgnoredCharacters()` utility function (see https://github.com/graphql/graphql-js/commit/081db43fc3b05bd93e9317ea1de011b521c5a216).

