### PR TITLE
Use PHPStan type alias for options in `SchemaPrinter`

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -37,16 +37,18 @@ use function str_replace;
 use function strlen;
 
 /**
- * Given an instance of Schema, prints it in schema definition language.
+ * Prints the contents of a Schema in schema definition language.
+ *
+ * @phpstan-type Options array{commentDescriptions?: bool}
+ *    Available options:
+ *    - commentDescriptions:
+ *        Provide true to use preceding comments as the description.
+ *        This option is provided to ease adoption and will be removed in v16.
  */
 class SchemaPrinter
 {
     /**
-     * @param array<string, bool> $options
-     *    Available options:
-     *    - commentDescriptions:
-     *        Provide true to use preceding comments as the description.
-     *        This option is provided to ease adoption and will be removed in v16.
+     * @param Options $options
      *
      * @api
      */
@@ -65,9 +67,9 @@ class SchemaPrinter
     }
 
     /**
-     * @param callable(Directive  $directive): bool $directiveFilter
-     * @param callable(Type       $type):      bool $typeFilter
-     * @param array<string, bool> $options
+     * @param callable(Directive $directive): bool $directiveFilter
+     * @param callable(Type      $type):      bool $typeFilter
+     * @param Options            $options
      */
     protected static function printFilteredSchema(Schema $schema, callable $directiveFilter, callable $typeFilter, array $options): string
     {
@@ -146,7 +148,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printDirective(Directive $directive, array $options): string
     {
@@ -248,7 +250,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     public static function printType(Type $type, array $options = []): string
     {
@@ -280,7 +282,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printScalar(ScalarType $type, array $options): string
     {
@@ -288,7 +290,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printObject(ObjectType $type, array $options): string
     {
@@ -356,7 +358,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printInterface(InterfaceType $type, array $options): string
     {
@@ -367,7 +369,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printUnion(UnionType $type, array $options): string
     {
@@ -380,7 +382,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printEnum(EnumType $type, array $options): string
     {
@@ -402,7 +404,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      */
     protected static function printInputObject(InputObjectType $type, array $options): string
     {
@@ -421,7 +423,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param array<string, bool> $options
+     * @param Options $options
      *
      * @api
      */

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -48,7 +48,8 @@ use function strlen;
 class SchemaPrinter
 {
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      *
      * @api
      */
@@ -67,9 +68,59 @@ class SchemaPrinter
     }
 
     /**
-     * @param callable(Directive $directive): bool $directiveFilter
-     * @param callable(Type      $type):      bool $typeFilter
-     * @param Options            $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
+     *
+     * @api
+     */
+    public static function printIntrospectionSchema(Schema $schema, array $options = []): string
+    {
+        return static::printFilteredSchema(
+            $schema,
+            [Directive::class, 'isSpecifiedDirective'],
+            [Introspection::class, 'isIntrospectionType'],
+            $options
+        );
+    }
+
+    /**
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
+     */
+    public static function printType(Type $type, array $options = []): string
+    {
+        if ($type instanceof ScalarType) {
+            return static::printScalar($type, $options);
+        }
+
+        if ($type instanceof ObjectType) {
+            return static::printObject($type, $options);
+        }
+
+        if ($type instanceof InterfaceType) {
+            return static::printInterface($type, $options);
+        }
+
+        if ($type instanceof UnionType) {
+            return static::printUnion($type, $options);
+        }
+
+        if ($type instanceof EnumType) {
+            return static::printEnum($type, $options);
+        }
+
+        if ($type instanceof InputObjectType) {
+            return static::printInputObject($type, $options);
+        }
+
+        throw new Error(sprintf('Unknown type: %s.', Utils::printSafe($type)));
+    }
+
+    /**
+     * @param callable(Directive  $directive): bool $directiveFilter
+     * @param callable(Type       $type):      bool $typeFilter
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printFilteredSchema(Schema $schema, callable $directiveFilter, callable $typeFilter, array $options): string
     {
@@ -148,7 +199,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printDirective(Directive $directive, array $options): string
     {
@@ -200,6 +252,7 @@ class SchemaPrinter
     /**
      * @param array<string, bool>       $options
      * @param array<int, FieldArgument> $args
+     * @phpstan-param Options $options
      */
     protected static function printArgs(array $options, array $args, string $indentation = ''): string
     {
@@ -250,39 +303,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
-     */
-    public static function printType(Type $type, array $options = []): string
-    {
-        if ($type instanceof ScalarType) {
-            return static::printScalar($type, $options);
-        }
-
-        if ($type instanceof ObjectType) {
-            return static::printObject($type, $options);
-        }
-
-        if ($type instanceof InterfaceType) {
-            return static::printInterface($type, $options);
-        }
-
-        if ($type instanceof UnionType) {
-            return static::printUnion($type, $options);
-        }
-
-        if ($type instanceof EnumType) {
-            return static::printEnum($type, $options);
-        }
-
-        if ($type instanceof InputObjectType) {
-            return static::printInputObject($type, $options);
-        }
-
-        throw new Error(sprintf('Unknown type: %s.', Utils::printSafe($type)));
-    }
-
-    /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printScalar(ScalarType $type, array $options): string
     {
@@ -290,7 +312,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printObject(ObjectType $type, array $options): string
     {
@@ -303,6 +326,7 @@ class SchemaPrinter
     /**
      * @param array<string, bool>      $options
      * @param ObjectType|InterfaceType $type
+     * @phpstan-param Options $options
      */
     protected static function printFields(array $options, $type): string
     {
@@ -358,7 +382,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printInterface(InterfaceType $type, array $options): string
     {
@@ -369,7 +394,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printUnion(UnionType $type, array $options): string
     {
@@ -382,7 +408,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printEnum(EnumType $type, array $options): string
     {
@@ -404,7 +431,8 @@ class SchemaPrinter
     }
 
     /**
-     * @param Options $options
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
      */
     protected static function printInputObject(InputObjectType $type, array $options): string
     {
@@ -420,21 +448,6 @@ class SchemaPrinter
         return static::printDescription($options, $type) .
             sprintf('input %s', $type->name) .
             static::printBlock($fields);
-    }
-
-    /**
-     * @param Options $options
-     *
-     * @api
-     */
-    public static function printIntrospectionSchema(Schema $schema, array $options = []): string
-    {
-        return static::printFilteredSchema(
-            $schema,
-            [Directive::class, 'isSpecifiedDirective'],
-            [Introspection::class, 'isIntrospectionType'],
-            $options
-        );
     }
 
     /**


### PR DESCRIPTION
This is a cherry-pick of @spawnia's changes from #941 that utilises `@phpstan-type` for options in  `SchemaPrinter`.

This PR is also to document the official intention of using PHPStan's [local type aliases](https://phpstan.org/writing-php-code/phpdoc-types#local-type-aliases) (`@phpstan-type` and `@phpstan-import-type`) and inherently [array shapes](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes) in the `graphql-php`'s codebase.

Both `@phpstan-type` and `@phpstan-import-type` are [supported](https://github.com/vimeo/psalm/commit/39e61ae942be9937bc877d2c2c69ba905507613f) by Psalm but there is no support yet in PHPStorm (vote in [WI-55929](https://youtrack.jetbrains.com/issue/WI-55929) and [WI-55928](https://youtrack.jetbrains.com/issue/WI-55928)).

PHPStorm's support for array shapes is currently [limited to one-line definitions only](https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/#array_shapes_phpdoc_syntax_support) (vote in [WI-56038](https://youtrack.jetbrains.com/issue/WI-56038)).

It's also important to note that array shapes in PHPStan are rather primitive; they can't be used for more advanced typing. Probably the biggest limitation is that two [array shapes can't be merged](https://github.com/phpstan/phpstan/issues/3931#issuecomment-921752417). Another important missing feature is support for additional arbitrary keys (an equivalent of TypeScript's `type X = {[k: string]: any}`). Both problems are related to phpstan/phpstan#4703.

Because of these limitations, and to support other tools and IDEs that don't understand `@phpstan-type`, it might be good to use `@phpstan-return` and `@phpstan-param` when referencing `@phpstan-type` (or using array shapes?) and `@return` and `@param` as a fallback. At least in the public API. For example:

```php
/**
 * @phpstan-type Options array{commentDescriptions?: bool}
 */
class SchemaPrinter
{
    /**
     * @phpstan-param Options $options
     * @param array<string, bool> $options
     *
     * @api
     */
    public static function doPrint(Schema $schema, array $options = []): string
    {
        // ...
    }
}
```

What do you think @spawnia and @simPod?