### PR TITLE
Align `SchemaPrinterTest` with `graphql-js` v15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Allow sending both `query` and `queryId`, ignore `queryId` in that case
 - Fix `extend()` to preserve `repeatable` (#931)
 - Preserve extended methods from class-based types in `SchemaExtender::extend()`
+- Fix printing of empty types (#940)
 
 ### Removed
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -11,6 +11,7 @@ use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\EnumValueDefinition;
 use GraphQL\Type\Definition\FieldArgument;
 use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\ImplementingType;
 use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -366,21 +367,10 @@ class SchemaPrinter
      */
     protected static function printObject(ObjectType $type, array $options): string
     {
-        $interfaces            = $type->getInterfaces();
-        $implementedInterfaces = count($interfaces) > 0
-            ? ' implements ' . implode(
-                ' & ',
-                array_map(
-                    static function (InterfaceType $interface): string {
-                        return $interface->name;
-                    },
-                    $interfaces
-                )
-            )
-            : '';
-
         return static::printDescription($options, $type) .
-            sprintf("type %s%s {\n%s\n}", $type->name, $implementedInterfaces, static::printFields($options, $type));
+            sprintf('type %s', $type->name) .
+            self::printImplementedInterfaces($type) .
+            static::printFields($options, $type);
     }
 
     /**
@@ -390,19 +380,21 @@ class SchemaPrinter
     protected static function printFields(array $options, $type): string
     {
         $fields = array_values($type->getFields());
-
-        return implode(
-            "\n",
-            array_map(
-                static function (FieldDefinition $f, int $i) use ($options): string {
-                    return static::printDescription($options, $f, '  ', $i === 0) . '  ' .
-                        $f->name . static::printArgs($options, $f->args, '  ') . ': ' .
-                        (string) $f->getType() . static::printDeprecated($f);
-                },
-                $fields,
-                array_keys($fields)
-            )
+        $fields = array_map(
+            static function (FieldDefinition $f, int $i) use ($options): string {
+                return static::printDescription($options, $f, '  ', $i === 0) .
+                    '  ' .
+                    $f->name .
+                    static::printArgs($options, $f->args, '  ') .
+                    ': ' .
+                    (string) $f->getType() .
+                    static::printDeprecated($f);
+            },
+            $fields,
+            array_keys($fields)
         );
+
+        return self::printBlock($fields);
     }
 
     /**
@@ -423,26 +415,30 @@ class SchemaPrinter
             Printer::doPrint(AST::astFromValue($reason, Type::string())) . ')';
     }
 
+    protected static function printImplementedInterfaces(ImplementingType $type): string
+    {
+        $interfaces = $type->getInterfaces();
+
+        return count($interfaces) > 0
+        ? ' implements ' . implode(
+            ' & ',
+            array_map(
+                static fn (InterfaceType $interface): string => $interface->name,
+                $interfaces
+            )
+        )
+        : '';
+    }
+
     /**
      * @param array<string, bool> $options
      */
     protected static function printInterface(InterfaceType $type, array $options): string
     {
-        $interfaces            = $type->getInterfaces();
-        $implementedInterfaces = count($interfaces) > 0
-            ? ' implements ' . implode(
-                ' & ',
-                array_map(
-                    static function (InterfaceType $interface): string {
-                        return $interface->name;
-                    },
-                    $interfaces
-                )
-            )
-            : '';
-
         return static::printDescription($options, $type) .
-            sprintf("interface %s%s {\n%s\n}", $type->name, $implementedInterfaces, static::printFields($options, $type));
+            sprintf('interface %s', $type->name) .
+            self::printImplementedInterfaces($type) .
+            static::printFields($options, $type);
     }
 
     /**
@@ -450,8 +446,10 @@ class SchemaPrinter
      */
     protected static function printUnion(UnionType $type, array $options): string
     {
-        return static::printDescription($options, $type) .
-            sprintf('union %s = %s', $type->name, implode(' | ', $type->getTypes()));
+        $types = $type->getTypes();
+        $types = count($types) > 0 ? ' = ' . implode(' | ', $types) : '';
+
+        return static::printDescription($options, $type) . 'union ' . $type->name . $types;
     }
 
     /**
@@ -459,27 +457,21 @@ class SchemaPrinter
      */
     protected static function printEnum(EnumType $type, array $options): string
     {
-        return static::printDescription($options, $type) .
-            sprintf("enum %s {\n%s\n}", $type->name, static::printEnumValues($type->getValues(), $options));
-    }
-
-    /**
-     * @param array<int, EnumValueDefinition> $values
-     * @param array<string, bool>             $options
-     */
-    protected static function printEnumValues(array $values, array $options): string
-    {
-        return implode(
-            "\n",
-            array_map(
-                static function (EnumValueDefinition $value, int $i) use ($options): string {
-                    return static::printDescription($options, $value, '  ', $i === 0) . '  ' .
-                        $value->name . static::printDeprecated($value);
-                },
-                $values,
-                array_keys($values)
-            )
+        $values = $type->getValues();
+        $values = array_map(
+            static function (EnumValueDefinition $value, int $i) use ($options): string {
+                return static::printDescription($options, $value, '  ', $i === 0) .
+                    '  ' .
+                    $value->name .
+                    static::printDeprecated($value);
+            },
+            $values,
+            array_keys($values)
         );
+
+        return static::printDescription($options, $type) .
+            sprintf('enum %s', $type->name) .
+            static::printBlock($values);
     }
 
     /**
@@ -488,22 +480,17 @@ class SchemaPrinter
     protected static function printInputObject(InputObjectType $type, array $options): string
     {
         $fields = array_values($type->getFields());
+        $fields = array_map(
+            static function ($f, $i) use ($options): string {
+                return static::printDescription($options, $f, '  ', ! $i) . '  ' . static::printInputValue($f);
+            },
+            $fields,
+            array_keys($fields)
+        );
 
         return static::printDescription($options, $type) .
-            sprintf(
-                "input %s {\n%s\n}",
-                $type->name,
-                implode(
-                    "\n",
-                    array_map(
-                        static function ($f, $i) use ($options): string {
-                            return static::printDescription($options, $f, '  ', ! $i) . '  ' . static::printInputValue($f);
-                        },
-                        $fields,
-                        array_keys($fields)
-                    )
-                )
-            );
+            sprintf('input %s', $type->name) .
+            static::printBlock($fields);
     }
 
     /**
@@ -519,5 +506,13 @@ class SchemaPrinter
             [Introspection::class, 'isIntrospectionType'],
             $options
         );
+    }
+
+    /**
+     * @param array<string> $items
+     */
+    protected static function printBlock(array $items): string
+    {
+        return count($items) > 0 ? " {\n" . implode("\n", $items) . "\n}" : '';
     }
 }

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -38,7 +38,9 @@ use function strlen;
 use function substr;
 
 /**
- * Given an instance of Schema, prints it in schema definition language.
+ * Prints the contents of a Schema in schema definition language.
+ *
+ * @phpstan-type Options array{commentDescriptions?: bool}
  */
 class SchemaPrinter
 {
@@ -48,6 +50,7 @@ class SchemaPrinter
      *    - commentDescriptions:
      *        Provide true to use preceding comments as the description.
      *        This option is provided to ease adoption and will be removed in v16.
+     * @phpstan-param Options $options
      *
      * @api
      */
@@ -66,9 +69,9 @@ class SchemaPrinter
     }
 
     /**
-     * @param callable(Directive  $directive): bool $directiveFilter
-     * @param callable(Type       $type):      bool $typeFilter
-     * @param array<string, bool> $options
+     * @param callable(Directive $directive): bool $directiveFilter
+     * @param callable(Type      $type):      bool $typeFilter
+     * @param Options            $options
      */
     protected static function printFilteredSchema(Schema $schema, callable $directiveFilter, callable $typeFilter, array $options): string
     {
@@ -147,7 +150,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printDirective(Directive $directive, array $options): string
     {
@@ -323,7 +326,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     public static function printType(Type $type, array $options = []): string
     {
@@ -355,7 +358,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printScalar(ScalarType $type, array $options): string
     {
@@ -363,7 +366,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printObject(ObjectType $type, array $options): string
     {
@@ -431,7 +434,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printInterface(InterfaceType $type, array $options): string
     {
@@ -442,7 +445,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printUnion(UnionType $type, array $options): string
     {
@@ -453,7 +456,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printEnum(EnumType $type, array $options): string
     {
@@ -475,7 +478,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printInputObject(InputObjectType $type, array $options): string
     {
@@ -494,7 +497,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      *
      * @api
      */

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -215,44 +215,20 @@ class SchemaPrinter
      */
     protected static function printDescription(array $options, $def, string $indentation = '', bool $firstInBlock = true): string
     {
-        if ($def->description === null || $def->description === '') {
+        $description = $def->description;
+        if ($description === null || $description === '') {
             return '';
         }
 
         if (isset($options['commentDescriptions'])) {
-            $lines = static::descriptionLines($def->description, 120 - strlen($indentation));
-
-            return static::printDescriptionWithComments($lines, $indentation, $firstInBlock);
+            return static::printDescriptionWithComments($description, $indentation, $firstInBlock);
         }
 
-        $preferMultipleLines = mb_strlen($def->description) > 70;
-        $blockString         = BlockString::print($def->description, '', $preferMultipleLines);
+        $preferMultipleLines = mb_strlen($description) > 70;
+        $blockString         = BlockString::print($description, '', $preferMultipleLines);
         $prefix              = $indentation !== '' && ! $firstInBlock ? "\n" . $indentation : $indentation;
 
         return $prefix . str_replace("\n", "\n" . $indentation, $blockString) . "\n";
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    protected static function descriptionLines(string $description, int $maxLen): array
-    {
-        $lines    = [];
-        $rawLines = explode("\n", $description);
-        foreach ($rawLines as $line) {
-            if ($line === '') {
-                $lines[] = $line;
-            } else {
-                // For > 120 character long lines, cut at space boundaries into sublines
-                // of ~80 chars.
-                $sublines = static::breakLine($line, $maxLen);
-                foreach ($sublines as $subline) {
-                    $lines[] = $subline;
-                }
-            }
-        }
-
-        return $lines;
     }
 
     /**
@@ -270,21 +246,18 @@ class SchemaPrinter
         return array_map('trim', $parts);
     }
 
-    /**
-     * @param array<int, string> $lines
-     */
-    protected static function printDescriptionWithComments(array $lines, string $indentation, bool $firstInBlock): string
+    protected static function printDescriptionWithComments(string $description, string $indentation, bool $firstInBlock): string
     {
-        $description = $indentation !== '' && ! $firstInBlock ? "\n" : '';
-        foreach ($lines as $line) {
+        $comment = $indentation !== '' && ! $firstInBlock ? "\n" : '';
+        foreach (explode("\n", $description) as $line) {
             if ($line === '') {
-                $description .= $indentation . "#\n";
+                $comment .= $indentation . "#\n";
             } else {
-                $description .= $indentation . '# ' . $line . "\n";
+                $comment .= $indentation . '# ' . $line . "\n";
             }
         }
 
-        return $description;
+        return $comment;
     }
 
     /**

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -23,9 +23,11 @@ class SchemaPrinterTest extends TestCase
 {
     private static function assertPrintedSchemaEquals(string $expected, Schema $schema): void
     {
-        $schemaText = SchemaPrinter::doPrint($schema);
-        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
-        self::assertEquals($expected, $schemaText);
+        $printedSchema = SchemaPrinter::doPrint($schema);
+        self::assertEquals($expected, $printedSchema);
+
+        $cycledSchema = SchemaPrinter::doPrint(BuildSchema::build($printedSchema));
+        self::assertEquals($printedSchema, $cycledSchema);
     }
 
     /** @param array<string, mixed> $fieldConfig */

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -818,10 +818,9 @@ class SchemaPrinterTest extends TestCase
      */
     public function testOneLinePrintsAShortDescription(): void
     {
-        $description = 'This field is awesome';
-        $schema      = $this->buildSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type'        => Type::string(),
-            'description' => $description,
+            'description' => 'This field is awesome',
         ]);
 
         self::assertPrintedSchemaEquals(
@@ -841,8 +840,9 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintIntrospectionSchema(): void
     {
-        $schema   = new Schema([]);
-        $output   = SchemaPrinter::printIntrospectionSchema($schema);
+        $schema = new Schema([]);
+        $output = SchemaPrinter::printIntrospectionSchema($schema);
+
         $expected = <<<'GRAPHQL'
             """
             Directs the executor to include this field or fragment only when the `if` argument is true.

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -37,7 +37,7 @@ class SchemaPrinterTest extends TestCase
         $schemaText = SchemaPrinter::doPrint($schema);
         self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
 
-        return "\n" . $schemaText;
+        return $schemaText;
     }
 
     // Describe: Type System Printer
@@ -51,11 +51,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::string(),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: String
+            }
+
+            GQL,
             $output
         );
     }
@@ -69,11 +70,12 @@ type Query {
             'type' => Type::listOf(Type::string()),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String]
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String]
+            }
+
+            GQL,
             $output
         );
     }
@@ -87,11 +89,12 @@ type Query {
             'type' => Type::nonNull(Type::string()),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: String!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: String!
+            }
+
+            GQL,
             $output
         );
     }
@@ -105,11 +108,12 @@ type Query {
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String]!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String]!
+            }
+
+            GQL,
             $output
         );
     }
@@ -123,11 +127,12 @@ type Query {
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String!]
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String!]
+            }
+
+            GQL,
             $output
         );
     }
@@ -141,11 +146,12 @@ type Query {
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String!]!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String!]!
+            }
+
+            GQL,
             $output
         );
     }
@@ -162,11 +168,12 @@ type Query {
             'deprecationReason' => $deprecationReason,
         ]);
         self::assertSame(
-            '
-type Query {
-  singleField: Int' . $expectedDeprecationDirective . '
-}
-',
+            <<<GQL
+            type Query {
+              singleField: Int$expectedDeprecationDirective
+            }
+
+            GQL,
             $output
         );
     }
@@ -212,15 +219,16 @@ type Query {
         $schema = new Schema(['query' => $root]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Foo {
-  str: String
-}
+            <<<'GQL'
+            type Foo {
+              str: String
+            }
 
-type Query {
-  foo: Foo
-}
-',
+            type Query {
+              foo: Foo
+            }
+
+            GQL,
             $output
         );
     }
@@ -235,11 +243,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -254,11 +263,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = 2): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = 2): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -273,11 +283,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: String = "tes\t de\fault"): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: String = "tes\t de\fault"): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -292,11 +303,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = null): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = null): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -311,11 +323,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int!): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int!): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -333,11 +346,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -356,11 +370,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -379,11 +394,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -402,11 +418,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -423,15 +440,16 @@ type Query {
 
         $schema   = new Schema(['query' => $customQueryType]);
         $output   = $this->printForTest($schema);
-        $expected = '
-schema {
-  query: CustomQueryType
-}
+        $expected = <<<'GQL'
+            schema {
+              query: CustomQueryType
+            }
 
-type CustomQueryType {
-  bar: String
-}
-';
+            type CustomQueryType {
+              bar: String
+            }
+
+            GQL;
         self::assertEquals($expected, $output);
     }
 
@@ -462,19 +480,20 @@ type CustomQueryType {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Bar implements Foo {
-  str: String
-}
+            <<<'GQL'
+            type Bar implements Foo {
+              str: String
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -514,24 +533,25 @@ type Query {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-interface Baaz {
-  int: Int
-}
+            <<<'GQL'
+            interface Baaz {
+              int: Int
+            }
 
-type Bar implements Foo & Baaz {
-  str: String
-  int: Int
-}
+            type Bar implements Foo & Baaz {
+              str: String
+              int: Int
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -575,25 +595,26 @@ type Query {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-interface Baaz implements Foo {
-  int: Int
-  str: String
-}
+            <<<'GQL'
+            interface Baaz implements Foo {
+              int: Int
+              str: String
+            }
 
-type Bar implements Foo & Baaz {
-  str: String
-  int: Int
-}
+            type Bar implements Foo & Baaz {
+              str: String
+              int: Int
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -634,24 +655,25 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Bar {
-  str: String
-}
+            <<<'GQL'
+            type Bar {
+              str: String
+            }
 
-type Foo {
-  bool: Boolean
-}
+            type Foo {
+              bool: Boolean
+            }
 
-union MultipleUnion = Foo | Bar
+            union MultipleUnion = Foo | Bar
 
-type Query {
-  single: SingleUnion
-  multiple: MultipleUnion
-}
+            type Query {
+              single: SingleUnion
+              multiple: MultipleUnion
+            }
 
-union SingleUnion = Foo
-',
+            union SingleUnion = Foo
+
+            GQL,
             $output
         );
     }
@@ -679,15 +701,16 @@ union SingleUnion = Foo
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-input InputType {
-  int: Int
-}
+            <<<'GQL'
+            input InputType {
+              int: Int
+            }
 
-type Query {
-  str(argOne: InputType): String
-}
-',
+            type Query {
+              str(argOne: InputType): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -714,13 +737,14 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-scalar Odd
+            <<<'GQL'
+            scalar Odd
 
-type Query {
-  odd: Odd
-}
-',
+            type Query {
+              odd: Odd
+            }
+
+            GQL,
             $output
         );
     }
@@ -749,17 +773,18 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Query {
-  rgb: RGB
-}
+            <<<'GQL'
+            type Query {
+              rgb: RGB
+            }
 
-enum RGB {
-  RED
-  GREEN
-  BLUE
-}
-',
+            enum RGB {
+              RED
+              GREEN
+              BLUE
+            }
+
+            GQL,
             $output
         );
     }
@@ -782,7 +807,6 @@ enum RGB {
         $output = $this->printForTest($schema);
         self::assertEquals(
             <<<'GQL'
-
             enum SomeEnum
 
             input SomeInputObject
@@ -845,16 +869,17 @@ enum RGB {
 
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-directive @simpleDirective on FIELD
+            <<<'GQL'
+            directive @simpleDirective on FIELD
 
-"""Complex Directive"""
-directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
+            """Complex Directive"""
+            directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
-type Query {
-  field: String
-}
-',
+            type Query {
+              field: String
+            }
+
+            GQL,
             $output
         );
     }
@@ -871,12 +896,13 @@ type Query {
         ]);
 
         self::assertEquals(
-            '
-type Query {
-  """This field is awesome"""
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              """This field is awesome"""
+              singleField: String
+            }
+
+            GQL,
             $output
         );
 
@@ -898,14 +924,15 @@ type Query {
         ]);
 
         self::assertEquals(
-            '
-type Query {
-  """
-  This field is "awesome"
-  """
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              """
+              This field is "awesome"
+              """
+              singleField: String
+            }
+
+            GQL,
             $output
         );
 
@@ -918,7 +945,7 @@ type Query {
     /**
      * @see it('Preserves leading spaces when printing a description')
      */
-    public function testPReservesLeadingSpacesWhenPrintingADescription(): void
+    public function testPreservesLeadingSpacesWhenPrintingADescription(): void
     {
         $description = '    This field is "awesome"';
         $output      = $this->printSingleFieldSchema([
@@ -927,13 +954,14 @@ type Query {
         ]);
 
         self::assertEquals(
-            '
-type Query {
-  """    This field is "awesome"
-  """
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              """    This field is "awesome"
+              """
+              singleField: String
+            }
+
+            GQL,
             $output
         );
 
@@ -957,235 +985,235 @@ type Query {
 
         $schema              = new Schema(['query' => $query]);
         $output              = SchemaPrinter::printIntrospectionSchema($schema);
-        $introspectionSchema = <<<'EOT'
-"""
-Directs the executor to include this field or fragment only when the `if` argument is true.
-"""
-directive @include(
-  """Included when true."""
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        $introspectionSchema = <<<'GQL'
+            """
+            Directs the executor to include this field or fragment only when the `if` argument is true.
+            """
+            directive @include(
+              """Included when true."""
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""
-Directs the executor to skip this field or fragment when the `if` argument is true.
-"""
-directive @skip(
-  """Skipped when true."""
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            """
+            Directs the executor to skip this field or fragment when the `if` argument is true.
+            """
+            directive @skip(
+              """Skipped when true."""
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""Marks an element of a GraphQL schema as no longer supported."""
-directive @deprecated(
-  """
-  Explains why this element was deprecated, usually also including a suggestion
-  for how to access supported similar data. Formatted using the Markdown syntax
-  (as specified by [CommonMark](https://commonmark.org/).
-  """
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+            """Marks an element of a GraphQL schema as no longer supported."""
+            directive @deprecated(
+              """
+              Explains why this element was deprecated, usually also including a suggestion
+              for how to access supported similar data. Formatted using the Markdown syntax
+              (as specified by [CommonMark](https://commonmark.org/).
+              """
+              reason: String = "No longer supported"
+            ) on FIELD_DEFINITION | ENUM_VALUE
 
-"""
-A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+            """
+            A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 
-In some cases, you need to provide options to alter GraphQL's execution behavior
-in ways field arguments will not suffice, such as conditionally including or
-skipping a field. Directives provide this by describing additional information
-to the executor.
-"""
-type __Directive {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  isRepeatable: Boolean!
-  locations: [__DirectiveLocation!]!
-}
+            In some cases, you need to provide options to alter GraphQL's execution behavior
+            in ways field arguments will not suffice, such as conditionally including or
+            skipping a field. Directives provide this by describing additional information
+            to the executor.
+            """
+            type __Directive {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              isRepeatable: Boolean!
+              locations: [__DirectiveLocation!]!
+            }
 
-"""
-A Directive can be adjacent to many parts of the GraphQL language, a
-__DirectiveLocation describes one such possible adjacencies.
-"""
-enum __DirectiveLocation {
-  """Location adjacent to a query operation."""
-  QUERY
+            """
+            A Directive can be adjacent to many parts of the GraphQL language, a
+            __DirectiveLocation describes one such possible adjacencies.
+            """
+            enum __DirectiveLocation {
+              """Location adjacent to a query operation."""
+              QUERY
 
-  """Location adjacent to a mutation operation."""
-  MUTATION
+              """Location adjacent to a mutation operation."""
+              MUTATION
 
-  """Location adjacent to a subscription operation."""
-  SUBSCRIPTION
+              """Location adjacent to a subscription operation."""
+              SUBSCRIPTION
 
-  """Location adjacent to a field."""
-  FIELD
+              """Location adjacent to a field."""
+              FIELD
 
-  """Location adjacent to a fragment definition."""
-  FRAGMENT_DEFINITION
+              """Location adjacent to a fragment definition."""
+              FRAGMENT_DEFINITION
 
-  """Location adjacent to a fragment spread."""
-  FRAGMENT_SPREAD
+              """Location adjacent to a fragment spread."""
+              FRAGMENT_SPREAD
 
-  """Location adjacent to an inline fragment."""
-  INLINE_FRAGMENT
+              """Location adjacent to an inline fragment."""
+              INLINE_FRAGMENT
 
-  """Location adjacent to a variable definition."""
-  VARIABLE_DEFINITION
+              """Location adjacent to a variable definition."""
+              VARIABLE_DEFINITION
 
-  """Location adjacent to a schema definition."""
-  SCHEMA
+              """Location adjacent to a schema definition."""
+              SCHEMA
 
-  """Location adjacent to a scalar definition."""
-  SCALAR
+              """Location adjacent to a scalar definition."""
+              SCALAR
 
-  """Location adjacent to an object type definition."""
-  OBJECT
+              """Location adjacent to an object type definition."""
+              OBJECT
 
-  """Location adjacent to a field definition."""
-  FIELD_DEFINITION
+              """Location adjacent to a field definition."""
+              FIELD_DEFINITION
 
-  """Location adjacent to an argument definition."""
-  ARGUMENT_DEFINITION
+              """Location adjacent to an argument definition."""
+              ARGUMENT_DEFINITION
 
-  """Location adjacent to an interface definition."""
-  INTERFACE
+              """Location adjacent to an interface definition."""
+              INTERFACE
 
-  """Location adjacent to a union definition."""
-  UNION
+              """Location adjacent to a union definition."""
+              UNION
 
-  """Location adjacent to an enum definition."""
-  ENUM
+              """Location adjacent to an enum definition."""
+              ENUM
 
-  """Location adjacent to an enum value definition."""
-  ENUM_VALUE
+              """Location adjacent to an enum value definition."""
+              ENUM_VALUE
 
-  """Location adjacent to an input object type definition."""
-  INPUT_OBJECT
+              """Location adjacent to an input object type definition."""
+              INPUT_OBJECT
 
-  """Location adjacent to an input object field definition."""
-  INPUT_FIELD_DEFINITION
-}
+              """Location adjacent to an input object field definition."""
+              INPUT_FIELD_DEFINITION
+            }
 
-"""
-One possible value for a given Enum. Enum values are unique values, not a
-placeholder for a string or numeric value. However an Enum value is returned in
-a JSON response as a string.
-"""
-type __EnumValue {
-  name: String!
-  description: String
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            """
+            One possible value for a given Enum. Enum values are unique values, not a
+            placeholder for a string or numeric value. However an Enum value is returned in
+            a JSON response as a string.
+            """
+            type __EnumValue {
+              name: String!
+              description: String
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-"""
-Object and Interface types are described by a list of Fields, each of which has
-a name, potentially a list of arguments, and a return type.
-"""
-type __Field {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  type: __Type!
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            """
+            Object and Interface types are described by a list of Fields, each of which has
+            a name, potentially a list of arguments, and a return type.
+            """
+            type __Field {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              type: __Type!
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-"""
-Arguments provided to Fields or Directives and the input fields of an
-InputObject are represented as Input Values which describe their type and
-optionally a default value.
-"""
-type __InputValue {
-  name: String!
-  description: String
-  type: __Type!
+            """
+            Arguments provided to Fields or Directives and the input fields of an
+            InputObject are represented as Input Values which describe their type and
+            optionally a default value.
+            """
+            type __InputValue {
+              name: String!
+              description: String
+              type: __Type!
 
-  """
-  A GraphQL-formatted string representing the default value for this input value.
-  """
-  defaultValue: String
-}
+              """
+              A GraphQL-formatted string representing the default value for this input value.
+              """
+              defaultValue: String
+            }
 
-"""
-A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-available types and directives on the server, as well as the entry points for
-query, mutation, and subscription operations.
-"""
-type __Schema {
-  """A list of all types supported by this server."""
-  types: [__Type!]!
+            """
+            A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+            available types and directives on the server, as well as the entry points for
+            query, mutation, and subscription operations.
+            """
+            type __Schema {
+              """A list of all types supported by this server."""
+              types: [__Type!]!
 
-  """The type that query operations will be rooted at."""
-  queryType: __Type!
+              """The type that query operations will be rooted at."""
+              queryType: __Type!
 
-  """
-  If this server supports mutation, the type that mutation operations will be rooted at.
-  """
-  mutationType: __Type
+              """
+              If this server supports mutation, the type that mutation operations will be rooted at.
+              """
+              mutationType: __Type
 
-  """
-  If this server support subscription, the type that subscription operations will be rooted at.
-  """
-  subscriptionType: __Type
+              """
+              If this server support subscription, the type that subscription operations will be rooted at.
+              """
+              subscriptionType: __Type
 
-  """A list of all directives supported by this server."""
-  directives: [__Directive!]!
-}
+              """A list of all directives supported by this server."""
+              directives: [__Directive!]!
+            }
 
-"""
-The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-types in GraphQL as represented by the `__TypeKind` enum.
+            """
+            The fundamental unit of any GraphQL Schema is the type. There are many kinds of
+            types in GraphQL as represented by the `__TypeKind` enum.
 
-Depending on the kind of a type, certain fields describe information about that
-type. Scalar types provide no information beyond a name and description, while
-Enum types provide their values. Object and Interface types provide the fields
-they describe. Abstract types, Union and Interface, provide the Object types
-possible at runtime. List and NonNull types compose other types.
-"""
-type __Type {
-  kind: __TypeKind!
-  name: String
-  description: String
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  interfaces: [__Type!]
-  possibleTypes: [__Type!]
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  inputFields: [__InputValue!]
-  ofType: __Type
-}
+            Depending on the kind of a type, certain fields describe information about that
+            type. Scalar types provide no information beyond a name and description, while
+            Enum types provide their values. Object and Interface types provide the fields
+            they describe. Abstract types, Union and Interface, provide the Object types
+            possible at runtime. List and NonNull types compose other types.
+            """
+            type __Type {
+              kind: __TypeKind!
+              name: String
+              description: String
+              fields(includeDeprecated: Boolean = false): [__Field!]
+              interfaces: [__Type!]
+              possibleTypes: [__Type!]
+              enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+              inputFields: [__InputValue!]
+              ofType: __Type
+            }
 
-"""An enum describing what kind of type a given `__Type` is."""
-enum __TypeKind {
-  """Indicates this type is a scalar."""
-  SCALAR
+            """An enum describing what kind of type a given `__Type` is."""
+            enum __TypeKind {
+              """Indicates this type is a scalar."""
+              SCALAR
 
-  """
-  Indicates this type is an object. `fields` and `interfaces` are valid fields.
-  """
-  OBJECT
+              """
+              Indicates this type is an object. `fields` and `interfaces` are valid fields.
+              """
+              OBJECT
 
-  """
-  Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
-  """
-  INTERFACE
+              """
+              Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
+              """
+              INTERFACE
 
-  """Indicates this type is a union. `possibleTypes` is a valid field."""
-  UNION
+              """Indicates this type is a union. `possibleTypes` is a valid field."""
+              UNION
 
-  """Indicates this type is an enum. `enumValues` is a valid field."""
-  ENUM
+              """Indicates this type is an enum. `enumValues` is a valid field."""
+              ENUM
 
-  """
-  Indicates this type is an input object. `inputFields` is a valid field.
-  """
-  INPUT_OBJECT
+              """
+              Indicates this type is an input object. `inputFields` is a valid field.
+              """
+              INPUT_OBJECT
 
-  """Indicates this type is a list. `ofType` is a valid field."""
-  LIST
+              """Indicates this type is a list. `ofType` is a valid field."""
+              LIST
 
-  """Indicates this type is a non-null. `ofType` is a valid field."""
-  NON_NULL
-}
+              """Indicates this type is a non-null. `ofType` is a valid field."""
+              NON_NULL
+            }
 
-EOT;
+            GQL;
         self::assertEquals($introspectionSchema, $output);
     }
 
@@ -1206,203 +1234,203 @@ EOT;
             $schema,
             ['commentDescriptions' => true]
         );
-        $introspectionSchema = <<<'EOT'
-# Directs the executor to include this field or fragment only when the `if` argument is true.
-directive @include(
-  # Included when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        $introspectionSchema = <<<'GQL'
+            # Directs the executor to include this field or fragment only when the `if` argument is true.
+            directive @include(
+              # Included when true.
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Directs the executor to skip this field or fragment when the `if` argument is true.
-directive @skip(
-  # Skipped when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            # Directs the executor to skip this field or fragment when the `if` argument is true.
+            directive @skip(
+              # Skipped when true.
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Marks an element of a GraphQL schema as no longer supported.
-directive @deprecated(
-  # Explains why this element was deprecated, usually also including a suggestion
-  # for how to access supported similar data. Formatted using the Markdown syntax
-  # (as specified by [CommonMark](https://commonmark.org/).
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+            # Marks an element of a GraphQL schema as no longer supported.
+            directive @deprecated(
+              # Explains why this element was deprecated, usually also including a suggestion
+              # for how to access supported similar data. Formatted using the Markdown syntax
+              # (as specified by [CommonMark](https://commonmark.org/).
+              reason: String = "No longer supported"
+            ) on FIELD_DEFINITION | ENUM_VALUE
 
-# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
-#
-# In some cases, you need to provide options to alter GraphQL's execution behavior
-# in ways field arguments will not suffice, such as conditionally including or
-# skipping a field. Directives provide this by describing additional information
-# to the executor.
-type __Directive {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  isRepeatable: Boolean!
-  locations: [__DirectiveLocation!]!
-}
+            # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+            #
+            # In some cases, you need to provide options to alter GraphQL's execution behavior
+            # in ways field arguments will not suffice, such as conditionally including or
+            # skipping a field. Directives provide this by describing additional information
+            # to the executor.
+            type __Directive {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              isRepeatable: Boolean!
+              locations: [__DirectiveLocation!]!
+            }
 
-# A Directive can be adjacent to many parts of the GraphQL language, a
-# __DirectiveLocation describes one such possible adjacencies.
-enum __DirectiveLocation {
-  # Location adjacent to a query operation.
-  QUERY
+            # A Directive can be adjacent to many parts of the GraphQL language, a
+            # __DirectiveLocation describes one such possible adjacencies.
+            enum __DirectiveLocation {
+              # Location adjacent to a query operation.
+              QUERY
 
-  # Location adjacent to a mutation operation.
-  MUTATION
+              # Location adjacent to a mutation operation.
+              MUTATION
 
-  # Location adjacent to a subscription operation.
-  SUBSCRIPTION
+              # Location adjacent to a subscription operation.
+              SUBSCRIPTION
 
-  # Location adjacent to a field.
-  FIELD
+              # Location adjacent to a field.
+              FIELD
 
-  # Location adjacent to a fragment definition.
-  FRAGMENT_DEFINITION
+              # Location adjacent to a fragment definition.
+              FRAGMENT_DEFINITION
 
-  # Location adjacent to a fragment spread.
-  FRAGMENT_SPREAD
+              # Location adjacent to a fragment spread.
+              FRAGMENT_SPREAD
 
-  # Location adjacent to an inline fragment.
-  INLINE_FRAGMENT
+              # Location adjacent to an inline fragment.
+              INLINE_FRAGMENT
 
-  # Location adjacent to a variable definition.
-  VARIABLE_DEFINITION
+              # Location adjacent to a variable definition.
+              VARIABLE_DEFINITION
 
-  # Location adjacent to a schema definition.
-  SCHEMA
+              # Location adjacent to a schema definition.
+              SCHEMA
 
-  # Location adjacent to a scalar definition.
-  SCALAR
+              # Location adjacent to a scalar definition.
+              SCALAR
 
-  # Location adjacent to an object type definition.
-  OBJECT
+              # Location adjacent to an object type definition.
+              OBJECT
 
-  # Location adjacent to a field definition.
-  FIELD_DEFINITION
+              # Location adjacent to a field definition.
+              FIELD_DEFINITION
 
-  # Location adjacent to an argument definition.
-  ARGUMENT_DEFINITION
+              # Location adjacent to an argument definition.
+              ARGUMENT_DEFINITION
 
-  # Location adjacent to an interface definition.
-  INTERFACE
+              # Location adjacent to an interface definition.
+              INTERFACE
 
-  # Location adjacent to a union definition.
-  UNION
+              # Location adjacent to a union definition.
+              UNION
 
-  # Location adjacent to an enum definition.
-  ENUM
+              # Location adjacent to an enum definition.
+              ENUM
 
-  # Location adjacent to an enum value definition.
-  ENUM_VALUE
+              # Location adjacent to an enum value definition.
+              ENUM_VALUE
 
-  # Location adjacent to an input object type definition.
-  INPUT_OBJECT
+              # Location adjacent to an input object type definition.
+              INPUT_OBJECT
 
-  # Location adjacent to an input object field definition.
-  INPUT_FIELD_DEFINITION
-}
+              # Location adjacent to an input object field definition.
+              INPUT_FIELD_DEFINITION
+            }
 
-# One possible value for a given Enum. Enum values are unique values, not a
-# placeholder for a string or numeric value. However an Enum value is returned in
-# a JSON response as a string.
-type __EnumValue {
-  name: String!
-  description: String
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            # One possible value for a given Enum. Enum values are unique values, not a
+            # placeholder for a string or numeric value. However an Enum value is returned in
+            # a JSON response as a string.
+            type __EnumValue {
+              name: String!
+              description: String
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-# Object and Interface types are described by a list of Fields, each of which has
-# a name, potentially a list of arguments, and a return type.
-type __Field {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  type: __Type!
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            # Object and Interface types are described by a list of Fields, each of which has
+            # a name, potentially a list of arguments, and a return type.
+            type __Field {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              type: __Type!
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-# Arguments provided to Fields or Directives and the input fields of an
-# InputObject are represented as Input Values which describe their type and
-# optionally a default value.
-type __InputValue {
-  name: String!
-  description: String
-  type: __Type!
+            # Arguments provided to Fields or Directives and the input fields of an
+            # InputObject are represented as Input Values which describe their type and
+            # optionally a default value.
+            type __InputValue {
+              name: String!
+              description: String
+              type: __Type!
 
-  # A GraphQL-formatted string representing the default value for this input value.
-  defaultValue: String
-}
+              # A GraphQL-formatted string representing the default value for this input value.
+              defaultValue: String
+            }
 
-# A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-# available types and directives on the server, as well as the entry points for
-# query, mutation, and subscription operations.
-type __Schema {
-  # A list of all types supported by this server.
-  types: [__Type!]!
+            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+            # available types and directives on the server, as well as the entry points for
+            # query, mutation, and subscription operations.
+            type __Schema {
+              # A list of all types supported by this server.
+              types: [__Type!]!
 
-  # The type that query operations will be rooted at.
-  queryType: __Type!
+              # The type that query operations will be rooted at.
+              queryType: __Type!
 
-  # If this server supports mutation, the type that mutation operations will be rooted at.
-  mutationType: __Type
+              # If this server supports mutation, the type that mutation operations will be rooted at.
+              mutationType: __Type
 
-  # If this server support subscription, the type that subscription operations will be rooted at.
-  subscriptionType: __Type
+              # If this server support subscription, the type that subscription operations will be rooted at.
+              subscriptionType: __Type
 
-  # A list of all directives supported by this server.
-  directives: [__Directive!]!
-}
+              # A list of all directives supported by this server.
+              directives: [__Directive!]!
+            }
 
-# The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-# types in GraphQL as represented by the `__TypeKind` enum.
-#
-# Depending on the kind of a type, certain fields describe information about that
-# type. Scalar types provide no information beyond a name and description, while
-# Enum types provide their values. Object and Interface types provide the fields
-# they describe. Abstract types, Union and Interface, provide the Object types
-# possible at runtime. List and NonNull types compose other types.
-type __Type {
-  kind: __TypeKind!
-  name: String
-  description: String
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  interfaces: [__Type!]
-  possibleTypes: [__Type!]
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  inputFields: [__InputValue!]
-  ofType: __Type
-}
+            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
+            # types in GraphQL as represented by the `__TypeKind` enum.
+            #
+            # Depending on the kind of a type, certain fields describe information about that
+            # type. Scalar types provide no information beyond a name and description, while
+            # Enum types provide their values. Object and Interface types provide the fields
+            # they describe. Abstract types, Union and Interface, provide the Object types
+            # possible at runtime. List and NonNull types compose other types.
+            type __Type {
+              kind: __TypeKind!
+              name: String
+              description: String
+              fields(includeDeprecated: Boolean = false): [__Field!]
+              interfaces: [__Type!]
+              possibleTypes: [__Type!]
+              enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+              inputFields: [__InputValue!]
+              ofType: __Type
+            }
 
-# An enum describing what kind of type a given `__Type` is.
-enum __TypeKind {
-  # Indicates this type is a scalar.
-  SCALAR
+            # An enum describing what kind of type a given `__Type` is.
+            enum __TypeKind {
+              # Indicates this type is a scalar.
+              SCALAR
 
-  # Indicates this type is an object. `fields` and `interfaces` are valid fields.
-  OBJECT
+              # Indicates this type is an object. `fields` and `interfaces` are valid fields.
+              OBJECT
 
-  # Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
-  INTERFACE
+              # Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
+              INTERFACE
 
-  # Indicates this type is a union. `possibleTypes` is a valid field.
-  UNION
+              # Indicates this type is a union. `possibleTypes` is a valid field.
+              UNION
 
-  # Indicates this type is an enum. `enumValues` is a valid field.
-  ENUM
+              # Indicates this type is an enum. `enumValues` is a valid field.
+              ENUM
 
-  # Indicates this type is an input object. `inputFields` is a valid field.
-  INPUT_OBJECT
+              # Indicates this type is an input object. `inputFields` is a valid field.
+              INPUT_OBJECT
 
-  # Indicates this type is a list. `ofType` is a valid field.
-  LIST
+              # Indicates this type is a list. `ofType` is a valid field.
+              LIST
 
-  # Indicates this type is a non-null. `ofType` is a valid field.
-  NON_NULL
-}
+              # Indicates this type is a non-null. `ofType` is a valid field.
+              NON_NULL
+            }
 
-EOT;
+            GQL;
         self::assertEquals($introspectionSchema, $output);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -764,6 +764,40 @@ enum RGB {
     }
 
     /**
+     * @see it('Prints empty types')
+     */
+    public function testPrintsEmptyTypes(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new EnumType(['name' => 'SomeEnum', 'values' => []]),
+                new InputObjectType(['name' => 'SomeInputObject', 'fields' => []]),
+                new InterfaceType(['name' => 'SomeInterface', 'fields' => []]),
+                new ObjectType(['name' => 'SomeObject', 'fields' => []]),
+                new UnionType(['name' => 'SomeUnion', 'types' => []]),
+            ],
+        ]);
+
+        $output = $this->printForTest($schema);
+        self::assertEquals(
+            <<<'GQL'
+
+            enum SomeEnum
+
+            input SomeInputObject
+
+            interface SomeInterface
+
+            type SomeObject
+
+            union SomeUnion
+
+            GQL,
+            $output
+        );
+    }
+
+    /**
      * @see it('Prints custom directives')
      */
     public function testPrintsCustomDirectives(): void

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -52,12 +52,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::string(),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -71,12 +71,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::listOf(Type::string()),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String]
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -90,12 +90,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::string()),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: String!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -109,12 +109,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String]!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -128,12 +128,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String!]
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -147,12 +147,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String!]!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -169,12 +169,12 @@ class SchemaPrinterTest extends TestCase
             'deprecationReason' => $deprecationReason,
         ]);
         self::assertPrintedSchemaEquals(
-            <<<GQL
+            <<<GRAPHQL
             type Query {
               singleField: Int$expectedDeprecationDirective
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -214,12 +214,12 @@ class SchemaPrinterTest extends TestCase
         $schema  = new Schema(['types' => [$fooType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Foo {
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -234,12 +234,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -254,12 +254,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = 2): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -274,12 +274,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: String = "tes\t de\fault"): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -294,12 +294,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = null): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -314,12 +314,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int!): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -337,12 +337,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -361,12 +361,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -385,12 +385,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -409,12 +409,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -428,14 +428,14 @@ class SchemaPrinterTest extends TestCase
             'query' => new ObjectType(['name' => 'CustomType', 'fields' => []]),
         ]);
 
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             schema {
               query: CustomType
             }
 
             type CustomType
 
-            GQL;
+            GRAPHQL;
         self::assertPrintedSchemaEquals($expected, $schema);
     }
 
@@ -449,14 +449,14 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             schema {
               mutation: CustomType
             }
 
             type CustomType
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -471,14 +471,14 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             schema {
               subscription: CustomType
             }
 
             type CustomType
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -502,7 +502,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$barType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Bar implements Foo {
               str: String
             }
@@ -511,7 +511,7 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -543,7 +543,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$barType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             interface Baaz {
               int: Int
             }
@@ -557,7 +557,7 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -601,7 +601,7 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             interface Baaz implements Foo {
               int: Int
               str: String
@@ -620,7 +620,7 @@ class SchemaPrinterTest extends TestCase
               bar: Bar
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -653,7 +653,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$singleUnion, $multipleUnion]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Bar {
               str: String
             }
@@ -666,7 +666,7 @@ class SchemaPrinterTest extends TestCase
 
             union SingleUnion = Foo
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -684,12 +684,12 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$inputType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             input InputType {
               int: Int
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -704,10 +704,10 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$oddType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             scalar Odd
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -729,14 +729,14 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$RGBType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             enum RGB {
               RED
               GREEN
               BLUE
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -757,7 +757,7 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             enum SomeEnum
 
             input SomeInputObject
@@ -768,7 +768,7 @@ class SchemaPrinterTest extends TestCase
 
             union SomeUnion
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -802,13 +802,13 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             directive @simpleDirective on FIELD
 
             """Complex Directive"""
             directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -825,13 +825,13 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               """This field is awesome"""
               singleField: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -843,7 +843,7 @@ class SchemaPrinterTest extends TestCase
     {
         $schema   = new Schema([]);
         $output   = SchemaPrinter::printIntrospectionSchema($schema);
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             """
             Directs the executor to include this field or fragment only when the `if` argument is true.
             """
@@ -1071,7 +1071,7 @@ class SchemaPrinterTest extends TestCase
               NON_NULL
             }
 
-            GQL;
+            GRAPHQL;
         self::assertEquals($expected, $output);
     }
 
@@ -1085,7 +1085,7 @@ class SchemaPrinterTest extends TestCase
             $schema,
             ['commentDescriptions' => true]
         );
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             # Directs the executor to include this field or fragment only when the `if` argument is true.
             directive @include(
               # Included when true.
@@ -1281,7 +1281,7 @@ class SchemaPrinterTest extends TestCase
               NON_NULL
             }
 
-            GQL;
+            GRAPHQL;
         self::assertEquals($expected, $output);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -21,23 +21,22 @@ use PHPUnit\Framework\TestCase;
 
 class SchemaPrinterTest extends TestCase
 {
-    /** @param array<string, mixed> $fieldConfig */
-    private function printSingleFieldSchema(array $fieldConfig): string
-    {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['singleField' => $fieldConfig],
-        ]);
-
-        return $this->printForTest(new Schema(['query' => $query]));
-    }
-
-    private function printForTest(Schema $schema): string
+    private static function assertPrintedSchemaEquals(string $expected, Schema $schema): void
     {
         $schemaText = SchemaPrinter::doPrint($schema);
         self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
+        self::assertEquals($expected, $schemaText);
+    }
 
-        return $schemaText;
+    /** @param array<string, mixed> $fieldConfig */
+    private function buildSingleFieldSchema(array $fieldConfig): Schema
+    {
+        $query = new ObjectType([
+            'name' => 'Query',
+            'fields' => ['singleField' => $fieldConfig],
+        ]);
+
+        return new Schema(['query' => $query]);
     }
 
     // Describe: Type System Printer
@@ -47,17 +46,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -66,17 +65,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintArrayStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::listOf(Type::string()),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: [String]
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -85,17 +84,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintNonNullStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::nonNull(Type::string()),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: String!
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -104,17 +103,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintNonNullArrayStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: [String]!
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -123,17 +122,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintArrayNonNullStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: [String!]
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -142,17 +141,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintNonNullArrayNonNullStringField(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField: [String!]!
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -163,18 +162,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintDeprecatedField(?string $deprecationReason, string $expectedDeprecationDirective): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::int(),
             'deprecationReason' => $deprecationReason,
         ]);
-        self::assertSame(
+        self::assertPrintedSchemaEquals(
             <<<GQL
             type Query {
               singleField: Int$expectedDeprecationDirective
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -210,26 +209,16 @@ class SchemaPrinterTest extends TestCase
             'name'   => 'Foo',
             'fields' => ['str' => ['type' => Type::string()]],
         ]);
+        $schema  = new Schema(['types' => [$fooType]]);
 
-        $root = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['foo' => ['type' => $fooType]],
-        ]);
-
-        $schema = new Schema(['query' => $root]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Foo {
               str: String
             }
 
-            type Query {
-              foo: Foo
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -238,18 +227,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithIntArg(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -258,18 +247,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithIntArgWithDefault(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int = 2): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -278,18 +267,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithStringArgWithDefault(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: String = "tes\t de\fault"): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -298,18 +287,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithIntArgWithDefaultNull(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int = null): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -318,18 +307,18 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithNonNullIntArg(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int!): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -338,21 +327,21 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithMultipleArgs(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => [
                 'argOne' => ['type' => Type::int()],
                 'argTwo' => ['type' => Type::string()],
             ],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int, argTwo: String): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -361,7 +350,7 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithMultipleArgsFirstIsDefault(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => [
                 'argOne'   => ['type' => Type::int(), 'defaultValue' => 1],
@@ -369,14 +358,14 @@ class SchemaPrinterTest extends TestCase
                 'argThree' => ['type' => Type::boolean()],
             ],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -385,7 +374,7 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithMultipleArgsSecondIsDefault(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => [
                 'argOne'   => ['type' => Type::int()],
@@ -393,14 +382,14 @@ class SchemaPrinterTest extends TestCase
                 'argThree' => ['type' => Type::boolean()],
             ],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -409,7 +398,7 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsStringFieldWithMultipleArgsLastIsDefault(): void
     {
-        $output = $this->printSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type' => Type::string(),
             'args' => [
                 'argOne'   => ['type' => Type::int()],
@@ -417,40 +406,79 @@ class SchemaPrinterTest extends TestCase
                 'argThree' => ['type' => Type::boolean(), 'defaultValue' => false],
             ],
         ]);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
     /**
-     * @see it('Prints custom query root type')
+     * @see it('Prints custom query root types')
      */
-    public function testPrintsCustomQueryRootType(): void
+    public function testPrintsCustomQueryRootTypes(): void
     {
-        $customQueryType = new ObjectType([
-            'name'   => 'CustomQueryType',
-            'fields' => ['bar' => ['type' => Type::string()]],
+        $schema = new Schema([
+            'query' => new ObjectType(['name' => 'CustomType', 'fields' => []]),
         ]);
 
-        $schema   = new Schema(['query' => $customQueryType]);
-        $output   = $this->printForTest($schema);
         $expected = <<<'GQL'
             schema {
-              query: CustomQueryType
+              query: CustomType
             }
 
-            type CustomQueryType {
-              bar: String
-            }
+            type CustomType
 
             GQL;
-        self::assertEquals($expected, $output);
+        self::assertPrintedSchemaEquals($expected, $schema);
+    }
+
+    /**
+     * @see it('Prints custom mutation root types')
+     */
+    public function testPrintsCustomMutationRootTypes(): void
+    {
+        $schema = new Schema([
+            'mutation' => new ObjectType(['name' => 'CustomType', 'fields' => []]),
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GQL'
+            schema {
+              mutation: CustomType
+            }
+
+            type CustomType
+
+            GQL,
+            $schema
+        );
+    }
+
+    /**
+     * @see it('Prints custom subscription root types')
+     */
+    public function testPrintsCustomSubscriptionRootTypes(): void
+    {
+        $schema = new Schema([
+            'subscription' => new ObjectType(['name' => 'CustomType', 'fields' => []]),
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GQL'
+            schema {
+              subscription: CustomType
+            }
+
+            type CustomType
+
+            GQL,
+            $schema
+        );
     }
 
     /**
@@ -469,17 +497,9 @@ class SchemaPrinterTest extends TestCase
             'interfaces' => [$fooType],
         ]);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['bar' => ['type' => $barType]],
-        ]);
+        $schema = new Schema(['types' => [$barType]]);
 
-        $schema = new Schema([
-            'query' => $query,
-            'types' => [$barType],
-        ]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Bar implements Foo {
               str: String
@@ -489,12 +509,8 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            type Query {
-              bar: Bar
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -522,17 +538,9 @@ class SchemaPrinterTest extends TestCase
             'interfaces' => [$fooType, $baazType],
         ]);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['bar' => ['type' => $barType]],
-        ]);
+        $schema = new Schema(['types' => [$barType]]);
 
-        $schema = new Schema([
-            'query' => $query,
-            'types' => [$barType],
-        ]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             interface Baaz {
               int: Int
@@ -547,12 +555,8 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            type Query {
-              bar: Bar
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -593,8 +597,8 @@ class SchemaPrinterTest extends TestCase
             'query' => $query,
             'types' => [$BarType],
         ]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             interface Baaz implements Foo {
               int: Int
@@ -615,7 +619,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -644,17 +648,9 @@ class SchemaPrinterTest extends TestCase
             'types' => [$fooType, $barType],
         ]);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'single'   => ['type' => $singleUnion],
-                'multiple' => ['type' => $multipleUnion],
-            ],
-        ]);
+        $schema = new Schema(['types' => [$singleUnion, $multipleUnion]]);
 
-        $schema = new Schema(['query' => $query]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Bar {
               str: String
@@ -666,15 +662,10 @@ class SchemaPrinterTest extends TestCase
 
             union MultipleUnion = Foo | Bar
 
-            type Query {
-              single: SingleUnion
-              multiple: MultipleUnion
-            }
-
             union SingleUnion = Foo
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -688,30 +679,16 @@ class SchemaPrinterTest extends TestCase
             'fields' => ['int' => ['type' => Type::int()]],
         ]);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'str' => [
-                    'type' => Type::string(),
-                    'args' => ['argOne' => ['type' => $inputType]],
-                ],
-            ],
-        ]);
+        $schema = new Schema(['types' => [$inputType]]);
 
-        $schema = new Schema(['query' => $query]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             input InputType {
               int: Int
             }
 
-            type Query {
-              str(argOne: InputType): String
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -720,32 +697,16 @@ class SchemaPrinterTest extends TestCase
      */
     public function testCustomScalar(): void
     {
-        $oddType = new CustomScalarType([
-            'name'      => 'Odd',
-            'serialize' => static function ($value) {
-                return $value % 2 === 1 ? $value : null;
-            },
-        ]);
+        $oddType = new CustomScalarType(['name' => 'Odd']);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'odd' => ['type' => $oddType],
-            ],
-        ]);
+        $schema = new Schema(['types' => [$oddType]]);
 
-        $schema = new Schema(['query' => $query]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             scalar Odd
 
-            type Query {
-              odd: Odd
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -757,27 +718,16 @@ class SchemaPrinterTest extends TestCase
         $RGBType = new EnumType([
             'name'   => 'RGB',
             'values' => [
-                'RED'   => ['value' => 0],
-                'GREEN' => ['value' => 1],
-                'BLUE'  => ['value' => 2],
+                'RED'   => [],
+                'GREEN' => [],
+                'BLUE'  => [],
             ],
         ]);
 
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'rgb' => ['type' => $RGBType],
-            ],
-        ]);
+        $schema = new Schema(['types' => [$RGBType]]);
 
-        $schema = new Schema(['query' => $query]);
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
-            type Query {
-              rgb: RGB
-            }
-
             enum RGB {
               RED
               GREEN
@@ -785,7 +735,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -804,8 +754,7 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
 
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             enum SomeEnum
 
@@ -818,7 +767,7 @@ class SchemaPrinterTest extends TestCase
             union SomeUnion
 
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -827,33 +776,17 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintsCustomDirectives(): void
     {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'field' => [
-                    'type' => Type::string(),
-                ],
-            ],
-        ]);
-
         $simpleDirective = new Directive([
             'name'      => 'simpleDirective',
-            'locations' => [
-                DirectiveLocation::FIELD,
-            ],
+            'locations' => [DirectiveLocation::FIELD],
         ]);
 
         $complexDirective = new Directive([
             'name'      => 'complexDirective',
             'description' => 'Complex Directive',
             'args' => [
-                'stringArg' => [
-                    'type' => Type::string(),
-                ],
-                'intArg' => [
-                    'type' => Type::int(),
-                    'defaultValue' => -1,
-                ],
+                'stringArg' => ['type' => Type::string()],
+                'intArg' => ['type' => Type::int(), 'defaultValue' => -1],
             ],
             'isRepeatable' => true,
             'locations' => [
@@ -863,24 +796,18 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         $schema = new Schema([
-            'query'      => $query,
             'directives' => [$simpleDirective, $complexDirective],
         ]);
 
-        $output = $this->printForTest($schema);
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             directive @simpleDirective on FIELD
 
             """Complex Directive"""
             directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
-            type Query {
-              field: String
-            }
-
             GQL,
-            $output
+            $schema
         );
     }
 
@@ -890,12 +817,12 @@ class SchemaPrinterTest extends TestCase
     public function testOneLinePrintsAShortDescription(): void
     {
         $description = 'This field is awesome';
-        $output      = $this->printSingleFieldSchema([
+        $schema      = $this->buildSingleFieldSchema([
             'type'        => Type::string(),
             'description' => $description,
         ]);
 
-        self::assertEquals(
+        self::assertPrintedSchemaEquals(
             <<<'GQL'
             type Query {
               """This field is awesome"""
@@ -903,72 +830,8 @@ class SchemaPrinterTest extends TestCase
             }
 
             GQL,
-            $output
+            $schema
         );
-
-        /** @var ObjectType $recreatedRoot */
-        $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
-        $recreatedField = $recreatedRoot->getFields()['singleField'];
-        self::assertEquals($description, $recreatedField->description);
-    }
-
-    /**
-     * @see it('Does not one-line print a description that ends with a quote')
-     */
-    public function testDoesNotOneLinePrintADescriptionThatEndsWithAQuote(): void
-    {
-        $description = 'This field is "awesome"';
-        $output      = $this->printSingleFieldSchema([
-            'type'        => Type::string(),
-            'description' => $description,
-        ]);
-
-        self::assertEquals(
-            <<<'GQL'
-            type Query {
-              """
-              This field is "awesome"
-              """
-              singleField: String
-            }
-
-            GQL,
-            $output
-        );
-
-        /** @var ObjectType $recreatedRoot */
-        $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
-        $recreatedField = $recreatedRoot->getFields()['singleField'];
-        self::assertEquals($description, $recreatedField->description);
-    }
-
-    /**
-     * @see it('Preserves leading spaces when printing a description')
-     */
-    public function testPreservesLeadingSpacesWhenPrintingADescription(): void
-    {
-        $description = '    This field is "awesome"';
-        $output      = $this->printSingleFieldSchema([
-            'type'        => Type::string(),
-            'description' => $description,
-        ]);
-
-        self::assertEquals(
-            <<<'GQL'
-            type Query {
-              """    This field is "awesome"
-              """
-              singleField: String
-            }
-
-            GQL,
-            $output
-        );
-
-        /** @var ObjectType $recreatedRoot */
-        $recreatedRoot  = BuildSchema::build($output)->getTypeMap()['Query'];
-        $recreatedField = $recreatedRoot->getFields()['singleField'];
-        self::assertEquals($description, $recreatedField->description);
     }
 
     /**
@@ -976,16 +839,9 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintIntrospectionSchema(): void
     {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'onlyField' => ['type' => Type::string()],
-            ],
-        ]);
-
-        $schema              = new Schema(['query' => $query]);
-        $output              = SchemaPrinter::printIntrospectionSchema($schema);
-        $introspectionSchema = <<<'GQL'
+        $schema   = new Schema([]);
+        $output   = SchemaPrinter::printIntrospectionSchema($schema);
+        $expected = <<<'GQL'
             """
             Directs the executor to include this field or fragment only when the `if` argument is true.
             """
@@ -1214,7 +1070,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             GQL;
-        self::assertEquals($introspectionSchema, $output);
+        self::assertEquals($expected, $output);
     }
 
     /**
@@ -1222,19 +1078,12 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintIntrospectionSchemaWithCommentDescriptions(): void
     {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => [
-                'onlyField' => ['type' => Type::string()],
-            ],
-        ]);
-
-        $schema              = new Schema(['query' => $query]);
-        $output              = SchemaPrinter::printIntrospectionSchema(
+        $schema   = new Schema([]);
+        $output   = SchemaPrinter::printIntrospectionSchema(
             $schema,
             ['commentDescriptions' => true]
         );
-        $introspectionSchema = <<<'GQL'
+        $expected = <<<'GQL'
             # Directs the executor to include this field or fragment only when the `if` argument is true.
             directive @include(
               # Included when true.
@@ -1431,6 +1280,6 @@ class SchemaPrinterTest extends TestCase
             }
 
             GQL;
-        self::assertEquals($introspectionSchema, $output);
+        self::assertEquals($expected, $output);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -863,9 +863,7 @@ class SchemaPrinterTest extends TestCase
             """Marks an element of a GraphQL schema as no longer supported."""
             directive @deprecated(
               """
-              Explains why this element was deprecated, usually also including a suggestion
-              for how to access supported similar data. Formatted using the Markdown syntax
-              (as specified by [CommonMark](https://commonmark.org/).
+              Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).
               """
               reason: String = "No longer supported"
             ) on FIELD_DEFINITION | ENUM_VALUE
@@ -873,10 +871,7 @@ class SchemaPrinterTest extends TestCase
             """
             A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 
-            In some cases, you need to provide options to alter GraphQL's execution behavior
-            in ways field arguments will not suffice, such as conditionally including or
-            skipping a field. Directives provide this by describing additional information
-            to the executor.
+            In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
             """
             type __Directive {
               name: String!
@@ -887,8 +882,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            A Directive can be adjacent to many parts of the GraphQL language, a
-            __DirectiveLocation describes one such possible adjacencies.
+            A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
             """
             enum __DirectiveLocation {
               """Location adjacent to a query operation."""
@@ -950,9 +944,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            One possible value for a given Enum. Enum values are unique values, not a
-            placeholder for a string or numeric value. However an Enum value is returned in
-            a JSON response as a string.
+            One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
             """
             type __EnumValue {
               name: String!
@@ -962,8 +954,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            Object and Interface types are described by a list of Fields, each of which has
-            a name, potentially a list of arguments, and a return type.
+            Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
             """
             type __Field {
               name: String!
@@ -975,9 +966,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            Arguments provided to Fields or Directives and the input fields of an
-            InputObject are represented as Input Values which describe their type and
-            optionally a default value.
+            Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
             """
             type __InputValue {
               name: String!
@@ -991,9 +980,7 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-            available types and directives on the server, as well as the entry points for
-            query, mutation, and subscription operations.
+            A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
             """
             type __Schema {
               """A list of all types supported by this server."""
@@ -1017,14 +1004,9 @@ class SchemaPrinterTest extends TestCase
             }
 
             """
-            The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-            types in GraphQL as represented by the `__TypeKind` enum.
+            The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
 
-            Depending on the kind of a type, certain fields describe information about that
-            type. Scalar types provide no information beyond a name and description, while
-            Enum types provide their values. Object and Interface types provide the fields
-            they describe. Abstract types, Union and Interface, provide the Object types
-            possible at runtime. List and NonNull types compose other types.
+            Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
             """
             type __Type {
               kind: __TypeKind!
@@ -1100,18 +1082,13 @@ class SchemaPrinterTest extends TestCase
 
             # Marks an element of a GraphQL schema as no longer supported.
             directive @deprecated(
-              # Explains why this element was deprecated, usually also including a suggestion
-              # for how to access supported similar data. Formatted using the Markdown syntax
-              # (as specified by [CommonMark](https://commonmark.org/).
+              # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).
               reason: String = "No longer supported"
             ) on FIELD_DEFINITION | ENUM_VALUE
 
             # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
             #
-            # In some cases, you need to provide options to alter GraphQL's execution behavior
-            # in ways field arguments will not suffice, such as conditionally including or
-            # skipping a field. Directives provide this by describing additional information
-            # to the executor.
+            # In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
             type __Directive {
               name: String!
               description: String
@@ -1120,8 +1097,7 @@ class SchemaPrinterTest extends TestCase
               locations: [__DirectiveLocation!]!
             }
 
-            # A Directive can be adjacent to many parts of the GraphQL language, a
-            # __DirectiveLocation describes one such possible adjacencies.
+            # A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
             enum __DirectiveLocation {
               # Location adjacent to a query operation.
               QUERY
@@ -1181,9 +1157,7 @@ class SchemaPrinterTest extends TestCase
               INPUT_FIELD_DEFINITION
             }
 
-            # One possible value for a given Enum. Enum values are unique values, not a
-            # placeholder for a string or numeric value. However an Enum value is returned in
-            # a JSON response as a string.
+            # One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
             type __EnumValue {
               name: String!
               description: String
@@ -1191,8 +1165,7 @@ class SchemaPrinterTest extends TestCase
               deprecationReason: String
             }
 
-            # Object and Interface types are described by a list of Fields, each of which has
-            # a name, potentially a list of arguments, and a return type.
+            # Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
             type __Field {
               name: String!
               description: String
@@ -1202,9 +1175,7 @@ class SchemaPrinterTest extends TestCase
               deprecationReason: String
             }
 
-            # Arguments provided to Fields or Directives and the input fields of an
-            # InputObject are represented as Input Values which describe their type and
-            # optionally a default value.
+            # Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
             type __InputValue {
               name: String!
               description: String
@@ -1214,9 +1185,7 @@ class SchemaPrinterTest extends TestCase
               defaultValue: String
             }
 
-            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-            # available types and directives on the server, as well as the entry points for
-            # query, mutation, and subscription operations.
+            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
             type __Schema {
               # A list of all types supported by this server.
               types: [__Type!]!
@@ -1234,14 +1203,9 @@ class SchemaPrinterTest extends TestCase
               directives: [__Directive!]!
             }
 
-            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-            # types in GraphQL as represented by the `__TypeKind` enum.
+            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
             #
-            # Depending on the kind of a type, certain fields describe information about that
-            # type. Scalar types provide no information beyond a name and description, while
-            # Enum types provide their values. Object and Interface types provide the fields
-            # they describe. Abstract types, Union and Interface, provide the Object types
-            # possible at runtime. List and NonNull types compose other types.
+            # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
             type __Type {
               kind: __TypeKind!
               name: String

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -21,6 +21,25 @@ use PHPUnit\Framework\TestCase;
 
 class SchemaPrinterTest extends TestCase
 {
+    /** @param array<string, mixed> $fieldConfig */
+    private function printSingleFieldSchema(array $fieldConfig): string
+    {
+        $query = new ObjectType([
+            'name'   => 'Query',
+            'fields' => ['singleField' => $fieldConfig],
+        ]);
+
+        return $this->printForTest(new Schema(['query' => $query]));
+    }
+
+    private function printForTest(Schema $schema): string
+    {
+        $schemaText = SchemaPrinter::doPrint($schema);
+        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
+
+        return "\n" . $schemaText;
+    }
+
     // Describe: Type System Printer
 
     /**
@@ -39,24 +58,6 @@ type Query {
 ',
             $output
         );
-    }
-
-    private function printSingleFieldSchema($fieldConfig)
-    {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['singleField' => $fieldConfig],
-        ]);
-
-        return $this->printForTest(new Schema(['query' => $query]));
-    }
-
-    private function printForTest($schema)
-    {
-        $schemaText = SchemaPrinter::doPrint($schema);
-        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
-
-        return "\n" . $schemaText;
     }
 
     /**

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -151,7 +151,7 @@ type Query {
     }
 
     /**
-     * @see it('Prints Field With "@deprecated" Directive')
+     * @see https://github.com/webonyx/graphql-php/pull/631
      *
      * @dataProvider deprecationReasonDataProvider
      */


### PR DESCRIPTION
Aligns `SchemaPrinterTest.php` with `printSchema-test.js` from the reference implementation v15.5 as much as possible.

Relevant changes in `graphql-js`:
- https://github.com/graphql/graphql-js/commit/34b7ced883ff813a1d2d13c5fd58ba8158d69b60
- https://github.com/graphql/graphql-js/commit/4fcef75248a3db75da6080ed889ea2ce26a29928
- https://github.com/graphql/graphql-js/commit/ea089e016f1526fb5b5137b5f8a8739ec17b322c

TBD:
- [ ] different order of printed types (interfaces, unions)
- [ ] outdated introspection
- [ ] schema with description

Depends on #940, conflicts with #938 (shouldn't matter much but probably better merge #938 first) 