### PR TITLE
Restore support for Non-null variable types

### DIFF
--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -446,7 +446,7 @@ class Printer
             case $node instanceof VariableDefinitionNode:
                 return '$' . $this->p($node->variable->name)
                     . ': '
-                    . $this->p($node->type->name)
+                    . $this->p($node->type)
                     . $this->wrap(' = ', $this->p($node->defaultValue))
                     . $this->wrap(' ', $this->printList($node->directives, ' '));
 

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -88,6 +88,22 @@ class PrinterTest extends TestCase
         self::assertEquals($expected, Printer::doPrint($mutationAstWithArtifacts));
     }
 
+    public function testCorrectlyPrintsOpsWithNonNullableVariableArgument(): void
+    {
+        $queryWithNonNullVariable = Parser::parse(
+            'query ($var: ID!) { a(arg: $var) { __typename } }
+'
+        );
+
+        $expected = 'query ($var: ID!) {
+  a(arg: $var) {
+    __typename
+  }
+}
+';
+        self::assertEquals($expected, Printer::doPrint($queryWithNonNullVariable));
+    }
+
     /**
      * @see it('prints query with variable directives')
      */


### PR DESCRIPTION
There was a huge change in #697 and tests did not cover it.