### PR TITLE
Align `SchemaPrinterTest` with `graphql-js` v15.5

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -164,46 +164,22 @@ class SchemaPrinter
      */
     protected static function printDescription(array $options, $def, string $indentation = '', bool $firstInBlock = true): string
     {
-        if ($def->description === null) {
+        $description = $def->description;
+        if ($description === null) {
             return '';
         }
 
         if (isset($options['commentDescriptions'])) {
-            $lines = static::descriptionLines($def->description, 120 - strlen($indentation));
-
-            return static::printDescriptionWithComments($lines, $indentation, $firstInBlock);
+            return static::printDescriptionWithComments($description, $indentation, $firstInBlock);
         }
 
-        $preferMultipleLines = mb_strlen($def->description) > 70;
-        $blockString         = BlockString::print($def->description, '', $preferMultipleLines);
+        $preferMultipleLines = mb_strlen($description) > 70;
+        $blockString         = BlockString::print($description, '', $preferMultipleLines);
         $prefix              = $indentation !== '' && ! $firstInBlock
             ? "\n" . $indentation
             : $indentation;
 
         return $prefix . str_replace("\n", "\n" . $indentation, $blockString) . "\n";
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    protected static function descriptionLines(string $description, int $maxLen): array
-    {
-        $lines    = [];
-        $rawLines = explode("\n", $description);
-        foreach ($rawLines as $line) {
-            if ($line === '') {
-                $lines[] = $line;
-            } else {
-                // For > 120 character long lines, cut at space boundaries into sublines
-                // of ~80 chars.
-                $sublines = static::breakLine($line, $maxLen);
-                foreach ($sublines as $subline) {
-                    $lines[] = $subline;
-                }
-            }
-        }
-
-        return $lines;
     }
 
     /**
@@ -221,21 +197,18 @@ class SchemaPrinter
         return array_map('trim', $parts);
     }
 
-    /**
-     * @param array<int, string> $lines
-     */
-    protected static function printDescriptionWithComments(array $lines, string $indentation, bool $firstInBlock): string
+    protected static function printDescriptionWithComments(string $description, string $indentation, bool $firstInBlock): string
     {
-        $description = $indentation !== '' && ! $firstInBlock ? "\n" : '';
-        foreach ($lines as $line) {
+        $comment = $indentation !== '' && ! $firstInBlock ? "\n" : '';
+        foreach (explode("\n", $description) as $line) {
             if ($line === '') {
-                $description .= $indentation . "#\n";
+                $comment .= $indentation . "#\n";
             } else {
-                $description .= $indentation . '# ' . $line . "\n";
+                $comment .= $indentation . '# ' . $line . "\n";
             }
         }
 
-        return $description;
+        return $comment;
     }
 
     /**

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -32,7 +32,6 @@ use function explode;
 use function implode;
 use function ksort;
 use function mb_strlen;
-use function preg_match_all;
 use function sprintf;
 use function str_replace;
 use function strlen;
@@ -180,21 +179,6 @@ class SchemaPrinter
             : $indentation;
 
         return $prefix . str_replace("\n", "\n" . $indentation, $blockString) . "\n";
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    protected static function breakLine(string $line, int $maxLen): array
-    {
-        if (strlen($line) < $maxLen + 5) {
-            return [$line];
-        }
-
-        preg_match_all('/((?: |^).{15,' . ($maxLen - 40) . '}(?= |$))/', $line, $parts);
-        $parts = $parts[0];
-
-        return array_map('trim', $parts);
     }
 
     protected static function printDescriptionWithComments(string $description, string $indentation, bool $firstInBlock): string

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -840,10 +840,9 @@ class SchemaPrinterTest extends TestCase
      */
     public function testOneLinePrintsAShortDescription(): void
     {
-        $description = 'This field is awesome';
-        $schema      = $this->buildSingleFieldSchema([
+        $schema = $this->buildSingleFieldSchema([
             'type'        => Type::string(),
-            'description' => $description,
+            'description' => 'This field is awesome',
         ]);
 
         self::assertPrintedSchemaEquals(
@@ -863,8 +862,9 @@ class SchemaPrinterTest extends TestCase
      */
     public function testPrintIntrospectionSchema(): void
     {
-        $schema   = new Schema([]);
-        $output   = SchemaPrinter::printIntrospectionSchema($schema);
+        $schema = new Schema([]);
+        $output = SchemaPrinter::printIntrospectionSchema($schema);
+
         $expected = <<<'GRAPHQL'
             """
             Directs the executor to include this field or fragment only when the `if` argument is true.

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -542,6 +542,7 @@ class SchemaPrinterTest extends TestCase
 
         $schema = new Schema(['types' => [$barType]]);
 
+        // the expected SDL differs from graphql-js: https://github.com/webonyx/graphql-php/issues/954
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
             interface Baaz {
@@ -600,6 +601,7 @@ class SchemaPrinterTest extends TestCase
             'types' => [$BarType],
         ]);
 
+        // the expected SDL differs from graphql-js: https://github.com/webonyx/graphql-php/issues/954
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
             interface Baaz implements Foo {
@@ -652,6 +654,7 @@ class SchemaPrinterTest extends TestCase
 
         $schema = new Schema(['types' => [$singleUnion, $multipleUnion]]);
 
+        // the expected SDL differs from graphql-js: https://github.com/webonyx/graphql-php/issues/954
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
             type Bar {

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -52,12 +52,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::string(),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -71,12 +71,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::listOf(Type::string()),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String]
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -90,12 +90,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::string()),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: String!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -109,12 +109,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String]!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -128,12 +128,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String!]
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -147,12 +147,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField: [String!]!
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -169,12 +169,12 @@ class SchemaPrinterTest extends TestCase
             'deprecationReason' => $deprecationReason,
         ]);
         self::assertPrintedSchemaEquals(
-            <<<GQL
+            <<<GRAPHQL
             type Query {
               singleField: Int$expectedDeprecationDirective
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -214,12 +214,12 @@ class SchemaPrinterTest extends TestCase
         $schema  = new Schema(['types' => [$fooType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Foo {
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -234,12 +234,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -254,12 +254,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = 2): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -274,12 +274,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: String = "tes\t de\fault"): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -294,12 +294,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = null): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -314,12 +314,12 @@ class SchemaPrinterTest extends TestCase
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int!): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -337,12 +337,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -361,12 +361,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -385,12 +385,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -409,12 +409,12 @@ class SchemaPrinterTest extends TestCase
             ],
         ]);
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -428,14 +428,14 @@ class SchemaPrinterTest extends TestCase
             'query' => new ObjectType(['name' => 'CustomType', 'fields' => []]),
         ]);
 
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             schema {
               query: CustomType
             }
 
             type CustomType
 
-            GQL;
+            GRAPHQL;
         self::assertPrintedSchemaEquals($expected, $schema);
     }
 
@@ -449,14 +449,14 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             schema {
               mutation: CustomType
             }
 
             type CustomType
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -471,14 +471,14 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             schema {
               subscription: CustomType
             }
 
             type CustomType
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -502,7 +502,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$barType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Bar implements Foo {
               str: String
             }
@@ -511,7 +511,7 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -543,7 +543,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$barType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             interface Baaz {
               int: Int
             }
@@ -557,7 +557,7 @@ class SchemaPrinterTest extends TestCase
               str: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -601,7 +601,7 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             interface Baaz implements Foo {
               int: Int
               str: String
@@ -620,7 +620,7 @@ class SchemaPrinterTest extends TestCase
               bar: Bar
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -653,7 +653,7 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$singleUnion, $multipleUnion]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Bar {
               str: String
             }
@@ -666,7 +666,7 @@ class SchemaPrinterTest extends TestCase
 
             union SingleUnion = Foo
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -684,12 +684,12 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$inputType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             input InputType {
               int: Int
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -704,10 +704,10 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$oddType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             scalar Odd
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -729,14 +729,14 @@ class SchemaPrinterTest extends TestCase
         $schema = new Schema(['types' => [$RGBType]]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             enum RGB {
               RED
               GREEN
               BLUE
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -802,13 +802,13 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             directive @simpleDirective on FIELD
 
             """Complex Directive"""
             directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -847,13 +847,13 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               """This field is awesome"""
               singleField: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }
@@ -865,7 +865,7 @@ class SchemaPrinterTest extends TestCase
     {
         $schema   = new Schema([]);
         $output   = SchemaPrinter::printIntrospectionSchema($schema);
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             """
             Directs the executor to include this field or fragment only when the `if` argument is true.
             """
@@ -1075,7 +1075,7 @@ class SchemaPrinterTest extends TestCase
               NON_NULL
             }
 
-            GQL;
+            GRAPHQL;
         self::assertEquals($expected, $output);
     }
 
@@ -1089,7 +1089,7 @@ class SchemaPrinterTest extends TestCase
             $schema,
             ['commentDescriptions' => true]
         );
-        $expected = <<<'GQL'
+        $expected = <<<'GRAPHQL'
             # Directs the executor to include this field or fragment only when the `if` argument is true.
             directive @include(
               # Included when true.
@@ -1285,7 +1285,7 @@ class SchemaPrinterTest extends TestCase
               NON_NULL
             }
 
-            GQL;
+            GRAPHQL;
         self::assertEquals($expected, $output);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -23,9 +23,11 @@ class SchemaPrinterTest extends TestCase
 {
     private static function assertPrintedSchemaEquals(string $expected, Schema $schema): void
     {
-        $schemaText = SchemaPrinter::doPrint($schema);
-        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
-        self::assertEquals($expected, $schemaText);
+        $printedSchema = SchemaPrinter::doPrint($schema);
+        self::assertEquals($expected, $printedSchema);
+
+        $cycledSchema = SchemaPrinter::doPrint(BuildSchema::build($printedSchema));
+        self::assertEquals($printedSchema, $cycledSchema);
     }
 
     /** @param array<string, mixed> $fieldConfig */

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -824,13 +824,13 @@ class SchemaPrinterTest extends TestCase
         ]);
 
         self::assertPrintedSchemaEquals(
-            <<<'GQL'
+            <<<'GRAPHQL'
             type Query {
               """"""
               singleField: String
             }
 
-            GQL,
+            GRAPHQL,
             $schema
         );
     }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -37,7 +37,7 @@ class SchemaPrinterTest extends TestCase
         $schemaText = SchemaPrinter::doPrint($schema);
         self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
 
-        return "\n" . $schemaText;
+        return $schemaText;
     }
 
     // Describe: Type System Printer
@@ -51,11 +51,12 @@ class SchemaPrinterTest extends TestCase
             'type' => Type::string(),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: String
+            }
+
+            GQL,
             $output
         );
     }
@@ -69,11 +70,12 @@ type Query {
             'type' => Type::listOf(Type::string()),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String]
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String]
+            }
+
+            GQL,
             $output
         );
     }
@@ -87,11 +89,12 @@ type Query {
             'type' => Type::nonNull(Type::string()),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: String!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: String!
+            }
+
+            GQL,
             $output
         );
     }
@@ -105,11 +108,12 @@ type Query {
             'type' => Type::nonNull(Type::listOf(Type::string())),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String]!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String]!
+            }
+
+            GQL,
             $output
         );
     }
@@ -123,11 +127,12 @@ type Query {
             'type' => Type::listOf(Type::nonNull(Type::string())),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String!]
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String!]
+            }
+
+            GQL,
             $output
         );
     }
@@ -141,11 +146,12 @@ type Query {
             'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField: [String!]!
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField: [String!]!
+            }
+
+            GQL,
             $output
         );
     }
@@ -162,11 +168,12 @@ type Query {
             'deprecationReason' => $deprecationReason,
         ]);
         self::assertSame(
-            '
-type Query {
-  singleField: Int' . $expectedDeprecationDirective . '
-}
-',
+            <<<GQL
+            type Query {
+              singleField: Int$expectedDeprecationDirective
+            }
+
+            GQL,
             $output
         );
     }
@@ -212,15 +219,16 @@ type Query {
         $schema = new Schema(['query' => $root]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Foo {
-  str: String
-}
+            <<<'GQL'
+            type Foo {
+              str: String
+            }
 
-type Query {
-  foo: Foo
-}
-',
+            type Query {
+              foo: Foo
+            }
+
+            GQL,
             $output
         );
     }
@@ -235,11 +243,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int()]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -254,11 +263,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => 2]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = 2): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = 2): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -273,11 +283,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::string(), 'defaultValue' => "tes\t de\fault"]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: String = "tes\t de\fault"): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: String = "tes\t de\fault"): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -292,11 +303,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::int(), 'defaultValue' => null]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = null): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = null): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -311,11 +323,12 @@ type Query {
             'args' => ['argOne' => ['type' => Type::nonNull(Type::int())]],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int!): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int!): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -333,11 +346,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -356,11 +370,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -379,11 +394,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -402,11 +418,12 @@ type Query {
             ],
         ]);
         self::assertEquals(
-            '
-type Query {
-  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
-}
-',
+            <<<'GQL'
+            type Query {
+              singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -423,15 +440,16 @@ type Query {
 
         $schema   = new Schema(['query' => $customQueryType]);
         $output   = $this->printForTest($schema);
-        $expected = '
-schema {
-  query: CustomQueryType
-}
+        $expected = <<<'GQL'
+            schema {
+              query: CustomQueryType
+            }
 
-type CustomQueryType {
-  bar: String
-}
-';
+            type CustomQueryType {
+              bar: String
+            }
+
+            GQL;
         self::assertEquals($expected, $output);
     }
 
@@ -462,19 +480,20 @@ type CustomQueryType {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Bar implements Foo {
-  str: String
-}
+            <<<'GQL'
+            type Bar implements Foo {
+              str: String
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -514,24 +533,25 @@ type Query {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-interface Baaz {
-  int: Int
-}
+            <<<'GQL'
+            interface Baaz {
+              int: Int
+            }
 
-type Bar implements Foo & Baaz {
-  str: String
-  int: Int
-}
+            type Bar implements Foo & Baaz {
+              str: String
+              int: Int
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -575,25 +595,26 @@ type Query {
         ]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-interface Baaz implements Foo {
-  int: Int
-  str: String
-}
+            <<<'GQL'
+            interface Baaz implements Foo {
+              int: Int
+              str: String
+            }
 
-type Bar implements Foo & Baaz {
-  str: String
-  int: Int
-}
+            type Bar implements Foo & Baaz {
+              str: String
+              int: Int
+            }
 
-interface Foo {
-  str: String
-}
+            interface Foo {
+              str: String
+            }
 
-type Query {
-  bar: Bar
-}
-',
+            type Query {
+              bar: Bar
+            }
+
+            GQL,
             $output
         );
     }
@@ -634,24 +655,25 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Bar {
-  str: String
-}
+            <<<'GQL'
+            type Bar {
+              str: String
+            }
 
-type Foo {
-  bool: Boolean
-}
+            type Foo {
+              bool: Boolean
+            }
 
-union MultipleUnion = Foo | Bar
+            union MultipleUnion = Foo | Bar
 
-type Query {
-  single: SingleUnion
-  multiple: MultipleUnion
-}
+            type Query {
+              single: SingleUnion
+              multiple: MultipleUnion
+            }
 
-union SingleUnion = Foo
-',
+            union SingleUnion = Foo
+
+            GQL,
             $output
         );
     }
@@ -679,15 +701,16 @@ union SingleUnion = Foo
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-input InputType {
-  int: Int
-}
+            <<<'GQL'
+            input InputType {
+              int: Int
+            }
 
-type Query {
-  str(argOne: InputType): String
-}
-',
+            type Query {
+              str(argOne: InputType): String
+            }
+
+            GQL,
             $output
         );
     }
@@ -714,13 +737,14 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-scalar Odd
+            <<<'GQL'
+            scalar Odd
 
-type Query {
-  odd: Odd
-}
-',
+            type Query {
+              odd: Odd
+            }
+
+            GQL,
             $output
         );
     }
@@ -749,17 +773,18 @@ type Query {
         $schema = new Schema(['query' => $query]);
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-type Query {
-  rgb: RGB
-}
+            <<<'GQL'
+            type Query {
+              rgb: RGB
+            }
 
-enum RGB {
-  RED
-  GREEN
-  BLUE
-}
-',
+            enum RGB {
+              RED
+              GREEN
+              BLUE
+            }
+
+            GQL,
             $output
         );
     }
@@ -782,7 +807,6 @@ enum RGB {
         $output = $this->printForTest($schema);
         self::assertEquals(
             <<<'GRAPHQL'
-
             enum SomeEnum
 
             input SomeInputObject
@@ -845,16 +869,17 @@ enum RGB {
 
         $output = $this->printForTest($schema);
         self::assertEquals(
-            '
-directive @simpleDirective on FIELD
+            <<<'GQL'
+            directive @simpleDirective on FIELD
 
-"""Complex Directive"""
-directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
+            """Complex Directive"""
+            directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
-type Query {
-  field: String
-}
-',
+            type Query {
+              field: String
+            }
+
+            GQL,
             $output
         );
     }
@@ -870,12 +895,13 @@ type Query {
         ]);
 
         self::assertEquals(
-            '
-type Query {
-  """"""
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              """"""
+              singleField: String
+            }
+
+            GQL,
             $output
         );
     }
@@ -892,12 +918,13 @@ type Query {
         ]);
 
         self::assertEquals(
-            '
-type Query {
-  """This field is awesome"""
-  singleField: String
-}
-',
+            <<<'GQL'
+            type Query {
+              """This field is awesome"""
+              singleField: String
+            }
+
+            GQL,
             $output
         );
 
@@ -921,217 +948,217 @@ type Query {
 
         $schema              = new Schema(['query' => $query]);
         $output              = SchemaPrinter::printIntrospectionSchema($schema);
-        $introspectionSchema = <<<'EOT'
-"""
-Directs the executor to include this field or fragment only when the `if` argument is true.
-"""
-directive @include(
-  """Included when true."""
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        $introspectionSchema = <<<'GQL'
+            """
+            Directs the executor to include this field or fragment only when the `if` argument is true.
+            """
+            directive @include(
+              """Included when true."""
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""
-Directs the executor to skip this field or fragment when the `if` argument is true.
-"""
-directive @skip(
-  """Skipped when true."""
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            """
+            Directs the executor to skip this field or fragment when the `if` argument is true.
+            """
+            directive @skip(
+              """Skipped when true."""
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""Marks an element of a GraphQL schema as no longer supported."""
-directive @deprecated(
-  """
-  Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).
-  """
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+            """Marks an element of a GraphQL schema as no longer supported."""
+            directive @deprecated(
+              """
+              Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).
+              """
+              reason: String = "No longer supported"
+            ) on FIELD_DEFINITION | ENUM_VALUE
 
-"""
-A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+            """
+            A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
 
-In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
-"""
-type __Directive {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  isRepeatable: Boolean!
-  locations: [__DirectiveLocation!]!
-}
+            In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
+            """
+            type __Directive {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              isRepeatable: Boolean!
+              locations: [__DirectiveLocation!]!
+            }
 
-"""
-A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
-"""
-enum __DirectiveLocation {
-  """Location adjacent to a query operation."""
-  QUERY
+            """
+            A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
+            """
+            enum __DirectiveLocation {
+              """Location adjacent to a query operation."""
+              QUERY
 
-  """Location adjacent to a mutation operation."""
-  MUTATION
+              """Location adjacent to a mutation operation."""
+              MUTATION
 
-  """Location adjacent to a subscription operation."""
-  SUBSCRIPTION
+              """Location adjacent to a subscription operation."""
+              SUBSCRIPTION
 
-  """Location adjacent to a field."""
-  FIELD
+              """Location adjacent to a field."""
+              FIELD
 
-  """Location adjacent to a fragment definition."""
-  FRAGMENT_DEFINITION
+              """Location adjacent to a fragment definition."""
+              FRAGMENT_DEFINITION
 
-  """Location adjacent to a fragment spread."""
-  FRAGMENT_SPREAD
+              """Location adjacent to a fragment spread."""
+              FRAGMENT_SPREAD
 
-  """Location adjacent to an inline fragment."""
-  INLINE_FRAGMENT
+              """Location adjacent to an inline fragment."""
+              INLINE_FRAGMENT
 
-  """Location adjacent to a variable definition."""
-  VARIABLE_DEFINITION
+              """Location adjacent to a variable definition."""
+              VARIABLE_DEFINITION
 
-  """Location adjacent to a schema definition."""
-  SCHEMA
+              """Location adjacent to a schema definition."""
+              SCHEMA
 
-  """Location adjacent to a scalar definition."""
-  SCALAR
+              """Location adjacent to a scalar definition."""
+              SCALAR
 
-  """Location adjacent to an object type definition."""
-  OBJECT
+              """Location adjacent to an object type definition."""
+              OBJECT
 
-  """Location adjacent to a field definition."""
-  FIELD_DEFINITION
+              """Location adjacent to a field definition."""
+              FIELD_DEFINITION
 
-  """Location adjacent to an argument definition."""
-  ARGUMENT_DEFINITION
+              """Location adjacent to an argument definition."""
+              ARGUMENT_DEFINITION
 
-  """Location adjacent to an interface definition."""
-  INTERFACE
+              """Location adjacent to an interface definition."""
+              INTERFACE
 
-  """Location adjacent to a union definition."""
-  UNION
+              """Location adjacent to a union definition."""
+              UNION
 
-  """Location adjacent to an enum definition."""
-  ENUM
+              """Location adjacent to an enum definition."""
+              ENUM
 
-  """Location adjacent to an enum value definition."""
-  ENUM_VALUE
+              """Location adjacent to an enum value definition."""
+              ENUM_VALUE
 
-  """Location adjacent to an input object type definition."""
-  INPUT_OBJECT
+              """Location adjacent to an input object type definition."""
+              INPUT_OBJECT
 
-  """Location adjacent to an input object field definition."""
-  INPUT_FIELD_DEFINITION
-}
+              """Location adjacent to an input object field definition."""
+              INPUT_FIELD_DEFINITION
+            }
 
-"""
-One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
-"""
-type __EnumValue {
-  name: String!
-  description: String
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            """
+            One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
+            """
+            type __EnumValue {
+              name: String!
+              description: String
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-"""
-Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
-"""
-type __Field {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  type: __Type!
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            """
+            Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
+            """
+            type __Field {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              type: __Type!
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-"""
-Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
-"""
-type __InputValue {
-  name: String!
-  description: String
-  type: __Type!
+            """
+            Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
+            """
+            type __InputValue {
+              name: String!
+              description: String
+              type: __Type!
 
-  """
-  A GraphQL-formatted string representing the default value for this input value.
-  """
-  defaultValue: String
-}
+              """
+              A GraphQL-formatted string representing the default value for this input value.
+              """
+              defaultValue: String
+            }
 
-"""
-A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
-"""
-type __Schema {
-  """A list of all types supported by this server."""
-  types: [__Type!]!
+            """
+            A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
+            """
+            type __Schema {
+              """A list of all types supported by this server."""
+              types: [__Type!]!
 
-  """The type that query operations will be rooted at."""
-  queryType: __Type!
+              """The type that query operations will be rooted at."""
+              queryType: __Type!
 
-  """
-  If this server supports mutation, the type that mutation operations will be rooted at.
-  """
-  mutationType: __Type
+              """
+              If this server supports mutation, the type that mutation operations will be rooted at.
+              """
+              mutationType: __Type
 
-  """
-  If this server support subscription, the type that subscription operations will be rooted at.
-  """
-  subscriptionType: __Type
+              """
+              If this server support subscription, the type that subscription operations will be rooted at.
+              """
+              subscriptionType: __Type
 
-  """A list of all directives supported by this server."""
-  directives: [__Directive!]!
-}
+              """A list of all directives supported by this server."""
+              directives: [__Directive!]!
+            }
 
-"""
-The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
+            """
+            The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
 
-Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
-"""
-type __Type {
-  kind: __TypeKind!
-  name: String
-  description: String
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  interfaces: [__Type!]
-  possibleTypes: [__Type!]
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  inputFields: [__InputValue!]
-  ofType: __Type
-}
+            Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+            """
+            type __Type {
+              kind: __TypeKind!
+              name: String
+              description: String
+              fields(includeDeprecated: Boolean = false): [__Field!]
+              interfaces: [__Type!]
+              possibleTypes: [__Type!]
+              enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+              inputFields: [__InputValue!]
+              ofType: __Type
+            }
 
-"""An enum describing what kind of type a given `__Type` is."""
-enum __TypeKind {
-  """Indicates this type is a scalar."""
-  SCALAR
+            """An enum describing what kind of type a given `__Type` is."""
+            enum __TypeKind {
+              """Indicates this type is a scalar."""
+              SCALAR
 
-  """
-  Indicates this type is an object. `fields` and `interfaces` are valid fields.
-  """
-  OBJECT
+              """
+              Indicates this type is an object. `fields` and `interfaces` are valid fields.
+              """
+              OBJECT
 
-  """
-  Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
-  """
-  INTERFACE
+              """
+              Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
+              """
+              INTERFACE
 
-  """Indicates this type is a union. `possibleTypes` is a valid field."""
-  UNION
+              """Indicates this type is a union. `possibleTypes` is a valid field."""
+              UNION
 
-  """Indicates this type is an enum. `enumValues` is a valid field."""
-  ENUM
+              """Indicates this type is an enum. `enumValues` is a valid field."""
+              ENUM
 
-  """
-  Indicates this type is an input object. `inputFields` is a valid field.
-  """
-  INPUT_OBJECT
+              """
+              Indicates this type is an input object. `inputFields` is a valid field.
+              """
+              INPUT_OBJECT
 
-  """Indicates this type is a list. `ofType` is a valid field."""
-  LIST
+              """Indicates this type is a list. `ofType` is a valid field."""
+              LIST
 
-  """Indicates this type is a non-null. `ofType` is a valid field."""
-  NON_NULL
-}
+              """Indicates this type is a non-null. `ofType` is a valid field."""
+              NON_NULL
+            }
 
-EOT;
+            GQL;
         self::assertEquals($introspectionSchema, $output);
     }
 
@@ -1152,203 +1179,203 @@ EOT;
             $schema,
             ['commentDescriptions' => true]
         );
-        $introspectionSchema = <<<'EOT'
-# Directs the executor to include this field or fragment only when the `if` argument is true.
-directive @include(
-  # Included when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        $introspectionSchema = <<<'GQL'
+            # Directs the executor to include this field or fragment only when the `if` argument is true.
+            directive @include(
+              # Included when true.
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Directs the executor to skip this field or fragment when the `if` argument is true.
-directive @skip(
-  # Skipped when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            # Directs the executor to skip this field or fragment when the `if` argument is true.
+            directive @skip(
+              # Skipped when true.
+              if: Boolean!
+            ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Marks an element of a GraphQL schema as no longer supported.
-directive @deprecated(
-  # Explains why this element was deprecated, usually also including a suggestion
-  # for how to access supported similar data. Formatted using the Markdown syntax
-  # (as specified by [CommonMark](https://commonmark.org/).
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+            # Marks an element of a GraphQL schema as no longer supported.
+            directive @deprecated(
+              # Explains why this element was deprecated, usually also including a suggestion
+              # for how to access supported similar data. Formatted using the Markdown syntax
+              # (as specified by [CommonMark](https://commonmark.org/).
+              reason: String = "No longer supported"
+            ) on FIELD_DEFINITION | ENUM_VALUE
 
-# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
-#
-# In some cases, you need to provide options to alter GraphQL's execution behavior
-# in ways field arguments will not suffice, such as conditionally including or
-# skipping a field. Directives provide this by describing additional information
-# to the executor.
-type __Directive {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  isRepeatable: Boolean!
-  locations: [__DirectiveLocation!]!
-}
+            # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+            #
+            # In some cases, you need to provide options to alter GraphQL's execution behavior
+            # in ways field arguments will not suffice, such as conditionally including or
+            # skipping a field. Directives provide this by describing additional information
+            # to the executor.
+            type __Directive {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              isRepeatable: Boolean!
+              locations: [__DirectiveLocation!]!
+            }
 
-# A Directive can be adjacent to many parts of the GraphQL language, a
-# __DirectiveLocation describes one such possible adjacencies.
-enum __DirectiveLocation {
-  # Location adjacent to a query operation.
-  QUERY
+            # A Directive can be adjacent to many parts of the GraphQL language, a
+            # __DirectiveLocation describes one such possible adjacencies.
+            enum __DirectiveLocation {
+              # Location adjacent to a query operation.
+              QUERY
 
-  # Location adjacent to a mutation operation.
-  MUTATION
+              # Location adjacent to a mutation operation.
+              MUTATION
 
-  # Location adjacent to a subscription operation.
-  SUBSCRIPTION
+              # Location adjacent to a subscription operation.
+              SUBSCRIPTION
 
-  # Location adjacent to a field.
-  FIELD
+              # Location adjacent to a field.
+              FIELD
 
-  # Location adjacent to a fragment definition.
-  FRAGMENT_DEFINITION
+              # Location adjacent to a fragment definition.
+              FRAGMENT_DEFINITION
 
-  # Location adjacent to a fragment spread.
-  FRAGMENT_SPREAD
+              # Location adjacent to a fragment spread.
+              FRAGMENT_SPREAD
 
-  # Location adjacent to an inline fragment.
-  INLINE_FRAGMENT
+              # Location adjacent to an inline fragment.
+              INLINE_FRAGMENT
 
-  # Location adjacent to a variable definition.
-  VARIABLE_DEFINITION
+              # Location adjacent to a variable definition.
+              VARIABLE_DEFINITION
 
-  # Location adjacent to a schema definition.
-  SCHEMA
+              # Location adjacent to a schema definition.
+              SCHEMA
 
-  # Location adjacent to a scalar definition.
-  SCALAR
+              # Location adjacent to a scalar definition.
+              SCALAR
 
-  # Location adjacent to an object type definition.
-  OBJECT
+              # Location adjacent to an object type definition.
+              OBJECT
 
-  # Location adjacent to a field definition.
-  FIELD_DEFINITION
+              # Location adjacent to a field definition.
+              FIELD_DEFINITION
 
-  # Location adjacent to an argument definition.
-  ARGUMENT_DEFINITION
+              # Location adjacent to an argument definition.
+              ARGUMENT_DEFINITION
 
-  # Location adjacent to an interface definition.
-  INTERFACE
+              # Location adjacent to an interface definition.
+              INTERFACE
 
-  # Location adjacent to a union definition.
-  UNION
+              # Location adjacent to a union definition.
+              UNION
 
-  # Location adjacent to an enum definition.
-  ENUM
+              # Location adjacent to an enum definition.
+              ENUM
 
-  # Location adjacent to an enum value definition.
-  ENUM_VALUE
+              # Location adjacent to an enum value definition.
+              ENUM_VALUE
 
-  # Location adjacent to an input object type definition.
-  INPUT_OBJECT
+              # Location adjacent to an input object type definition.
+              INPUT_OBJECT
 
-  # Location adjacent to an input object field definition.
-  INPUT_FIELD_DEFINITION
-}
+              # Location adjacent to an input object field definition.
+              INPUT_FIELD_DEFINITION
+            }
 
-# One possible value for a given Enum. Enum values are unique values, not a
-# placeholder for a string or numeric value. However an Enum value is returned in
-# a JSON response as a string.
-type __EnumValue {
-  name: String!
-  description: String
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            # One possible value for a given Enum. Enum values are unique values, not a
+            # placeholder for a string or numeric value. However an Enum value is returned in
+            # a JSON response as a string.
+            type __EnumValue {
+              name: String!
+              description: String
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-# Object and Interface types are described by a list of Fields, each of which has
-# a name, potentially a list of arguments, and a return type.
-type __Field {
-  name: String!
-  description: String
-  args: [__InputValue!]!
-  type: __Type!
-  isDeprecated: Boolean!
-  deprecationReason: String
-}
+            # Object and Interface types are described by a list of Fields, each of which has
+            # a name, potentially a list of arguments, and a return type.
+            type __Field {
+              name: String!
+              description: String
+              args: [__InputValue!]!
+              type: __Type!
+              isDeprecated: Boolean!
+              deprecationReason: String
+            }
 
-# Arguments provided to Fields or Directives and the input fields of an
-# InputObject are represented as Input Values which describe their type and
-# optionally a default value.
-type __InputValue {
-  name: String!
-  description: String
-  type: __Type!
+            # Arguments provided to Fields or Directives and the input fields of an
+            # InputObject are represented as Input Values which describe their type and
+            # optionally a default value.
+            type __InputValue {
+              name: String!
+              description: String
+              type: __Type!
 
-  # A GraphQL-formatted string representing the default value for this input value.
-  defaultValue: String
-}
+              # A GraphQL-formatted string representing the default value for this input value.
+              defaultValue: String
+            }
 
-# A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-# available types and directives on the server, as well as the entry points for
-# query, mutation, and subscription operations.
-type __Schema {
-  # A list of all types supported by this server.
-  types: [__Type!]!
+            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+            # available types and directives on the server, as well as the entry points for
+            # query, mutation, and subscription operations.
+            type __Schema {
+              # A list of all types supported by this server.
+              types: [__Type!]!
 
-  # The type that query operations will be rooted at.
-  queryType: __Type!
+              # The type that query operations will be rooted at.
+              queryType: __Type!
 
-  # If this server supports mutation, the type that mutation operations will be rooted at.
-  mutationType: __Type
+              # If this server supports mutation, the type that mutation operations will be rooted at.
+              mutationType: __Type
 
-  # If this server support subscription, the type that subscription operations will be rooted at.
-  subscriptionType: __Type
+              # If this server support subscription, the type that subscription operations will be rooted at.
+              subscriptionType: __Type
 
-  # A list of all directives supported by this server.
-  directives: [__Directive!]!
-}
+              # A list of all directives supported by this server.
+              directives: [__Directive!]!
+            }
 
-# The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-# types in GraphQL as represented by the `__TypeKind` enum.
-#
-# Depending on the kind of a type, certain fields describe information about that
-# type. Scalar types provide no information beyond a name and description, while
-# Enum types provide their values. Object and Interface types provide the fields
-# they describe. Abstract types, Union and Interface, provide the Object types
-# possible at runtime. List and NonNull types compose other types.
-type __Type {
-  kind: __TypeKind!
-  name: String
-  description: String
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  interfaces: [__Type!]
-  possibleTypes: [__Type!]
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  inputFields: [__InputValue!]
-  ofType: __Type
-}
+            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
+            # types in GraphQL as represented by the `__TypeKind` enum.
+            #
+            # Depending on the kind of a type, certain fields describe information about that
+            # type. Scalar types provide no information beyond a name and description, while
+            # Enum types provide their values. Object and Interface types provide the fields
+            # they describe. Abstract types, Union and Interface, provide the Object types
+            # possible at runtime. List and NonNull types compose other types.
+            type __Type {
+              kind: __TypeKind!
+              name: String
+              description: String
+              fields(includeDeprecated: Boolean = false): [__Field!]
+              interfaces: [__Type!]
+              possibleTypes: [__Type!]
+              enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+              inputFields: [__InputValue!]
+              ofType: __Type
+            }
 
-# An enum describing what kind of type a given `__Type` is.
-enum __TypeKind {
-  # Indicates this type is a scalar.
-  SCALAR
+            # An enum describing what kind of type a given `__Type` is.
+            enum __TypeKind {
+              # Indicates this type is a scalar.
+              SCALAR
 
-  # Indicates this type is an object. `fields` and `interfaces` are valid fields.
-  OBJECT
+              # Indicates this type is an object. `fields` and `interfaces` are valid fields.
+              OBJECT
 
-  # Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
-  INTERFACE
+              # Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
+              INTERFACE
 
-  # Indicates this type is a union. `possibleTypes` is a valid field.
-  UNION
+              # Indicates this type is a union. `possibleTypes` is a valid field.
+              UNION
 
-  # Indicates this type is an enum. `enumValues` is a valid field.
-  ENUM
+              # Indicates this type is an enum. `enumValues` is a valid field.
+              ENUM
 
-  # Indicates this type is an input object. `inputFields` is a valid field.
-  INPUT_OBJECT
+              # Indicates this type is an input object. `inputFields` is a valid field.
+              INPUT_OBJECT
 
-  # Indicates this type is a list. `ofType` is a valid field.
-  LIST
+              # Indicates this type is a list. `ofType` is a valid field.
+              LIST
 
-  # Indicates this type is a non-null. `ofType` is a valid field.
-  NON_NULL
-}
+              # Indicates this type is a non-null. `ofType` is a valid field.
+              NON_NULL
+            }
 
-EOT;
+            GQL;
         self::assertEquals($introspectionSchema, $output);
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -526,8 +526,8 @@ class SchemaPrinterTest extends TestCase
             'fields' => ['str' => ['type' => Type::string()]],
         ]);
 
-        $baazType = new InterfaceType([
-            'name'   => 'Baaz',
+        $bazType = new InterfaceType([
+            'name'   => 'Baz',
             'fields' => ['int' => ['type' => Type::int()]],
         ]);
 
@@ -537,7 +537,7 @@ class SchemaPrinterTest extends TestCase
                 'str' => ['type' => Type::string()],
                 'int' => ['type' => Type::int()],
             ],
-            'interfaces' => [$fooType, $baazType],
+            'interfaces' => [$fooType, $bazType],
         ]);
 
         $schema = new Schema(['types' => [$barType]]);
@@ -545,12 +545,12 @@ class SchemaPrinterTest extends TestCase
         // the expected SDL differs from graphql-js: https://github.com/webonyx/graphql-php/issues/954
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
-            interface Baaz {
+            type Bar implements Foo & Baz {
+              str: String
               int: Int
             }
 
-            type Bar implements Foo & Baaz {
-              str: String
+            interface Baz {
               int: Int
             }
 
@@ -573,8 +573,8 @@ class SchemaPrinterTest extends TestCase
             'fields' => ['str' => ['type' => Type::string()]],
         ]);
 
-        $BaazType = new InterfaceType([
-            'name'       => 'Baaz',
+        $BazType = new InterfaceType([
+            'name'       => 'Baz',
             'interfaces' => [$FooType],
             'fields'     => [
                 'int' => ['type' => Type::int()],
@@ -588,7 +588,7 @@ class SchemaPrinterTest extends TestCase
                 'str' => ['type' => Type::string()],
                 'int' => ['type' => Type::int()],
             ],
-            'interfaces' => [$FooType, $BaazType],
+            'interfaces' => [$FooType, $BazType],
         ]);
 
         $query = new ObjectType([
@@ -604,14 +604,14 @@ class SchemaPrinterTest extends TestCase
         // the expected SDL differs from graphql-js: https://github.com/webonyx/graphql-php/issues/954
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
-            interface Baaz implements Foo {
-              int: Int
+            type Bar implements Foo & Baz {
               str: String
+              int: Int
             }
 
-            type Bar implements Foo & Baaz {
-              str: String
+            interface Baz implements Foo {
               int: Int
+              str: String
             }
 
             interface Foo {

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1104,18 +1104,13 @@ class SchemaPrinterTest extends TestCase
 
             # Marks an element of a GraphQL schema as no longer supported.
             directive @deprecated(
-              # Explains why this element was deprecated, usually also including a suggestion
-              # for how to access supported similar data. Formatted using the Markdown syntax
-              # (as specified by [CommonMark](https://commonmark.org/).
+              # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).
               reason: String = "No longer supported"
             ) on FIELD_DEFINITION | ENUM_VALUE
 
             # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
             #
-            # In some cases, you need to provide options to alter GraphQL's execution behavior
-            # in ways field arguments will not suffice, such as conditionally including or
-            # skipping a field. Directives provide this by describing additional information
-            # to the executor.
+            # In some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.
             type __Directive {
               name: String!
               description: String
@@ -1124,8 +1119,7 @@ class SchemaPrinterTest extends TestCase
               locations: [__DirectiveLocation!]!
             }
 
-            # A Directive can be adjacent to many parts of the GraphQL language, a
-            # __DirectiveLocation describes one such possible adjacencies.
+            # A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
             enum __DirectiveLocation {
               # Location adjacent to a query operation.
               QUERY
@@ -1185,9 +1179,7 @@ class SchemaPrinterTest extends TestCase
               INPUT_FIELD_DEFINITION
             }
 
-            # One possible value for a given Enum. Enum values are unique values, not a
-            # placeholder for a string or numeric value. However an Enum value is returned in
-            # a JSON response as a string.
+            # One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
             type __EnumValue {
               name: String!
               description: String
@@ -1195,8 +1187,7 @@ class SchemaPrinterTest extends TestCase
               deprecationReason: String
             }
 
-            # Object and Interface types are described by a list of Fields, each of which has
-            # a name, potentially a list of arguments, and a return type.
+            # Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
             type __Field {
               name: String!
               description: String
@@ -1206,9 +1197,7 @@ class SchemaPrinterTest extends TestCase
               deprecationReason: String
             }
 
-            # Arguments provided to Fields or Directives and the input fields of an
-            # InputObject are represented as Input Values which describe their type and
-            # optionally a default value.
+            # Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
             type __InputValue {
               name: String!
               description: String
@@ -1218,9 +1207,7 @@ class SchemaPrinterTest extends TestCase
               defaultValue: String
             }
 
-            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-            # available types and directives on the server, as well as the entry points for
-            # query, mutation, and subscription operations.
+            # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
             type __Schema {
               # A list of all types supported by this server.
               types: [__Type!]!
@@ -1238,14 +1225,9 @@ class SchemaPrinterTest extends TestCase
               directives: [__Directive!]!
             }
 
-            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-            # types in GraphQL as represented by the `__TypeKind` enum.
+            # The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
             #
-            # Depending on the kind of a type, certain fields describe information about that
-            # type. Scalar types provide no information beyond a name and description, while
-            # Enum types provide their values. Object and Interface types provide the fields
-            # they describe. Abstract types, Union and Interface, provide the Object types
-            # possible at runtime. List and NonNull types compose other types.
+            # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
             type __Type {
               kind: __TypeKind!
               name: String

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -24,10 +24,10 @@ class SchemaPrinterTest extends TestCase
     private static function assertPrintedSchemaEquals(string $expected, Schema $schema): void
     {
         $printedSchema = SchemaPrinter::doPrint($schema);
-        self::assertEquals($expected, $printedSchema);
+        $cycledSchema  = SchemaPrinter::doPrint(BuildSchema::build($printedSchema));
 
-        $cycledSchema = SchemaPrinter::doPrint(BuildSchema::build($printedSchema));
         self::assertEquals($printedSchema, $cycledSchema);
+        self::assertEquals($expected, $printedSchema);
     }
 
     /** @param array<string, mixed> $fieldConfig */

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -21,6 +21,25 @@ use PHPUnit\Framework\TestCase;
 
 class SchemaPrinterTest extends TestCase
 {
+    /** @param array<string, mixed> $fieldConfig */
+    private function printSingleFieldSchema(array $fieldConfig): string
+    {
+        $query = new ObjectType([
+            'name'   => 'Query',
+            'fields' => ['singleField' => $fieldConfig],
+        ]);
+
+        return $this->printForTest(new Schema(['query' => $query]));
+    }
+
+    private function printForTest(Schema $schema): string
+    {
+        $schemaText = SchemaPrinter::doPrint($schema);
+        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
+
+        return "\n" . $schemaText;
+    }
+
     // Describe: Type System Printer
 
     /**
@@ -39,24 +58,6 @@ type Query {
 ',
             $output
         );
-    }
-
-    private function printSingleFieldSchema($fieldConfig)
-    {
-        $query = new ObjectType([
-            'name'   => 'Query',
-            'fields' => ['singleField' => $fieldConfig],
-        ]);
-
-        return $this->printForTest(new Schema(['query' => $query]));
-    }
-
-    private function printForTest($schema)
-    {
-        $schemaText = SchemaPrinter::doPrint($schema);
-        self::assertEquals($schemaText, SchemaPrinter::doPrint(BuildSchema::build($schemaText)));
-
-        return "\n" . $schemaText;
     }
 
     /**

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -151,7 +151,7 @@ type Query {
     }
 
     /**
-     * @see it('Prints Field With "@deprecated" Directive')
+     * @see https://github.com/webonyx/graphql-php/pull/631
      *
      * @dataProvider deprecationReasonDataProvider
      */


### PR DESCRIPTION
Supersedes #941. Aligns `SchemaPrinterTest.php` with `printSchema-test.js` from the reference implementation v15.5 as much as possible.

Relevant changes in `graphql-js`:
- https://github.com/graphql/graphql-js/commit/34b7ced883ff813a1d2d13c5fd58ba8158d69b60
- https://github.com/graphql/graphql-js/commit/4fcef75248a3db75da6080ed889ea2ce26a29928
- https://github.com/graphql/graphql-js/commit/ea089e016f1526fb5b5137b5f8a8739ec17b322c

TBD:
- [ ] different order of printed types (interfaces, unions) – #954
- [ ] outdated introspection
- [ ] schema with description
- [ ] `@specifiedBy` directive

In addition, this also updates the printing of legacy comment descriptions omitted in #938.