### PR TITLE
Fix website to display table of contents correctly

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1,4 +1,4 @@
-# GraphQL\GraphQL
+## GraphQL\GraphQL
 
 This is the primary facade for fulfilling GraphQL operations.
 See [related documentation](executing-queries.md).
@@ -143,7 +143,7 @@ static function getStandardValidationRules(): array
 static function setDefaultFieldResolver(callable $fn): void
 ```
 
-# GraphQL\Type\Definition\Type
+## GraphQL\Type\Definition\Type
 
 Registry of standard GraphQL types
 and a base class for all other types.
@@ -262,7 +262,7 @@ static function isAbstractType($type): bool
 static function getNullableType(GraphQL\Type\Definition\Type $type): GraphQL\Type\Definition\Type
 ```
 
-# GraphQL\Type\Definition\ResolveInfo
+## GraphQL\Type\Definition\ResolveInfo
 
 Structure containing information useful for field resolution process.
 
@@ -403,7 +403,7 @@ public $variableValues;
 function getFieldSelection($depth = 0)
 ```
 
-# GraphQL\Language\DirectiveLocation
+## GraphQL\Language\DirectiveLocation
 
 List of available directive locations
 
@@ -431,7 +431,7 @@ const INPUT_OBJECT = "INPUT_OBJECT";
 const INPUT_FIELD_DEFINITION = "INPUT_FIELD_DEFINITION";
 ```
 
-# GraphQL\Type\SchemaConfig
+## GraphQL\Type\SchemaConfig
 
 Schema configuration class.
 Could be passed directly to schema constructor. List of options accepted by **create** method is
@@ -579,7 +579,7 @@ function getTypeLoader()
 function setTypeLoader(callable $typeLoader)
 ```
 
-# GraphQL\Type\Schema
+## GraphQL\Type\Schema
 
 Schema Definition (see [schema definition docs](schema-definition.md))
 
@@ -780,7 +780,7 @@ function assertValid()
 function validate()
 ```
 
-# GraphQL\Language\Parser
+## GraphQL\Language\Parser
 
 Parses string containing GraphQL query language or [schema definition language](schema-definition-language.md) to Abstract Syntax Tree.
 
@@ -918,7 +918,7 @@ static function parseValue($source, array $options = [])
 static function parseType($source, array $options = [])
 ```
 
-# GraphQL\Language\Printer
+## GraphQL\Language\Printer
 
 Prints AST to string. Capable of printing GraphQL queries and Type definition language.
 Useful for pretty-printing queries or printing back AST for logging, documentation, etc.
@@ -946,7 +946,7 @@ $printed = GraphQL\Language\Printer::doPrint($ast);
 static function doPrint($ast)
 ```
 
-# GraphQL\Language\Visitor
+## GraphQL\Language\Visitor
 
 Utility for efficient AST traversal and modification.
 
@@ -1086,7 +1086,7 @@ static function skipNode()
 static function removeNode()
 ```
 
-# GraphQL\Language\AST\NodeKind
+## GraphQL\Language\AST\NodeKind
 
 **Class Constants:**
 
@@ -1136,7 +1136,7 @@ const DIRECTIVE_DEFINITION = "DirectiveDefinition";
 const SCHEMA_EXTENSION = "SchemaExtension";
 ```
 
-# GraphQL\Executor\Executor
+## GraphQL\Executor\Executor
 
 Implements the "Evaluating requests" section of the GraphQL specification.
 
@@ -1197,7 +1197,7 @@ static function promiseToExecute(
 )
 ```
 
-# GraphQL\Executor\ExecutionResult
+## GraphQL\Executor\ExecutionResult
 
 Returned after [query execution](executing-queries.md).
 Represents both - result of successful execution and of a failed one
@@ -1296,7 +1296,7 @@ function setErrorsHandler(callable $handler)
 function toArray(int $debug = "GraphQL\Error\DebugFlag::NONE"): array
 ```
 
-# GraphQL\Executor\Promise\PromiseAdapter
+## GraphQL\Executor\Promise\PromiseAdapter
 
 Provides a means for integration of async PHP platforms ([related docs](data-fetching.md#async-php))
 
@@ -1399,7 +1399,7 @@ function createRejected($reason)
 function all(array $promisesOrValues)
 ```
 
-# GraphQL\Validator\DocumentValidator
+## GraphQL\Validator\DocumentValidator
 
 Implements the "Validation" section of the spec.
 
@@ -1474,7 +1474,7 @@ static function getRule($name)
 static function addRule(GraphQL\Validator\Rules\ValidationRule $rule)
 ```
 
-# GraphQL\Error\Error
+## GraphQL\Error\Error
 
 Describes an Error found during the parse, validate, or
 execute phases of performing a GraphQL operation. In addition to a message
@@ -1529,7 +1529,7 @@ function getLocations(): array
 function getPath()
 ```
 
-# GraphQL\Error\Warning
+## GraphQL\Error\Warning
 
 Encapsulates warnings produced by the library.
 
@@ -1591,7 +1591,7 @@ static function suppress($suppress = true): void
 static function enable($enable = true): void
 ```
 
-# GraphQL\Error\ClientAware
+## GraphQL\Error\ClientAware
 
 This interface is used for [default error formatting](error-handling.md).
 
@@ -1626,7 +1626,7 @@ function isClientSafe()
 function getCategory()
 ```
 
-# GraphQL\Error\DebugFlag
+## GraphQL\Error\DebugFlag
 
 Collection of flags for [error debugging](error-handling.md#debugging-tools).
 
@@ -1640,7 +1640,7 @@ const RETHROW_INTERNAL_EXCEPTIONS = 4;
 const RETHROW_UNSAFE_EXCEPTIONS = 8;
 ```
 
-# GraphQL\Error\FormattedError
+## GraphQL\Error\FormattedError
 
 This class is used for [default error formatting](error-handling.md).
 It converts PHP exceptions to [spec-compliant errors](https://facebook.github.io/graphql/#sec-Errors)
@@ -1698,7 +1698,7 @@ static function createFromException(
 static function toSafeTrace($error)
 ```
 
-# GraphQL\Server\StandardServer
+## GraphQL\Server\StandardServer
 
 GraphQL server compatible with both: [express-graphql](https://github.com/graphql/express-graphql)
 and [Apollo Server](https://github.com/apollographql/graphql-server).
@@ -1831,7 +1831,7 @@ function executePsrRequest(Psr\Http\Message\RequestInterface $request)
 function getHelper()
 ```
 
-# GraphQL\Server\ServerConfig
+## GraphQL\Server\ServerConfig
 
 Server configuration class.
 Could be passed directly to server constructor. List of options accepted by **create** method is
@@ -1976,7 +1976,7 @@ function setQueryBatching(bool $enableBatching): self
 function setPromiseAdapter(GraphQL\Executor\Promise\PromiseAdapter $promiseAdapter)
 ```
 
-# GraphQL\Server\Helper
+## GraphQL\Server\Helper
 
 Contains functionality that could be re-used by various server implementations
 
@@ -2107,7 +2107,7 @@ function toPsrResponse(
 )
 ```
 
-# GraphQL\Server\OperationParams
+## GraphQL\Server\OperationParams
 
 Structure representing parsed HTTP parameters for GraphQL operation
 
@@ -2188,7 +2188,7 @@ function getOriginalInput($key)
 function isReadOnly()
 ```
 
-# GraphQL\Utils\BuildSchema
+## GraphQL\Utils\BuildSchema
 
 Build instance of `GraphQL\Type\Schema` out of schema language definition (string or parsed AST)
 See [schema definition language docs](schema-definition-language.md) for details.
@@ -2242,7 +2242,7 @@ static function buildAST(
 )
 ```
 
-# GraphQL\Utils\AST
+## GraphQL\Utils\AST
 
 Various utilities dealing with AST
 
@@ -2409,7 +2409,7 @@ static function typeFromAST(GraphQL\Type\Schema $schema, $inputTypeNode)
 static function getOperation(GraphQL\Language\AST\DocumentNode $document, $operationName = null)
 ```
 
-# GraphQL\Utils\SchemaPrinter
+## GraphQL\Utils\SchemaPrinter
 
 Given an instance of Schema, prints it in schema definition language.
 

--- a/docs/complementary-tools.md
+++ b/docs/complementary-tools.md
@@ -1,4 +1,4 @@
-# Server Integrations
+## Server Integrations
 
 - [Standard Server](executing-queries.md#using-server) – Out of the box integration with any PSR-7 compatible framework (like [Slim](http://slimframework.com) or [Zend Expressive](http://zendframework.github.io/zend-expressive/))
 - [Lighthouse](https://github.com/nuwave/lighthouse) – Laravel package, SDL-first
@@ -8,7 +8,7 @@
 - [Siler](https://github.com/leocavalcante/siler) - Flat files and plain-old PHP functions, supports Swoole
 - [API Platform](https://api-platform.com/docs/core/graphql) - Creates a GraphQL API from PHP models
 
-# Server Utilities
+## Server Utilities
 
 - [GraphQLite](https://graphqlite.thecodingmachine.io) – Use PHP Annotations to define your schema
 - [GraphQL Doctrine](https://github.com/Ecodev/graphql-doctrine) – Define types with Doctrine ORM annotations
@@ -20,7 +20,7 @@
 
 * [MLL Scalars](https://github.com/mll-lab/graphql-php-scalars) - Collection of custom scalar types
 
-# GraphQL Clients
+## GraphQL Clients
 
 - [GraphiQL](https://github.com/graphql/graphiql) – Graphical interactive in-browser GraphQL IDE
 - [GraphQL Playground](https://github.com/prismagraphql/graphql-playground) – GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 GraphQL is data-centric. On the very top level it is built around three major concepts:
 **Schema**, **Query** and **Mutation**.
@@ -90,7 +90,7 @@ returned after mutation. In our example the mutation will return:
 }
 ```
 
-# Type System
+## Type System
 
 Conceptually a GraphQL type is a collection of fields. Each field in turn
 has its own type which allows building complex hierarchies.
@@ -146,7 +146,7 @@ $blogPostType = new ObjectType([
 ]);
 ```
 
-# Further Reading
+## Further Reading
 
 To get deeper understanding of GraphQL concepts - [read the docs on official GraphQL website](http://graphql.org/learn/)
 

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 GraphQL is data-storage agnostic. You can use any underlying data storage engine, including SQL or NoSQL database,
 plain files or in-memory data structures.
@@ -100,7 +100,7 @@ But then the question appears - field **title** has no **resolve** option. How i
 There is a default resolver for all fields. When you define your own **resolve** function
 for a field you simply override this default resolver.
 
-# Default Field Resolver
+## Default Field Resolver
 
 **graphql-php** provides following default field resolver:
 
@@ -132,7 +132,7 @@ If the value is not set - it returns **null**.
 
 To override the default resolver, pass it as an argument of [executeQuery](executing-queries.md) call.
 
-# Default Field Resolver per Type
+## Default Field Resolver per Type
 
 Sometimes it might be convenient to set default field resolver per type. You can do so by providing
 [resolveField option in type config](type-definitions/object-types.md#configuration-options). For example:
@@ -167,7 +167,7 @@ $userType = new ObjectType([
 Keep in mind that **field resolver** has precedence over **default field resolver per type** which in turn
 has precedence over **default field resolver**.
 
-# Solving N+1 Problem
+## Solving N+1 Problem
 
 Since: 0.9.0
 
@@ -236,7 +236,7 @@ Even though **author** field is located on different levels of the query - it ca
 In this example, only one query will be executed for all story authors comparing to 20 queries
 in a naive implementation.
 
-# Async PHP
+## Async PHP
 
 Since: 0.10.0 (version 0.9.0 had slightly different API which still works, but is deprecated)
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,4 +1,4 @@
-# Errors in GraphQL
+## Errors in GraphQL
 
 There are 3 types of errors in GraphQL:
 
@@ -27,7 +27,7 @@ converted to arrays as well using default error formatting (see below).
 Alternatively, you can apply [custom error filtering and formatting](#custom-error-handling-and-formatting)
 for your specific requirements.
 
-# Default Error formatting
+## Default Error formatting
 
 By default, each error entry is converted to an associative array with following structure:
 
@@ -57,7 +57,7 @@ Entry at key **path** exists only for errors caused by exceptions thrown in reso
 It contains a path from the very root field to actual field value producing an error
 (including indexes for list types and field names for composite types).
 
-**Internal errors**
+### Internal errors
 
 As of version **0.10.0**, all exceptions thrown in resolvers are reported with generic message **"Internal server error"**.
 This is done to avoid information leak in production environments (e.g. database connection errors, file access errors, etc).
@@ -103,7 +103,7 @@ To change default **"Internal server error"** message to something else, use:
 GraphQL\Error\FormattedError::setInternalErrorMessage("Unexpected error");
 ```
 
-# Debugging tools
+## Debugging tools
 
 During development or debugging use `$result->toArray(DebugFlag::INCLUDE_DEBUG_MESSAGE)` to add **debugMessage** key to
 each formatted error entry. If you also want to add exception trace - pass flags instead:
@@ -151,7 +151,7 @@ $result = GraphQL::executeQuery(/*args*/)->toArray($debug);
 If you only want to re-throw Exceptions that are not marked as safe through the `ClientAware` interface, use
 the flag `Debug::RETHROW_UNSAFE_EXCEPTIONS`.
 
-# Custom Error Handling and Formatting
+## Custom Error Handling and Formatting
 
 It is possible to define custom **formatter** and **handler** for result errors.
 
@@ -183,7 +183,7 @@ $result = GraphQL::executeQuery(/* $args */)
 Note that when you pass [debug flags](#debugging-tools) to **toArray()** your custom formatter will still be
 decorated with same debugging information mentioned above.
 
-# Schema Errors
+## Schema Errors
 
 So far we only covered errors which occur during query execution process. Schema definition can
 also throw `GraphQL\Error\InvariantViolation` if there is an error in one of type definitions.

--- a/docs/executing-queries.md
+++ b/docs/executing-queries.md
@@ -1,5 +1,4 @@
-# Using Facade Method
-
+## Using Facade Method
 Query execution is a complex process involving multiple steps, including query **parsing**,
 **validating** and finally **executing** against your [schema](schema-definition.md).
 
@@ -34,6 +33,7 @@ Returned array contains **data** and **errors** keys, as described by the
 This array is suitable for further serialization (e.g. using **json_encode**).
 See also the section on [error handling and formatting](error-handling.md).
 
+### Method arguments
 Description of **executeQuery** method arguments:
 
 | Argument        | Type                                                          | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -47,7 +47,7 @@ Description of **executeQuery** method arguments:
 | fieldResolver   | `callable`                                                    | A resolver function to use when one is not provided by the schema. If not provided, the [default field resolver is used](data-fetching.md#default-field-resolver).                                                                                                                                                                                                                                                                       |
 | validationRules | `array`                                                       | A set of rules for query validation step. The default value is all available rules. Empty array would allow skipping query validation (may be convenient for persisted queries which are validated before persisting and assumed valid during execution)                                                                                                                                                                                 |
 
-# Using Server
+## Using Server
 
 If you are building HTTP GraphQL API, you may prefer our Standard Server
 (compatible with [express-graphql](https://github.com/graphql/express-graphql)).
@@ -94,7 +94,7 @@ PSR-7 is useful when you want to integrate the server into existing framework:
 - [Slim](https://www.slimframework.com/docs/v4/concepts/value-objects.html)
 - [Zend Expressive](http://zendframework.github.io/zend-expressive/)
 
-## Server configuration options
+### Server configuration options
 
 | Argument              | Type                                                                        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | --------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -110,7 +110,7 @@ PSR-7 is useful when you want to integrate the server into existing framework:
 | errorsHandler         | `callable`                                                                  | Custom errors handler. See [error handling docs](error-handling.md#custom-error-handling-and-formatting).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | promiseAdapter        | [`PromiseAdapter`](class-reference.md#graphqlexecutorpromisepromiseadapter) | Required for [Async PHP](data-fetching.md#async-php) only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
-**Server config instance**
+#### Using config class
 
 If you prefer fluid interface for config with autocomplete in IDE and static time validation,
 use [`GraphQL\Server\ServerConfig`](class-reference.md#graphqlserverserverconfig) instead of an array:
@@ -162,7 +162,7 @@ $server = new StandardServer([
 ]);
 ```
 
-# Custom Validation Rules
+## Custom Validation Rules
 
 Before execution, a query is validated using a set of standard rules defined by the GraphQL spec.
 It is possible to override standard set of rules globally or per execution.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,9 +1,9 @@
-# Prerequisites
+## Prerequisites
 
 This documentation assumes your familiarity with GraphQL concepts. If it is not the case -
 first learn about GraphQL on [the official website](http://graphql.org/learn/).
 
-# Installation
+## Installation
 
 Using [composer](https://getcomposer.org/doc/00-intro.md), run:
 
@@ -11,12 +11,12 @@ Using [composer](https://getcomposer.org/doc/00-intro.md), run:
 composer require webonyx/graphql-php
 ```
 
-# Upgrading
+## Upgrading
 
 We try to keep library releases backwards compatible when possible.
 For breaking changes we provide [upgrade instructions](https://github.com/webonyx/graphql-php/blob/master/UPGRADE.md).
 
-# Install Tools (optional)
+## Install Tools (optional)
 
 While it is possible to communicate with GraphQL API using regular HTTP tools it is way
 more convenient for humans to use [GraphiQL](https://github.com/graphql/graphiql) - an in-browser
@@ -33,7 +33,7 @@ The easiest way to use it is to install one of the existing Google Chrome extens
 Alternatively, you can follow instructions on [the GraphiQL](https://github.com/graphql/graphiql)
 page and install it locally.
 
-# Hello World
+## Hello World
 
 Let's create a type system that will be capable to process the following simple query:
 
@@ -120,7 +120,7 @@ which also includes simple mutation.
 Check out [the blog example](https://github.com/webonyx/graphql-php/blob/master/examples/01-blog) for something
 which is closer to real-world apps or read about the details of [schema definition](schema-definition.md).
 
-# Next Steps
+## Next Steps
 
 Obviously hello world only scratches the surface of what is possible.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,12 @@
+# graphql-php
+
 [![GitHub stars](https://img.shields.io/github/stars/webonyx/graphql-php.svg?style=social&label=Star)](https://github.com/webonyx/graphql-php)
 [![Build Status](https://travis-ci.org/webonyx/graphql-php.svg?branch=master)](https://travis-ci.org/webonyx/graphql-php)
 [![Coverage Status](https://coveralls.io/repos/github/webonyx/graphql-php/badge.svg)](https://coveralls.io/github/webonyx/graphql-php)
 [![Latest Stable Version](https://poser.pugx.org/webonyx/graphql-php/version)](https://packagist.org/packages/webonyx/graphql-php)
 [![License](https://poser.pugx.org/webonyx/graphql-php/license)](https://packagist.org/packages/webonyx/graphql-php)
 
-# About GraphQL
+## About GraphQL
 
 GraphQL is a modern way to build HTTP APIs consumed by the web and mobile clients.
 It is intended to be an alternative to REST and SOAP APIs (even for **existing applications**).
@@ -16,7 +18,7 @@ engineers. Various implementations of this specification were written
 Great overview of GraphQL features and benefits is presented on [the official website](http://graphql.org/).
 All of them equally apply to this PHP implementation.
 
-# About graphql-php
+## About graphql-php
 
 **graphql-php** is a feature-complete implementation of GraphQL specification in PHP.
 It was originally inspired by [reference JavaScript implementation](https://github.com/graphql/graphql-js)
@@ -40,7 +42,7 @@ Library features include:
 Also, several [complementary tools](complementary-tools.md) are available which provide integrations with
 existing PHP frameworks, add support for Relay, etc.
 
-## Current Status
+### Current Status
 
 The first version of this library (v0.1) was released on August 10th 2015.
 
@@ -51,6 +53,6 @@ as well as some experimental features like
 
 Ready for real-world usage.
 
-## GitHub
+### GitHub
 
 Project source code is [hosted on GitHub](https://github.com/webonyx/graphql-php).

--- a/docs/schema-definition-language.md
+++ b/docs/schema-definition-language.md
@@ -39,7 +39,7 @@ By default, such schema is created without any resolvers.
 We have to rely on [default field resolver](data-fetching.md#default-field-resolver) and **root value** in
 order to execute a query against this schema.
 
-# Defining resolvers
+## Defining resolvers
 
 Since 0.10.0
 
@@ -64,7 +64,7 @@ $contents = file_get_contents('schema.graphql');
 $schema = BuildSchema::build($contents, $typeConfigDecorator);
 ```
 
-# Performance considerations
+## Performance considerations
 
 Since 0.10.0
 

--- a/docs/schema-definition.md
+++ b/docs/schema-definition.md
@@ -17,7 +17,7 @@ $schema = new Schema([
 
 See possible constructor options [below](#configuration-options).
 
-# Query and Mutation types
+## Query and Mutation types
 
 The schema consists of two root types:
 
@@ -80,7 +80,7 @@ exactly the same way.
 Field names of Mutation type are usually verbs and they almost always have arguments - quite often
 with complex input values (see [Mutations and Input Types](type-definitions/inputs.md) for details).
 
-# Configuration Options
+## Configuration Options
 
 The schema constructor expects an instance of [`GraphQL\Type\SchemaConfig`](class-reference.md#graphqltypeschemaconfig)
 or an array with the following options:
@@ -94,7 +94,7 @@ or an array with the following options:
 | types        | `array<ObjectType>`            | List of object types which cannot be detected by **graphql-php** during static schema analysis.<br><br>Most often this happens when the object type is never referenced in fields directly but is still a part of a schema because it implements an interface which resolves to this object type in its **resolveType** callable. <br><br> Note that you are not required to pass all of your types here - it is simply a workaround for concrete a use-case. |
 | typeLoader   | `callable(string $name): Type` | Expected to return a type instance given the name. Must always return the same instance if called multiple times, see [lazy loading](#lazy-loading-of-types). See section below on lazy type loading.                                                                                                                                                                                                                                                         |
 
-# Using config class
+### Using config class
 
 If you prefer a fluid interface for the config with auto-completion in IDE and static time validation,
 use [`GraphQL\Type\SchemaConfig`](class-reference.md#graphqltypeschemaconfig) instead of an array:
@@ -111,7 +111,7 @@ $config = SchemaConfig::create()
 $schema = new Schema($config);
 ```
 
-# Lazy loading of types
+## Lazy loading of types
 
 By default, the schema will scan all of your type, field and argument definitions to serve GraphQL queries.
 It may cause performance overhead when there are many types in the schema.
@@ -172,7 +172,7 @@ introduce a Dependency Injection Container if your types have other dependencies
 Alternatively, all methods of the registry could be static - then there is no need
 to pass it in the constructor - instead use **TypeRegistry::myAType()** in your type definitions.
 
-# Schema Validation
+## Schema Validation
 
 By default, the schema is created with only shallow validation of type and field definitions  
 (because validation requires a full schema scan and is very costly on bigger schemas).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-# Query Complexity Analysis
+## Query Complexity Analysis
 
 This is a PHP port of [Query Complexity Analysis](http://sangria-graphql.org/learn/#query-complexity-analysis) in Sangria implementation.
 
@@ -50,7 +50,7 @@ $type = new ObjectType([
 ]);
 ```
 
-# Limiting Query Depth
+## Limiting Query Depth
 
 This is a PHP port of [Limiting Query Depth](http://sangria-graphql.org/learn/#limiting-query-depth) in Sangria implementation.
 For example, max depth of the introspection query is **7**.
@@ -71,7 +71,7 @@ GraphQL::executeQuery(/*...*/);
 
 This will set the rule globally. Alternatively, you can provide validation rules [per execution](executing-queries.md#custom-validation-rules).
 
-# Disabling Introspection
+## Disabling Introspection
 
 [Introspection](http://graphql.org/learn/introspection/) is a mechanism for fetching schema structure.
 It is used by tools like GraphiQL for auto-completion, query validation, etc.

--- a/docs/type-definitions/directives.md
+++ b/docs/type-definitions/directives.md
@@ -1,4 +1,4 @@
-# Built-in directives
+## Built-in directives
 The directive is a way for a client to give GraphQL server additional context and hints on how to execute
 the query. The directive can be attached to a field or fragment and can affect the execution of the 
 query in any way the server desires.
@@ -23,7 +23,7 @@ Here if **$withFriends** variable is set to **false** - friends section will be 
 from the response. Important implementation detail: those fields will never be executed 
 (not just removed from response after execution).
 
-# Custom directives
+## Custom directives
 **graphql-php** supports custom directives even though their presence does not affect the execution of fields.
 You can use [`GraphQL\Type\Definition\ResolveInfo`](../class-reference.md#graphqltypedefinitionresolveinfo) 
 in field resolvers to modify the output depending on those directives or perform statistics collection.

--- a/docs/type-definitions/enums.md
+++ b/docs/type-definitions/enums.md
@@ -2,6 +2,7 @@
 Enumeration types are a special kind of scalar that is restricted to a particular set 
 of allowed values. 
 
+## Writing Enum Types
 In **graphql-php** enum type is an instance of `GraphQL\Type\Definition\EnumType` 
 which accepts configuration array in constructor:
 
@@ -32,7 +33,7 @@ $episodeEnum = new EnumType([
 This example uses an **inline** style for Enum Type definition, but you can also use
 [inheritance or schema definition language](index.md#definition-styles).
 
-# Configuration options
+## Configuration options
 Enum Type constructor accepts an array with following options:
 
 Option | Type | Notes
@@ -51,7 +52,7 @@ description | `string` | Plain-text description of enum value for clients (e.g. 
 deprecationReason | `string` | Text describing why this enum value is deprecated. When not empty - item will not be returned by introspection queries (unless forced)
 
 
-# Shorthand definitions
+## Shorthand definitions
 If internal representation of enumerated item is the same as item name, then you can use
 following shorthand for definition:
 
@@ -99,7 +100,7 @@ $episodeEnum = new EnumType([
 ]);
 ```
 
-# Field Resolution
+## Field Resolution
 When object field is of Enum Type, field resolver is expected to return an internal 
 representation of corresponding Enum item (**value** in config). **graphql-php** will 
 then serialize this **value** to **name** to include in response:

--- a/docs/type-definitions/index.md
+++ b/docs/type-definitions/index.md
@@ -1,5 +1,6 @@
 # Type Definitions 
 graphql-php represents a **type** as a class instance from the `GraphQL\Type\Definition` namespace:
+
 - [`ObjectType`](object-types.md)
 - [`InterfaceType`](interfaces.md)
 - [`UnionType`](unions.md)
@@ -7,7 +8,7 @@ graphql-php represents a **type** as a class instance from the `GraphQL\Type\Def
 - [`ScalarType`](scalars.md)
 - [`EnumType`](enums.md)
 
-# Input vs. Output Types
+## Input vs. Output Types
 All types in GraphQL are of two categories: **input** and **output**.
 
 * **Output** types (or field types) are: [Scalar](scalars.md), [Enum](enums.md), [Object](object-types.md),
@@ -18,11 +19,11 @@ All types in GraphQL are of two categories: **input** and **output**.
 Obviously, [NonNull and List](lists-and-nonnulls.md) types belong to both categories depending on their
 inner type.
 
-# Definition styles
+## Definition styles
 
 Several styles of type definitions are supported depending on your preferences.
 
-## Inline definitions
+### Inline definitions
 ```php
 <?php
 namespace MyApp;
@@ -38,7 +39,7 @@ $myType = new ObjectType([
 ]);
 ```
 
-## Class per type
+### Class per type
 ```php
 <?php
 namespace MyApp;
@@ -62,7 +63,7 @@ class MyType extends ObjectType
 }
 ```
 
-## Schema definition language
+### Schema definition language
 ```graphql
 schema {
     query: Query

--- a/docs/type-definitions/inputs.md
+++ b/docs/type-definitions/inputs.md
@@ -2,6 +2,7 @@
 The GraphQL specification defines Input Object Type for complex inputs. It is similar to ObjectType
 except that it's fields have no **args** or **resolve** options and their **type** must be input type.
 
+## Writing Input Object Types
 In graphql-php **Input Object Type** is an instance of `GraphQL\Type\Definition\InputObjectType` 
 (or one of its subclasses) which accepts configuration array in its constructor:
 
@@ -31,7 +32,7 @@ $filters = new InputObjectType([
 
 Every field may be of other InputObjectType (thus complex hierarchies of inputs are possible)
 
-# Configuration options
+## Configuration options
 The constructor of InputObjectType accepts an array with only 3 options:
  
 Option       | Type     | Notes
@@ -49,7 +50,7 @@ type | `Type` | **Required.** Instance of one of [Input Types](inputs.md) (**Sca
 description | `string` | Plain-text description of this input field for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
 defaultValue | `scalar` | Default value of this input field. Use the internal value if specifying a default for an **enum** type
 
-# Using Input Object Type
+## Using Input Object Type
 In the example above we defined our InputObjectType. Now let's use it in one of field arguments:
 
 ```php

--- a/docs/type-definitions/interfaces.md
+++ b/docs/type-definitions/interfaces.md
@@ -2,6 +2,7 @@
 An Interface is an abstract type that includes a certain set of fields that a 
 type must include to implement the interface.
 
+## Writing Interface Types
 In **graphql-php** interface type is an instance of `GraphQL\Type\Definition\InterfaceType` 
 (or one of its subclasses) which accepts configuration array in a constructor:
 
@@ -35,7 +36,7 @@ $character = new InterfaceType([
 This example uses **inline** style for Interface definition, but you can also use  
 [inheritance or schema definition language](index.md#definition-styles).
 
-# Configuration options
+## Configuration options
 The constructor of InterfaceType accepts an array. Below is a full list of allowed options:
 
 Option | Type | Notes
@@ -45,7 +46,7 @@ fields | `array` | **Required.** List of fields required to be defined by interf
 description | `string` | Plain-text description of this type for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
 resolveType | `callback` | **function($value, $context, [ResolveInfo](../class-reference.md#graphqltypedefinitionresolveinfo) $info)**<br> Receives **$value** from resolver of the parent field and returns concrete interface implementor for this **$value**.
 
-# Implementing interface
+## Implementing interface
 To implement the Interface simply add it to **interfaces** array of Object Type definition:
 ```php
 <?php
@@ -75,7 +76,7 @@ Note that Object Type must include all fields of interface with exact same types
 The only exception is when object's field type is more specific than the type of this field defined in interface 
 (see [Covariant return types for interface fields](#covariant-return-types-for-interface-fields) below)
 
-# Covariant return types for interface fields
+## Covariant return types for interface fields
 Object types implementing interface may change the field type to more specific.
 Example:
 
@@ -89,7 +90,7 @@ type B implements A {
 }
 ```
 
-# Sharing Interface fields
+## Sharing Interface fields
 Since every Object Type implementing an Interface must have the same set of fields - it often makes 
 sense to reuse field definitions of Interface in Object Types:
 
@@ -126,7 +127,7 @@ option in [Object Type config](object-types.md#configuration-options) and handle
 resolutions there 
 (Note: **resolve** option in field definition has precedence over **resolveField** option in object type definition)
 
-# Interface role in data fetching
+## Interface role in data fetching
 The only responsibility of interface in Data Fetching process is to return concrete Object Type 
 for given **$value** in **resolveType**. Then resolution of fields is delegated to resolvers of this 
 concrete Object Type.
@@ -135,7 +136,7 @@ If a **resolveType** option is omitted, graphql-php will loop through all interf
 use their **isTypeOf** callback to pick the first suitable one. This is obviously less efficient 
 than single **resolveType** call. So it is recommended to define **resolveType** whenever possible.
 
-# Prevent invisible types
+## Prevent invisible types
 When object types that implement an interface are not directly referenced by a field, they cannot
 be discovered during schema introspection. For example:
 

--- a/docs/type-definitions/lists-and-nonnulls.md
+++ b/docs/type-definitions/lists-and-nonnulls.md
@@ -1,4 +1,4 @@
-# Lists
+## Lists
 **graphql-php** provides built-in support for lists. In order to create list type - wrap 
 existing type with `GraphQL\Type\Definition\Type::listOf()` modifier:
 
@@ -28,7 +28,7 @@ interface (**null** is allowed by default too).
 If returned value is not of one of these types - **graphql-php** will add an error to result 
 and set the field value to **null** (only if the field is nullable, see below for non-null fields).
 
-# Non-Nulls
+## Non-Nulls
 By default, every field or argument can have a **null** value.
 To indicate the value must be **non-null** use the `GraphQL\Type\Definition\Type::nonNull()` modifier:
 

--- a/docs/type-definitions/object-types.md
+++ b/docs/type-definitions/object-types.md
@@ -4,6 +4,7 @@ Object Type is the most frequently used primitive in a typical GraphQL applicati
 Conceptually Object Type is a collection of Fields. Each field, in turn,
 has its own type which allows building complex hierarchies.
 
+## Writing Object Types
 In **graphql-php** object type is an instance of `GraphQL\Type\Definition\ObjectType` 
 (or one of its subclasses) which accepts a configuration array in its constructor:
 
@@ -59,7 +60,7 @@ $blogStory = new ObjectType([
 This example uses **inline** style for Object Type definitions, but you can also use  
 [inheritance or schema definition language](index.md#definition-styles).
 
-# Configuration options
+## Configuration options
 
 Option       | Type     | Notes
 ------------ | -------- | -----
@@ -70,7 +71,7 @@ interfaces   | `array` or `callable` | List of interfaces implemented by this ty
 isTypeOf     | `callable` | **function($value, $context, [ResolveInfo](../class-reference.md#graphqltypedefinitionresolveinfo) $info)**<br> Expected to return **true** if **$value** qualifies for this type (see section about [Abstract Type Resolution](interfaces.md#interface-role-in-data-fetching) for explanation).
 resolveField | `callable` | **function($value, $args, $context, [ResolveInfo](../class-reference.md#graphqltypedefinitionresolveinfo) $info)**<br> Given the **$value** of this type, it is expected to return value for a field defined in **$info->fieldName**. A good place to define a type-specific strategy for field resolution. See section on [Data Fetching](../data-fetching.md) for details.
 
-## Field configuration options
+### Field configuration options
 
 Option | Type | Notes
 ------ | ---- | -----
@@ -82,7 +83,7 @@ complexity | `callable` | **function($childrenComplexity, $args)**<br> Used to r
 description | `string` | Plain-text description of this field for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
 deprecationReason | `string` | Text describing why this field is deprecated. When not empty - field will not be returned by introspection queries (unless forced)
 
-## Field argument configuration options
+### Field argument configuration options
 
 Option | Type | Notes
 ------ | ---- | -----
@@ -91,7 +92,7 @@ type | `Type` | **Required.** Instance of one of [Input Types](inputs.md) (**sca
 description | `string` | Plain-text description of this argument for clients (e.g. used by [GraphiQL](https://github.com/graphql/graphiql) for auto-generated documentation)
 defaultValue | `scalar` | Default value for this argument. Use the internal value if specifying a default for an **enum** type
 
-# Shorthand field definitions
+## Shorthand field definitions
 Fields can be also defined in **shorthand** notation (with only **name** and **type** options):
 ```php
 'fields' => [
@@ -115,7 +116,7 @@ which is in turn equivalent of the full form:
 ```
 Same shorthand notation applies to field arguments as well.
 
-# Recurring and circular types
+## Recurring and circular types
 Almost all real-world applications contain recurring or circular types. 
 Think user friends or nested comments for example. 
 
@@ -192,14 +193,14 @@ class MyTypes
 }
 ```
 
-# Field Resolution
+## Field Resolution
 Field resolution is the primary mechanism in **graphql-php** for returning actual data for your fields.
 It is implemented using **resolveField** callable in type definition or **resolve**
 callable in field definition (which has precedence).
 
 Read the section on [Data Fetching](../data-fetching.md) for a complete description of this process.
 
-# Custom Metadata
+## Custom Metadata
 All types in **graphql-php** accept configuration array. In some cases, you may be interested in 
 passing your own metadata for type or field definition.
 

--- a/docs/type-definitions/scalars.md
+++ b/docs/type-definitions/scalars.md
@@ -1,4 +1,8 @@
-# Built-in Scalar Types
+# Scalar Type Definition
+Scalar types represent primitive leaf values in a GraphQL type system. 
+When object fields have to resolve to some concrete data, that's where the scalar types come in.
+
+## Built-in Scalar Types
 
 The GraphQL specification describes several built-in scalar types. In **graphql-php** they are 
 exposed as static methods of the class [`GraphQL\Type\Definition\Type`](../class-reference.md#graphqltypedefinitiontype):
@@ -17,7 +21,7 @@ Type::id();      // ID type
 Those methods return instances of a subclass of `GraphQL\Type\Definition\ScalarType`.
 Use them directly in type definitions or wrapped in a type registry (see [lazy loading of types](../schema-definition.md#lazy-loading-of-types)). 
 
-# Writing Custom Scalar Types
+## Writing Custom Scalar Types
 
 In addition to built-in scalars, you can define your own scalar types with additional validation. 
 Typical examples of such types are **Email**, **Date**, **Url**, etc.

--- a/docs/type-definitions/unions.md
+++ b/docs/type-definitions/unions.md
@@ -2,6 +2,7 @@
 A Union is an abstract type that simply enumerates other Object Types. 
 The value of Union Type is actually a value of one of included Object Types.
 
+## Writing Union Types
 In **graphql-php** union type is an instance of `GraphQL\Type\Definition\UnionType` 
 (or one of its subclasses) which accepts configuration array in a constructor:
 
@@ -28,7 +29,7 @@ $searchResultType = new UnionType([
 This example uses **inline** style for Union definition, but you can also use  
 [inheritance or schema definition language](index.md#definition-styles).
 
-# Configuration options
+## Configuration options
 The constructor of UnionType accepts an array. Below is a full list of allowed options:
 
 Option | Type | Notes

--- a/generate-class-reference.php
+++ b/generate-class-reference.php
@@ -113,7 +113,7 @@ function renderClass(ReflectionClass $class, $options) {
     }
 
     return <<<TEMPLATE
-# {$class->getName()}
+## {$class->getName()}
 {$classDocs}
 
 $content

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ repo_url: https://github.com/webonyx/graphql-php
 theme:
   name: material
 docs_dir: docs/
+markdown_extensions:
+  - toc:
+      permalink: true
 nav:
 - About: index.md
 - Getting Started: getting-started.md


### PR DESCRIPTION
`mkdocs-material` has support for table of contents enabled by default but right now it's not working properly (majority of pages doesn't show ToC at all, only [Concepts](https://webonyx.github.io/graphql-php/concepts/) page shows something but it's broken anyway).

The problem is, for ToC to work, every page must contain only one heading of level 1. So what this PR essentially does is to bump titles one level up. Plus it adds a few new headings or changes levels as appropriate. It also enables permalinks to easily link to a page section.

If a Markdown file doesn't have a level 1 heading at all, it's inherited from the page name in the navigation. I'm a bit undecided if to add level one everywhere to be explicit about page title or not.

Before:

![webonyx github io_graphql-php_schema-definition](https://user-images.githubusercontent.com/243381/133882611-284bb9e0-8f43-4559-ae0f-b17ea7af3a67.png)

After:

![localhost_8000_schema-definition](https://user-images.githubusercontent.com/243381/133882615-31e755da-706e-4beb-a658-dce09e9346d5.png)

