### PR TITLE
Extract check for unique operation types into separate rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `AST::concatAST()` utility
 - Allow lazy input object fields
 - Add validation rule `UniqueEnumValueNames`
+- Add SDL validation rule `UniqueOperationTypes` (#995)
 
 ### Optimized
 

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -226,10 +226,6 @@ class BuildSchema
             $typeName  = $operationType->type->name->value;
             $operation = $operationType->operation;
 
-            if (isset($opTypes[$operation])) {
-                throw new Error('Must provide only one ' . $operation . ' type in schema.');
-            }
-
             if (! isset($this->nodeMap[$typeName])) {
                 throw new Error('Specified ' . $operation . ' type "' . $typeName . '" not found in document.');
             }

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -620,14 +620,7 @@ class SchemaExtender
 
         if ($schemaDef !== null) {
             foreach ($schemaDef->operationTypes as $operationType) {
-                $operation = $operationType->operation;
-                $type      = $operationType->type;
-
-                if (isset($operationTypes[$operation])) {
-                    throw new Error('Must provide only one ' . $operation . ' type in schema.');
-                }
-
-                $operationTypes[$operation] = static::$astBuilder->buildType($type);
+                $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
             }
         }
 
@@ -637,12 +630,7 @@ class SchemaExtender
             }
 
             foreach ($schemaExtension->operationTypes as $operationType) {
-                $operation = $operationType->operation;
-                if (isset($operationTypes[$operation])) {
-                    throw new Error('Must provide only one ' . $operation . ' type in schema.');
-                }
-
-                $operationTypes[$operation] = static::$astBuilder->buildType($operationType->type);
+                $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
             }
         }
 

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -39,6 +39,7 @@ use GraphQL\Validator\Rules\UniqueDirectivesPerLocation;
 use GraphQL\Validator\Rules\UniqueFragmentNames;
 use GraphQL\Validator\Rules\UniqueInputFieldNames;
 use GraphQL\Validator\Rules\UniqueOperationNames;
+use GraphQL\Validator\Rules\UniqueOperationTypes;
 use GraphQL\Validator\Rules\UniqueVariableNames;
 use GraphQL\Validator\Rules\ValidationRule;
 use GraphQL\Validator\Rules\ValuesOfCorrectType;
@@ -197,6 +198,7 @@ class DocumentValidator
         if (self::$sdlRules === null) {
             self::$sdlRules = [
                 LoneSchemaDefinition::class                  => new LoneSchemaDefinition(),
+                UniqueOperationTypes::class                  => new UniqueOperationTypes(),
                 KnownDirectives::class                       => new KnownDirectives(),
                 KnownArgumentNamesOnDirectives::class        => new KnownArgumentNamesOnDirectives(),
                 UniqueDirectivesPerLocation::class           => new UniqueDirectivesPerLocation(),

--- a/src/Validator/Rules/UniqueOperationTypes.php
+++ b/src/Validator/Rules/UniqueOperationTypes.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace GraphQL\Validator\Rules;
 
 use GraphQL\Error\Error;
-use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\SchemaDefinitionNode;
 use GraphQL\Language\AST\SchemaTypeExtensionNode;
 use GraphQL\Language\Visitor;
 use GraphQL\Language\VisitorOperation;
 use GraphQL\Validator\SDLValidationContext;
-use TypeError;
 
 /**
  * Unique operation types
@@ -36,11 +34,7 @@ class UniqueOperationTypes extends ValidationRule
         /**
          * @param SchemaDefinitionNode|SchemaTypeExtensionNode $node
          */
-        $checkOperationTypes = static function (Node $node) use ($context, &$definedOperationTypes, $existingOperationTypes): VisitorOperation {
-            if (! $node instanceof SchemaDefinitionNode && ! $node instanceof SchemaTypeExtensionNode) {
-                throw new TypeError('Expected $node to be ' . SchemaDefinitionNode::class . ' or ' . SchemaTypeExtensionNode::class . '.');
-            }
-
+        $checkOperationTypes = static function ($node) use ($context, &$definedOperationTypes, $existingOperationTypes): VisitorOperation {
             foreach ($node->operationTypes as $operationType) {
                 $operation                   = $operationType->operation;
                 $alreadyDefinedOperationType = $definedOperationTypes[$operation] ?? null;

--- a/src/Validator/Rules/UniqueOperationTypes.php
+++ b/src/Validator/Rules/UniqueOperationTypes.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace GraphQL\Validator\Rules;
 
 use GraphQL\Error\Error;
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\SchemaDefinitionNode;
 use GraphQL\Language\AST\SchemaTypeExtensionNode;
 use GraphQL\Language\Visitor;
 use GraphQL\Language\VisitorOperation;
 use GraphQL\Validator\SDLValidationContext;
+use TypeError;
 
 /**
  * Unique operation types
@@ -34,7 +36,11 @@ class UniqueOperationTypes extends ValidationRule
         /**
          * @param SchemaDefinitionNode|SchemaTypeExtensionNode $node
          */
-        $checkOperationTypes = static function ($node) use ($context, &$definedOperationTypes, $existingOperationTypes): VisitorOperation {
+        $checkOperationTypes = static function (Node $node) use ($context, &$definedOperationTypes, $existingOperationTypes): VisitorOperation {
+            if (! $node instanceof SchemaDefinitionNode && ! $node instanceof SchemaTypeExtensionNode) {
+                throw new TypeError('Expected $node to be ' . SchemaDefinitionNode::class . ' or ' . SchemaTypeExtensionNode::class . '.');
+            }
+
             $operationTypesNodes = $node->operationTypes;
             foreach ($operationTypesNodes as $operationType) {
                 $operation                    = $operationType->operation;

--- a/src/Validator/Rules/UniqueOperationTypes.php
+++ b/src/Validator/Rules/UniqueOperationTypes.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Validator\Rules;
+
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\SchemaDefinitionNode;
+use GraphQL\Language\AST\SchemaTypeExtensionNode;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorOperation;
+use GraphQL\Validator\SDLValidationContext;
+
+/**
+ * Unique operation types
+ *
+ * A GraphQL document is only valid if it has only one type per operation.
+ */
+class UniqueOperationTypes extends ValidationRule
+{
+    public function getSDLVisitor(SDLValidationContext $context): array
+    {
+        $schema                 = $context->getSchema();
+        $definedOperationTypes  = [];
+        $existingOperationTypes = $schema !== null
+            ? [
+                'query' => $schema->getQueryType(),
+                'mutation' => $schema->getMutationType(),
+                'subscription' => $schema->getSubscriptionType(),
+            ]
+            : [];
+
+        /**
+         * @param SchemaDefinitionNode|SchemaTypeExtensionNode $node
+         */
+        $checkOperationTypes = static function ($node) use ($context, &$definedOperationTypes, $existingOperationTypes): VisitorOperation {
+            $operationTypesNodes = $node->operationTypes;
+            foreach ($operationTypesNodes as $operationType) {
+                $operation                    = $operationType->operation;
+                $alreadyDefinedOperationType  = $definedOperationTypes[$operation] ?? null;
+                $alreadyExistingOperationType = $existingOperationTypes[$operation] ?? null;
+
+                if ($alreadyExistingOperationType !== null) {
+                    $context->reportError(
+                        new Error(
+                            "Type for ${operation} already defined in the schema. It cannot be redefined.",
+                            $operationType,
+                        ),
+                    );
+                } elseif ($alreadyDefinedOperationType !== null) {
+                    $context->reportError(
+                        new Error(
+                            "There can be only one ${operation} type in schema.",
+                            [$alreadyDefinedOperationType, $operationType],
+                        ),
+                    );
+                } else {
+                    $definedOperationTypes[$operation] = $operationType;
+                }
+            }
+
+            return Visitor::skipNode();
+        };
+
+        return [
+            NodeKind::SCHEMA_DEFINITION => $checkOperationTypes,
+            NodeKind::SCHEMA_EXTENSION => $checkOperationTypes,
+        ];
+    }
+}

--- a/src/Validator/Rules/UniqueOperationTypes.php
+++ b/src/Validator/Rules/UniqueOperationTypes.php
@@ -41,13 +41,11 @@ class UniqueOperationTypes extends ValidationRule
                 throw new TypeError('Expected $node to be ' . SchemaDefinitionNode::class . ' or ' . SchemaTypeExtensionNode::class . '.');
             }
 
-            $operationTypesNodes = $node->operationTypes;
-            foreach ($operationTypesNodes as $operationType) {
-                $operation                    = $operationType->operation;
-                $alreadyDefinedOperationType  = $definedOperationTypes[$operation] ?? null;
-                $alreadyExistingOperationType = $existingOperationTypes[$operation] ?? null;
+            foreach ($node->operationTypes as $operationType) {
+                $operation                   = $operationType->operation;
+                $alreadyDefinedOperationType = $definedOperationTypes[$operation] ?? null;
 
-                if ($alreadyExistingOperationType !== null) {
+                if (isset($existingOperationTypes[$operation])) {
                     $context->reportError(
                         new Error(
                             "Type for ${operation} already defined in the schema. It cannot be redefined.",

--- a/tests/Utils/BuildSchemaLegacyTest.php
+++ b/tests/Utils/BuildSchemaLegacyTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
  * but these changes to `graphql-js` haven't been reflected in `graphql-php` yet.
  * TODO align with:
  *   - https://github.com/graphql/graphql-js/commit/257797a0ebdddd3da6e75b7c237fdc12a1a7c75a
- *   - https://github.com/graphql/graphql-js/commit/9b7a8af43fc0865a01df5b5a084f37bbb8680ef8
  *   - https://github.com/graphql/graphql-js/commit/3b9ea61f2348215dee755f779caef83df749d2bb
  *   - https://github.com/graphql/graphql-js/commit/64a5c3448a201737f9218856786c51d66f2deabd
  */
@@ -151,83 +150,6 @@ class BuildSchemaLegacyTest extends TestCase
     }
 
     // Describe: Failures
-
-    /**
-     * @see it('Allows only a single query type')
-     */
-    public function testAllowsOnlySingleQueryType(): void
-    {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Must provide only one query type in schema.');
-        $sdl = '
-            schema {
-              query: Hello
-              query: Yellow
-            }
-            
-            type Hello {
-              bar: String
-            }
-            
-            type Yellow {
-              isColor: Boolean
-            }
-        ';
-        $doc = Parser::parse($sdl);
-        BuildSchema::buildAST($doc);
-    }
-
-    /**
-     * @see it('Allows only a single mutation type')
-     */
-    public function testAllowsOnlySingleMutationType(): void
-    {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Must provide only one mutation type in schema.');
-        $sdl = '
-            schema {
-              query: Hello
-              mutation: Hello
-              mutation: Yellow
-            }
-            
-            type Hello {
-              bar: String
-            }
-            
-            type Yellow {
-              isColor: Boolean
-            }
-        ';
-        $doc = Parser::parse($sdl);
-        BuildSchema::buildAST($doc);
-    }
-
-    /**
-     * @see it('Allows only a single subscription type')
-     */
-    public function testAllowsOnlySingleSubscriptionType(): void
-    {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage('Must provide only one subscription type in schema.');
-        $sdl = '
-            schema {
-              query: Hello
-              subscription: Hello
-              subscription: Yellow
-            }
-            
-            type Hello {
-              bar: String
-            }
-            
-            type Yellow {
-              isColor: Boolean
-            }
-        ';
-        $doc = Parser::parse($sdl);
-        BuildSchema::buildAST($doc);
-    }
 
     /**
      * @see it('Unknown type referenced')

--- a/tests/Utils/SchemaExtenderLegacyTest.php
+++ b/tests/Utils/SchemaExtenderLegacyTest.php
@@ -36,7 +36,6 @@ use function iterator_to_array;
  *   - https://github.com/graphql/graphql-js/commit/257797a0ebdddd3da6e75b7c237fdc12a1a7c75a
  *   - https://github.com/graphql/graphql-js/commit/3b9ea61f2348215dee755f779caef83df749d2bb
  *   - https://github.com/graphql/graphql-js/commit/e6a3f08cc92594f68a6e61d3d4b46a6d279f845e
- *   - https://github.com/graphql/graphql-js/commit/9b7a8af43fc0865a01df5b5a084f37bbb8680ef8
  */
 class SchemaExtenderLegacyTest extends TestCase
 {
@@ -494,84 +493,6 @@ class SchemaExtenderLegacyTest extends TestCase
             self::fail();
         } catch (Error $error) {
             self::assertEquals('Cannot extend non-input object type "Foo".', $error->getMessage());
-        }
-    }
-
-    // Extract check for unique operation types into separate rule (#1624)
-
-    /**
-     * @see it('does not allow redefining an existing root type')
-     */
-    public function testDoesNotAllowRedefiningAnExistingRootType(): void
-    {
-        $sdl = '
-            extend schema {
-                query: SomeType
-            }
-
-            type SomeType {
-                seeSomething: String
-            }
-        ';
-
-        try {
-            $this->extendTestSchema($sdl);
-            self::fail();
-        } catch (Error $error) {
-            self::assertEquals('Must provide only one query type in schema.', $error->getMessage());
-        }
-    }
-
-    /**
-     * @see it('does not allow defining a root operation type twice')
-     */
-    public function testDoesNotAllowDefiningARootOperationTypeTwice(): void
-    {
-        $sdl = '
-            extend schema {
-              mutation: Mutation
-            }
-            extend schema {
-              mutation: Mutation
-            }
-            type Mutation {
-              doSomething: String
-            }
-        ';
-
-        try {
-            $this->extendTestSchema($sdl);
-            self::fail();
-        } catch (Error $error) {
-            self::assertEquals('Must provide only one mutation type in schema.', $error->getMessage());
-        }
-    }
-
-    /**
-     * @see it('does not allow defining a root operation type with different types')
-     */
-    public function testDoesNotAllowDefiningARootOperationTypeWithDifferentTypes(): void
-    {
-        $sdl = '
-            extend schema {
-              mutation: Mutation
-            }
-            extend schema {
-              mutation: SomethingElse
-            }
-            type Mutation {
-              doSomething: String
-            }
-            type SomethingElse {
-              doSomethingElse: String
-            }
-        ';
-
-        try {
-            $this->extendTestSchema($sdl);
-            self::fail();
-        } catch (Error $error) {
-            self::assertEquals('Must provide only one mutation type in schema.', $error->getMessage());
         }
     }
 }

--- a/tests/Validator/UniqueOperationTypesTest.php
+++ b/tests/Validator/UniqueOperationTypesTest.php
@@ -15,9 +15,8 @@ class UniqueOperationTypesTest extends ValidatorTestCase
         $this->expectSDLErrorsFromRule(new UniqueOperationTypes(), $sdlString, $schema, $errors);
     }
 
-    // Validate: Unique operation types
-
     /**
+     * @see describe('Validate: Unique operation types')
      * @see it('no schema definition')
      */
     public function testNoSchemaDefinition(): void

--- a/tests/Validator/UniqueOperationTypesTest.php
+++ b/tests/Validator/UniqueOperationTypesTest.php
@@ -107,7 +107,7 @@ class UniqueOperationTypesTest extends ValidatorTestCase
     /**
      * @see it('duplicate operation types inside single schema definition')
      */
-    public function testDuplicateOperationTypesInsideSingleSchemaDefiniti(): void
+    public function testDuplicateOperationTypesInsideSingleSchemaDefinition(): void
     {
         $this->expectSDLErrors(
             '

--- a/tests/Validator/UniqueOperationTypesTest.php
+++ b/tests/Validator/UniqueOperationTypesTest.php
@@ -1,0 +1,463 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Validator;
+
+use GraphQL\Type\Schema;
+use GraphQL\Utils\BuildSchema;
+use GraphQL\Validator\Rules\UniqueOperationTypes;
+
+class UniqueOperationTypesTest extends ValidatorTestCase
+{
+    private function expectSDLErrors(string $sdlString, ?Schema $schema, array $errors): void
+    {
+        $this->expectSDLErrorsFromRule(new UniqueOperationTypes(), $sdlString, $schema, $errors);
+    }
+
+    // Validate: Unique operation types
+
+    /**
+     * @see it('no schema definition')
+     */
+    public function testNoSchemaDefinition(): void
+    {
+        $this->expectValidSDL(
+            new UniqueOperationTypes(),
+            '
+      type Foo
+            '
+        );
+    }
+
+    /**
+     * @see it('schema definition with all types')
+     */
+    public function testSchemaDefinitionWithAllTypes(): void
+    {
+        $this->expectValidSDL(
+            new UniqueOperationTypes(),
+            '
+      type Foo
+
+      schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+            '
+        );
+    }
+
+    /**
+     * @see it('schema definition with single extension')
+     */
+    public function testSchemaDefinitionWithSingleExtension(): void
+    {
+        $this->expectValidSDL(
+            new UniqueOperationTypes(),
+            '
+      type Foo
+
+      schema { query: Foo }
+
+      extend schema {
+        mutation: Foo
+        subscription: Foo
+      }
+            '
+        );
+    }
+
+    /**
+     * @see it('schema definition with separate extensions')
+     */
+    public function testSchemaDefinitionWithSeparateExtensions(): void
+    {
+        $this->expectValidSDL(
+            new UniqueOperationTypes(),
+            '
+      type Foo
+
+      schema { query: Foo }
+      extend schema { mutation: Foo }
+      extend schema { subscription: Foo }
+            '
+        );
+    }
+
+    /**
+     * @see it('extend schema before definition')
+     */
+    public function testExtendSchemaBeforeDefinition(): void
+    {
+        $this->expectValidSDL(
+            new UniqueOperationTypes(),
+            '
+      type Foo
+
+      extend schema { mutation: Foo }
+      extend schema { subscription: Foo }
+
+      schema { query: Foo }
+            '
+        );
+    }
+
+    /**
+     * @see it('duplicate operation types inside single schema definition')
+     */
+    public function testDuplicateOperationTypesInsideSingleSchemaDefiniti(): void
+    {
+        $this->expectSDLErrors(
+            '
+      type Foo
+
+      schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+            ',
+            null,
+            [
+                [
+                    'message' => 'There can be only one query type in schema.',
+                    'locations' => [
+                        ['line' => 5, 'column' => 9],
+                        ['line' => 9, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one mutation type in schema.',
+                    'locations' => [
+                        ['line' => 6, 'column' => 9],
+                        ['line' => 10, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one subscription type in schema.',
+                    'locations' => [
+                        ['line' => 7, 'column' => 9],
+                        ['line' => 11, 'column' => 9],
+                    ],
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @see it('duplicate operation types inside schema extension')
+     */
+    public function testDuplicateOperationTypesInsideSchemaExtension(): void
+    {
+        $this->expectSDLErrors(
+            '
+      type Foo
+
+      schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+            ',
+            null,
+            [
+                [
+                    'message' => 'There can be only one query type in schema.',
+                    'locations' => [
+                        ['line' => 5, 'column' => 9],
+                        ['line' => 11, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one mutation type in schema.',
+                    'locations' => [
+                        ['line' => 6, 'column' => 9],
+                        ['line' => 12, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one subscription type in schema.',
+                    'locations' => [
+                        ['line' => 7, 'column' => 9],
+                        ['line' => 13, 'column' => 9],
+                    ],
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @see it('duplicate operation types inside schema extension twice')
+     */
+    public function testDuplicateOperationTypesInsideSchemaExtensionTwice(): void
+    {
+        $this->expectSDLErrors(
+            '
+      type Foo
+
+      schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+            ',
+            null,
+            [
+                [
+                    'message' => 'There can be only one query type in schema.',
+                    'locations' => [
+                        ['line' => 5, 'column' => 9],
+                        ['line' => 11, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one mutation type in schema.',
+                    'locations' => [
+                        ['line' => 6, 'column' => 9],
+                        ['line' => 12, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one subscription type in schema.',
+                    'locations' => [
+                        ['line' => 7, 'column' => 9],
+                        ['line' => 13, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one query type in schema.',
+                    'locations' => [
+                        ['line' => 5, 'column' => 9],
+                        ['line' => 17, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one mutation type in schema.',
+                    'locations' => [
+                        ['line' => 6, 'column' => 9],
+                        ['line' => 18, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one subscription type in schema.',
+                    'locations' => [
+                        ['line' => 7, 'column' => 9],
+                        ['line' => 19, 'column' => 9],
+                    ],
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @see it('duplicate operation types inside second schema extension')
+     */
+    public function testDuplicateOperationTypesInsideSecondSchemaExtension(): void
+    {
+        $this->expectSDLErrors(
+            '
+      type Foo
+
+      schema {
+        query: Foo
+      }
+
+      extend schema {
+        mutation: Foo
+        subscription: Foo
+      }
+
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+            ',
+            null,
+            [
+                [
+                    'message' => 'There can be only one query type in schema.',
+                    'locations' => [
+                        ['line' => 5, 'column' => 9],
+                        ['line' => 14, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one mutation type in schema.',
+                    'locations' => [
+                        ['line' => 9, 'column' => 9],
+                        ['line' => 15, 'column' => 9],
+                    ],
+                ],
+                [
+                    'message' => 'There can be only one subscription type in schema.',
+                    'locations' => [
+                        ['line' => 10, 'column' => 9],
+                        ['line' => 16, 'column' => 9],
+                    ],
+                ],
+
+            ],
+        );
+    }
+
+    /**
+     * @see it('define schema inside extension SDL')
+     */
+    public function testDefineSchemaInsideExtensionSdl(): void
+    {
+        $schema = BuildSchema::build('type Foo');
+        $sdl    = '
+      schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+        ';
+
+        $this->expectValidSDL(new UniqueOperationTypes(), $sdl, $schema);
+    }
+
+    /**
+     * @see it('define and extend schema inside extension SDL')
+     */
+    public function testDefineAndExtendSchemaInsideExtensionSdl(): void
+    {
+        $schema = BuildSchema::build('type Foo');
+        $sdl    = '
+      schema { query: Foo }
+      extend schema { mutation: Foo }
+      extend schema { subscription: Foo }
+        ';
+
+        $this->expectValidSDL(new UniqueOperationTypes(), $sdl, $schema);
+    }
+
+    /**
+     * @see it('adding new operation types to existing schema')
+     */
+    public function testAddingNewOperationTypesToExistingSchema(): void
+    {
+        $schema = BuildSchema::build('type Query');
+        $sdl    = '
+      extend schema { mutation: Foo }
+      extend schema { subscription: Foo }
+        ';
+
+        $this->expectValidSDL(new UniqueOperationTypes(), $sdl, $schema);
+    }
+
+    /**
+     * @see it('adding conflicting operation types to existing schema')
+     */
+    public function testAddingConflictingOperationTypesToExistingSchema(): void
+    {
+        $schema = BuildSchema::build('
+      type Query
+      type Mutation
+      type Subscription
+
+      type Foo
+        ');
+
+        $sdl = '
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+        ';
+
+        $this->expectSDLErrors($sdl, $schema, [
+            [
+                'message' => 'Type for query already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 3, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for mutation already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 4, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for subscription already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 5, 'column' => 9]],
+            ],
+        ]);
+    }
+
+    /**
+     * @see it('adding conflicting operation types to existing schema twice')
+     */
+    public function testAddingConflictingOperationTypesToExistingSchemaTwice(): void
+    {
+        $schema = BuildSchema::build('
+      type Query
+      type Mutation
+      type Subscription
+        ');
+
+        $sdl = '
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+
+      extend schema {
+        query: Foo
+        mutation: Foo
+        subscription: Foo
+      }
+        ';
+
+        $this->expectSDLErrors($sdl, $schema, [
+            [
+                'message' => 'Type for query already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 3, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for mutation already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 4, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for subscription already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 5, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for query already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 9, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for mutation already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 10, 'column' => 9]],
+            ],
+            [
+                'message' => 'Type for subscription already defined in the schema. It cannot be redefined.',
+                'locations' => [['line' => 11, 'column' => 9]],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Introduces `UniqueOperationTypes` validation rule.

Corresponding change in the reference implementation: https://github.com/graphql/graphql-js/commit/9b7a8af43fc0865a01df5b5a084f37bbb8680ef8