### PR TITLE
SchemaPrinter: Directives support 🤩

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -46,7 +46,6 @@ use function ksort;
 use function ltrim;
 use function mb_strlen;
 use function mb_strpos;
-use function self;
 use function sprintf;
 use function str_replace;
 use function strlen;
@@ -531,7 +530,7 @@ class SchemaPrinter
         // Enabled?
         $filter = $options['printDirectives'] ?? null;
 
-        if (!$filter || !is_callable($filter)) {
+        if (!is_callable($filter)) {
             if ($type instanceof EnumValueDefinition || $type instanceof FieldDefinition) {
                 return static::printDeprecated($type);
             }
@@ -542,12 +541,11 @@ class SchemaPrinter
         // AST Node available and has directives?
         $node = $type->astNode;
 
-        if (!$node) {
+        if ($node === null) {
             return '';
         }
 
         // Print
-        /** @var array<string> $directives */
         $length = 0;
         $directives = [];
 
@@ -562,7 +560,7 @@ class SchemaPrinter
                 // empty
             }
 
-            if ($string) {
+            if ($string !== null) {
                 $length = $length + mb_strlen($string);
                 $directives[] = $string;
             }
@@ -571,7 +569,7 @@ class SchemaPrinter
         // Multiline?
         $serialized = '';
 
-        if ($directives) {
+        if (count($directives) > 0) {
             $delimiter  = static::isLineTooLong($length) ? "\n{$indentation}" : ' ';
             $serialized = $delimiter.implode($delimiter, $directives);
         }
@@ -632,7 +630,7 @@ class SchemaPrinter
     {
         $block = '';
 
-        if ($lines) {
+        if (count($lines) > 0) {
             $forceMultiline = $forceMultiline || static::isLineTooLong(array_sum(array_map('mb_strlen', $lines)));
 
             if ($forceMultiline) {

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -334,6 +334,7 @@ class SchemaPrinter
         return static::printDescription($options, $type) .
             sprintf('type %s', $type->name) .
             self::printImplementedInterfaces($type) .
+            static::printTypeDirectives($type, $options) .
             static::printFields($options, $type);
     }
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -494,8 +494,8 @@ class SchemaPrinter
     {
         $fields = array_values($type->getFields());
         $fields = array_map(
-            static function ($f, $i) use ($options): string {
-                return static::printDescription($options, $f, '  ', ! $i) . '  ' . static::printInputValue($f);
+            static function (InputObjectField $f, $i) use ($options): string {
+                return static::printInputObjectField($f, $options, '  ', ! $i);
             },
             $fields,
             array_keys($fields)
@@ -505,6 +505,24 @@ class SchemaPrinter
             sprintf('input %s', $type->name) .
             static::printTypeDirectives($type, $options) .
             static::printBlock($fields);
+    }
+
+    /**
+     * @param array<string, bool> $options
+     * @phpstan-param Options $options
+     */
+    protected static function printInputObjectField(InputObjectField $type, array $options, string $indentation = '', bool $firstInBlock = true): string
+    {
+        $field = static::printDescription($options, $type, $indentation, $firstInBlock) .
+            '  ' .
+            static::printInputValue($type) .
+            static::printTypeDirectives($type, $options, $indentation);
+
+        if (!$firstInBlock && mb_strlen($field) > static::LINE_LENGTH) {
+            $field = "\n".ltrim($field, "\n");
+        }
+
+        return $field;
     }
 
     /**
@@ -518,7 +536,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition|UnionType|InputObjectType $type
+     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition|UnionType|InputObjectType|InputObjectField $type
      * @param array<string, bool> $options
      * @phpstan-param Options $options
      */

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -434,8 +434,17 @@ class SchemaPrinter
         $types = count($types) > 0
             ? ' = ' . implode(' | ', $types)
             : '';
+        $directives = static::printTypeDirectives($type, $options, '');
 
-        return static::printDescription($options, $type) . 'union ' . $type->name . $types;
+        if (mb_strlen($directives) >  static::LINE_LENGTH) {
+            $types = ltrim($types);
+            $directives .= "\n";
+        }
+
+        return static::printDescription($options, $type) .
+            'union ' . $type->name .
+            $directives .
+            $types;
     }
 
     /**
@@ -508,7 +517,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition $type
+     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition|UnionType $type
      * @param array<string, bool> $options
      * @phpstan-param Options $options
      */

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -10,7 +10,10 @@ use GraphQL\Language\AST\ArgumentNode;
 use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\EnumValueDefinitionNode;
+use GraphQL\Language\AST\ListValueNode;
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\ScalarTypeDefinitionNode;
+use GraphQL\Language\AST\ValueNode;
 use GraphQL\Language\BlockString;
 use GraphQL\Language\Printer;
 use GraphQL\Type\Definition\Directive;
@@ -602,7 +605,24 @@ class SchemaPrinter
      */
     protected static function printArgument(ArgumentNode $argument, array $options, string $indentation): string
     {
-        return "{$indentation}{$argument->name->value}: " . Printer::doPrint($argument->value);
+        $value = $argument->value;
+
+        if ($value instanceof ListValueNode) {
+            $length = 0;
+            $values = [];
+
+            foreach ($value->values as $item) {
+                $string = '  ' . $indentation . Printer::doPrint($item);
+                $length = $length + mb_strlen($string);
+                $values[] = $string;
+            }
+
+            $value = static::printLines($values, '[', ']', static::isLineTooLong($length), $indentation);
+        } else {
+            $value = Printer::doPrint($value);
+        }
+
+        return "{$indentation}{$argument->name->value}: {$value}";
     }
 
     /**

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -503,6 +503,7 @@ class SchemaPrinter
 
         return static::printDescription($options, $type) .
             sprintf('input %s', $type->name) .
+            static::printTypeDirectives($type, $options) .
             static::printBlock($fields);
     }
 
@@ -517,7 +518,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition|UnionType $type
+     * @param Type|EnumValueDefinition|EnumType|InterfaceType|FieldDefinition|UnionType|InputObjectType $type
      * @param array<string, bool> $options
      * @phpstan-param Options $options
      */

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -651,14 +651,12 @@ class SchemaPrinter
     /**
      * @param array<string> $lines
      */
-    protected static function printChildrenBlock(array $lines, string $begin, string $end, bool $forceMultiline, string $indentation = ''): string
+    protected static function printChildrenBlock(array $lines, string $begin, string $end, bool $multiline, string $indentation = ''): string
     {
         $block = '';
 
         if (count($lines) > 0) {
-            $forceMultiline = $forceMultiline || static::isLineTooLong(array_sum(array_map('mb_strlen', $lines)));
-
-            if ($forceMultiline) {
+            if ($multiline) {
                 $wrapped = false;
 
                 for ($i = 0, $c = count($lines); $i < $c; $i++) {

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -7,6 +7,7 @@ namespace GraphQL\Utils;
 use Closure;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Language\AST\EnumTypeDefinitionNode;
 use GraphQL\Language\AST\EnumValueDefinitionNode;
 use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use GraphQL\Language\BlockString;
@@ -437,6 +438,7 @@ class SchemaPrinter
 
         return static::printDescription($options, $type) .
             sprintf('enum %s', $type->name) .
+            static::printTypeDirectives($type, $options) .
             static::printBlock($values);
     }
 
@@ -489,7 +491,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param Type|EnumValueDefinition $type
+     * @param Type|EnumValueDefinition|EnumType $type
      * @param array<string, bool> $options
      * @phpstan-param Options $options
      */
@@ -508,7 +510,7 @@ class SchemaPrinter
         // AST Node available and has directives?
         $node = $type->astNode;
 
-        if (!($node instanceof ScalarTypeDefinitionNode || $node instanceof EnumValueDefinitionNode)) {
+        if (!($node instanceof ScalarTypeDefinitionNode || $node instanceof EnumValueDefinitionNode || $node instanceof EnumTypeDefinitionNode)) {
             return '';
         }
 
@@ -535,8 +537,12 @@ class SchemaPrinter
         }
 
         // Multiline?
-        $delimiter = $length > static::LINE_LENGTH ? "\n{$indentation}" : ' ';
-        $serialized = $delimiter.implode($delimiter, $directives);
+        $serialized = '';
+
+        if ($directives) {
+            $delimiter  = $length > static::LINE_LENGTH ? "\n{$indentation}" : ' ';
+            $serialized = $delimiter.implode($delimiter, $directives);
+        }
 
         // Return
         return $serialized;

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -404,6 +404,7 @@ class SchemaPrinter
         return static::printDescription($options, $type) .
             sprintf('interface %s', $type->name) .
             self::printImplementedInterfaces($type) .
+            static::printTypeDirectives($type, $options) .
             static::printFields($options, $type);
     }
 
@@ -491,7 +492,7 @@ class SchemaPrinter
     }
 
     /**
-     * @param Type|EnumValueDefinition|EnumType $type
+     * @param Type|EnumValueDefinition|EnumType|InterfaceType $type
      * @param array<string, bool> $options
      * @phpstan-param Options $options
      */
@@ -510,7 +511,7 @@ class SchemaPrinter
         // AST Node available and has directives?
         $node = $type->astNode;
 
-        if (!($node instanceof ScalarTypeDefinitionNode || $node instanceof EnumValueDefinitionNode || $node instanceof EnumTypeDefinitionNode)) {
+        if (!$node) {
             return '';
         }
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -37,7 +37,6 @@ use GraphQL\Type\Schema;
 use function array_filter;
 use function array_keys;
 use function array_map;
-use function array_sum;
 use function array_values;
 use function count;
 use function explode;

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -301,7 +301,7 @@ class SchemaPrinter
         }
 
         // Return
-        return static::printLines($arguments, '(', ')', $description || static::isLineTooLong($length), $indentation);
+        return static::printChildrenBlock($arguments, '(', ')', $description || static::isLineTooLong($length), $indentation);
     }
 
     /**
@@ -448,7 +448,7 @@ class SchemaPrinter
             : '';
         $directives = static::printTypeDirectives($type, $options, '');
 
-        if (mb_strlen($directives) >  static::LINE_LENGTH) {
+        if (static::isLineTooLong($directives)) {
             $types = ltrim($types);
             $directives .= "\n";
         }
@@ -530,7 +530,8 @@ class SchemaPrinter
      */
     protected static function printBlock(array $items): string
     {
-        return static::printLines($items, ' {', '}', true);
+        // TODO Deprecated?
+        return static::printChildrenBlock($items, ' {', '}', true);
     }
 
     /**
@@ -612,7 +613,7 @@ class SchemaPrinter
         }
 
         return "@{$directive->name->value}" .
-            static::printLines($arguments, '(', ')', static::isLineTooLong($length), $indentation);
+            static::printChildrenBlock($arguments, '(', ')', static::isLineTooLong($length), $indentation);
     }
 
     /**
@@ -644,7 +645,7 @@ class SchemaPrinter
                 $values[] = $string;
             }
 
-            $result = static::printLines($values, '[', ']', static::isLineTooLong($length), $indentation);
+            $result = static::printChildrenBlock($values, '[', ']', static::isLineTooLong($length), $indentation);
         } else {
             $result = Printer::doPrint($value);
         }
@@ -655,7 +656,7 @@ class SchemaPrinter
     /**
      * @param array<string> $lines
      */
-    protected static function printLines(array $lines, string $begin, string $end, bool $forceMultiline, string $indentation = ''): string
+    protected static function printChildrenBlock(array $lines, string $begin, string $end, bool $forceMultiline, string $indentation = ''): string
     {
         $block = '';
 

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -155,6 +155,7 @@ enum Color {
 
   """Not a creative color"""
   GREEN
+
   BLUE
 }
 
@@ -187,6 +188,7 @@ enum Color {
 
   # Not a creative color
   GREEN
+
   BLUE
 }
 
@@ -492,7 +494,7 @@ type WorldTwo {
     {
         $schema = BuildSchema::build('
           union Hello = Hello
-    
+
           type Query {
             hello: Hello
           }
@@ -758,7 +760,7 @@ type Query {
       type TestType implements TestInterface {
         interfaceField: String
       }
-      
+
       scalar TestScalar
 
       directive @test(arg: TestScalar) on FIELD

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1352,12 +1352,12 @@ class SchemaPrinterTest extends TestCase
             }
 
             input InputB @test(value: "{$text}") {
-              a: ID
+              a: [String] = ["{$text}", "{$text}", "{$text}"]
             }
 
             type Query {
               a(a: String, b: String, c: String): Boolean @test
-              b("desc" a: String): Boolean @test(value: "{$text}")
+              b("desc" a: [String] = ["{$text}", "{$text}", "{$text}"]): Boolean @test(value: "{$text}")
               c(a: String @test(value: "{$text}")): Boolean
               d(
                 a: String @test
@@ -1441,7 +1441,11 @@ class SchemaPrinterTest extends TestCase
             @test(
               value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             ) {
-              a: ID
+              a: [String] = [
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              ]
             }
 
             interface InterfaceA @test {
@@ -1479,7 +1483,11 @@ class SchemaPrinterTest extends TestCase
 
               b(
                 """desc"""
-                a: String
+                a: [String] = [
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ]
               ): Boolean
               @test(
                 value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1281,6 +1281,7 @@ class SchemaPrinterTest extends TestCase
         $text = str_pad('a', 80, 'a');
         $schema = /** @lang GraphQL */ <<<GRAPHQL
             directive @test(
+              values: [String!]
               value: String @test(value: "{$text}")
               text: String
             ) on SCHEMA |
@@ -1366,10 +1367,13 @@ class SchemaPrinterTest extends TestCase
                 "{$text}"
                 d: String = "123" @test(value: "{$text}", text: "{$text}")
               ): Boolean
+              e: String @test(values: ["{$text}", "{$text}", "{$text}"])
             }
             GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
             directive @test(
+              values: [String!]
+
               value: String
               @test(
                 value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1507,6 +1511,15 @@ class SchemaPrinterTest extends TestCase
                   text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 )
               ): Boolean
+
+              e: String
+              @test(
+                values: [
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ]
+              )
             }
 
             scalar ScalarA @test

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1339,6 +1339,14 @@ class SchemaPrinterTest extends TestCase
             union UnionA @test = TypeA | TypeB
 
             union UnionB @test(value: "{$text}") = TypeA | TypeB
+
+            input InputA @test {
+              a: Int
+            }
+
+            input InputB @test(value: "{$text}") {
+              a: ID
+            }
             GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
             directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
@@ -1365,6 +1373,15 @@ class SchemaPrinterTest extends TestCase
             enum EnumB
             @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
               a
+            }
+
+            input InputA @test {
+              a: Int
+            }
+
+            input InputB
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+              a: ID
             }
 
             interface InterfaceA @test {

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1335,6 +1335,10 @@ class SchemaPrinterTest extends TestCase
             type TypeB implements InterfaceB @test(value: "{$text}") {
               a: ID
             }
+
+            union UnionA @test = TypeA | TypeB
+
+            union UnionB @test(value: "{$text}") = TypeA | TypeB
             GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
             directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
@@ -1415,6 +1419,12 @@ class SchemaPrinterTest extends TestCase
             @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
               a: ID
             }
+
+            union UnionA @test = TypeA | TypeB
+
+            union UnionB
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            = TypeA | TypeB
 
             GRAPHQL;
         $actual = SchemaPrinter::doPrint(BuildSchema::build($schema), [

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1341,7 +1341,12 @@ class SchemaPrinterTest extends TestCase
             union UnionB @test(value: "{$text}") = TypeA | TypeB
 
             input InputA @test {
-              a: Int
+              a: Int @test
+              b: Int @test(value: "{$text}")
+              "{$text}"
+              c: Int @test
+              "{$text}"
+              d: Int @test(value: "{$text}")
             }
 
             input InputB @test(value: "{$text}") {
@@ -1376,7 +1381,21 @@ class SchemaPrinterTest extends TestCase
             }
 
             input InputA @test {
-              a: Int
+              a: Int @test
+
+              b: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              c: Int @test
+
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              d: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
             }
 
             input InputB

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1278,7 +1278,7 @@ class SchemaPrinterTest extends TestCase
     }
 
     public function testPrintDirectives(): void {
-        $text   = str_pad('a', 80, 'a');
+        $text = str_pad('a', 80, 'a');
         $schema = /** @lang GraphQL */ <<<GRAPHQL
         directive @test(
           value: String
@@ -1297,19 +1297,23 @@ class SchemaPrinterTest extends TestCase
         scalar ScalarA @test
         scalar ScalarB @test(value: "{$text}")
 
-        enum EnumA {
+        enum EnumA @test {
           a @test @deprecated
           b @test(value: "{$text}")
           "{$text}"
           c @test
           "{$text}"
-          d @test(value: "{$text}")
+          d @test(value: "{$text}") @deprecated
+        }
+
+        enum EnumB @test(value: "{$text}") {
+          a
         }
         GRAPHQL;
-        $expected = <<<'GRAPHQL'
+        $expected = /** @lang GraphQL */ <<<'GRAPHQL'
         directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-        enum EnumA {
+        enum EnumA @test {
           a @test @deprecated
 
           b
@@ -1325,6 +1329,12 @@ class SchemaPrinterTest extends TestCase
           """
           d
           @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+          @deprecated
+        }
+
+        enum EnumB
+        @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+          a
         }
 
         scalar ScalarA @test

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1282,6 +1282,7 @@ class SchemaPrinterTest extends TestCase
         $schema = /** @lang GraphQL */ <<<GRAPHQL
             directive @test(
               value: String @test(value: "{$text}")
+              text: String
             ) on SCHEMA |
                 SCALAR |
                 OBJECT |
@@ -1363,21 +1364,27 @@ class SchemaPrinterTest extends TestCase
                 "{$text}"
                 c: String @test
                 "{$text}"
-                d: String = "123" @test(value: "{$text}")
+                d: String = "123" @test(value: "{$text}", text: "{$text}")
               ): Boolean
             }
             GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
             directive @test(
               value: String
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
+
+              text: String
             ) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
             enum EnumA @test {
               a @test @deprecated
 
               b
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
 
               """
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1388,12 +1395,16 @@ class SchemaPrinterTest extends TestCase
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
               d
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
               @deprecated
             }
 
             enum EnumB
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ) {
               a
             }
 
@@ -1401,7 +1412,9 @@ class SchemaPrinterTest extends TestCase
               a: Int @test
 
               b: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
 
               """
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1412,11 +1425,15 @@ class SchemaPrinterTest extends TestCase
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
               d: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
             }
 
             input InputB
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ) {
               a: ID
             }
 
@@ -1424,7 +1441,9 @@ class SchemaPrinterTest extends TestCase
               a: Int @test @deprecated
 
               b: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
 
               """
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1435,12 +1454,16 @@ class SchemaPrinterTest extends TestCase
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
               d: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
               @deprecated
             }
 
             interface InterfaceB implements InterfaceA
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ) {
               a: ID
             }
 
@@ -1451,18 +1474,24 @@ class SchemaPrinterTest extends TestCase
                 """desc"""
                 a: String
               ): Boolean
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
 
               c(
                 a: String
-                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                @test(
+                  value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                )
               ): Boolean
 
               d(
                 a: String @test
 
                 b: String
-                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                @test(
+                  value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                )
 
                 """
                 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1473,20 +1502,27 @@ class SchemaPrinterTest extends TestCase
                 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
                 """
                 d: String = "123"
-                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                @test(
+                  value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                )
               ): Boolean
             }
 
             scalar ScalarA @test
 
             scalar ScalarB
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            )
 
             type TypeA @test {
               a: Int @test @deprecated
 
               b: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
 
               """
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1497,19 +1533,25 @@ class SchemaPrinterTest extends TestCase
               aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
               d: Int
-              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @test(
+                value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              )
               @deprecated
             }
 
             type TypeB implements InterfaceB
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ) {
               a: ID
             }
 
             union UnionA @test = TypeA | TypeB
 
             union UnionB
-            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            @test(
+              value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            )
             = TypeA | TypeB
 
             GRAPHQL;

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -6,7 +6,6 @@ namespace GraphQL\Tests\Utils;
 
 use Generator;
 use GraphQL\Language\DirectiveLocation;
-use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
@@ -1277,9 +1276,10 @@ class SchemaPrinterTest extends TestCase
         self::assertEquals($expected, $output);
     }
 
-    public function testPrintDirectivesAst(): void {
-        $text = str_pad('a', 80, 'a');
-        $schema = /** @lang GraphQL */ <<<GRAPHQL
+    public function testPrintDirectivesAst(): void
+    {
+        $text     = str_pad('a', 80, 'a');
+        $schema   = /** @lang GraphQL */ <<<GRAPHQL
             directive @test(
               values: [String!]
               value: String @test(value: "{$text}")
@@ -1579,8 +1579,8 @@ class SchemaPrinterTest extends TestCase
             = TypeA | TypeB
 
             GRAPHQL;
-        $actual = SchemaPrinter::doPrint(BuildSchema::build($schema), [
-            'printDirectives' => static function(): bool {
+        $actual   = SchemaPrinter::doPrint(BuildSchema::build($schema), [
+            'printDirectives' => static function (): bool {
                 return true;
             },
         ]);
@@ -1588,25 +1588,26 @@ class SchemaPrinterTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function testPrintDirectivesDeprecated(): void {
-        $text = str_pad('a', 80, 'a');
-        $enum = new EnumType([
+    public function testPrintDirectivesDeprecated(): void
+    {
+        $text   = str_pad('a', 80, 'a');
+        $enum   = new EnumType([
             'name' => 'Aaa',
             'values' => [
                 'A' => [
                     'value' => 'AAA',
                     'description' => 'AAAAAAAAAAAAA',
-                    'deprecationReason' => 'deprecated for tests'
+                    'deprecationReason' => 'deprecated for tests',
                 ],
                 'B' => [
                     'value' => 'AAA',
-                    'deprecationReason' => $text
+                    'deprecationReason' => $text,
                 ],
-            ]
+            ],
         ]);
-        $schema  = new Schema(['types' => [$enum]]);
+        $schema = new Schema(['types' => [$enum]]);
         $actual = SchemaPrinter::doPrint($schema, [
-            'printDirectives' => static function(): bool {
+            'printDirectives' => static function (): bool {
                 return true;
             },
         ]);

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1280,142 +1280,143 @@ class SchemaPrinterTest extends TestCase
     public function testPrintDirectives(): void {
         $text = str_pad('a', 80, 'a');
         $schema = /** @lang GraphQL */ <<<GRAPHQL
-        directive @test(
-          value: String
-        ) on SCHEMA |
-            SCALAR |
-            OBJECT |
-            FIELD_DEFINITION |
-            ARGUMENT_DEFINITION |
-            INTERFACE |
-            UNION |
-            ENUM |
-            ENUM_VALUE |
-            INPUT_OBJECT |
-            INPUT_FIELD_DEFINITION
+            directive @test(
+              value: String
+            ) on SCHEMA |
+                SCALAR |
+                OBJECT |
+                FIELD_DEFINITION |
+                ARGUMENT_DEFINITION |
+                INTERFACE |
+                UNION |
+                ENUM |
+                ENUM_VALUE |
+                INPUT_OBJECT |
+                INPUT_FIELD_DEFINITION
 
-        scalar ScalarA @test
-        scalar ScalarB @test(value: "{$text}")
+            scalar ScalarA @test
+            scalar ScalarB @test(value: "{$text}")
 
-        enum EnumA @test {
-          a @test @deprecated
-          b @test(value: "{$text}")
-          "{$text}"
-          c @test
-          "{$text}"
-          d @test(value: "{$text}") @deprecated
-        }
+            enum EnumA @test {
+              a @test @deprecated
+              b @test(value: "{$text}")
+              "{$text}"
+              c @test
+              "{$text}"
+              d @test(value: "{$text}") @deprecated
+            }
 
-        enum EnumB @test(value: "{$text}") {
-          a
-        }
+            enum EnumB @test(value: "{$text}") {
+              a
+            }
 
-        interface InterfaceA @test {
-          a: Int @test @deprecated
-          b: Int @test(value: "{$text}")
-          "{$text}"
-          c: Int @test
-          "{$text}"
-          d: Int @test(value: "{$text}") @deprecated
-        }
+            interface InterfaceA @test {
+              a: Int @test @deprecated
+              b: Int @test(value: "{$text}")
+              "{$text}"
+              c: Int @test
+              "{$text}"
+              d: Int @test(value: "{$text}") @deprecated
+            }
 
-        interface InterfaceB @test(value: "{$text}") {
-          a: ID
-        }
+            interface InterfaceB implements InterfaceA @test(value: "{$text}") {
+              a: ID
+            }
 
-        type TypeA {
-          a: Int @test @deprecated
-          b: Int @test(value: "{$text}")
-          "{$text}"
-          c: Int @test
-          "{$text}"
-          d: Int @test(value: "{$text}") @deprecated
-        }
+            type TypeA @test {
+              a: Int @test @deprecated
+              b: Int @test(value: "{$text}")
+              "{$text}"
+              c: Int @test
+              "{$text}"
+              d: Int @test(value: "{$text}") @deprecated
+            }
 
-        type TypeB {
-          a: ID
-        }
-        GRAPHQL;
+            type TypeB implements InterfaceB @test(value: "{$text}") {
+              a: ID
+            }
+            GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
-        directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+            directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-        enum EnumA @test {
-          a @test @deprecated
+            enum EnumA @test {
+              a @test @deprecated
 
-          b
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              b
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          c @test
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              c @test
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          d
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-          @deprecated
-        }
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              d
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @deprecated
+            }
 
-        enum EnumB
-        @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
-          a
-        }
+            enum EnumB
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+              a
+            }
 
-        interface InterfaceA @test {
-          a: Int @test @deprecated
+            interface InterfaceA @test {
+              a: Int @test @deprecated
 
-          b: Int
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              b: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          c: Int @test
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              c: Int @test
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          d: Int
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-          @deprecated
-        }
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              d: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @deprecated
+            }
 
-        interface InterfaceB
-        @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
-          a: ID
-        }
+            interface InterfaceB implements InterfaceA
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+              a: ID
+            }
 
-        scalar ScalarA @test
+            scalar ScalarA @test
 
-        scalar ScalarB
-        @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            scalar ScalarB
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-        type TypeA {
-          a: Int @test @deprecated
+            type TypeA @test {
+              a: Int @test @deprecated
 
-          b: Int
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              b: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          c: Int @test
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              c: Int @test
 
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          """
-          d: Int
-          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-          @deprecated
-        }
+              """
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+              d: Int
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              @deprecated
+            }
 
-        type TypeB {
-          a: ID
-        }
+            type TypeB implements InterfaceB
+            @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+              a: ID
+            }
 
-        GRAPHQL;
+            GRAPHQL;
         $actual = SchemaPrinter::doPrint(BuildSchema::build($schema), [
             'printDirectives' => static function(): bool {
                 return true;

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1311,10 +1311,28 @@ class SchemaPrinterTest extends TestCase
         }
 
         interface InterfaceA @test {
-          a: ID
+          a: Int @test @deprecated
+          b: Int @test(value: "{$text}")
+          "{$text}"
+          c: Int @test
+          "{$text}"
+          d: Int @test(value: "{$text}") @deprecated
         }
 
         interface InterfaceB @test(value: "{$text}") {
+          a: ID
+        }
+
+        type TypeA {
+          a: Int @test @deprecated
+          b: Int @test(value: "{$text}")
+          "{$text}"
+          c: Int @test
+          "{$text}"
+          d: Int @test(value: "{$text}") @deprecated
+        }
+
+        type TypeB {
           a: ID
         }
         GRAPHQL;
@@ -1346,7 +1364,22 @@ class SchemaPrinterTest extends TestCase
         }
 
         interface InterfaceA @test {
-          a: ID
+          a: Int @test @deprecated
+
+          b: Int
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          c: Int @test
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          d: Int
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+          @deprecated
         }
 
         interface InterfaceB
@@ -1358,6 +1391,29 @@ class SchemaPrinterTest extends TestCase
 
         scalar ScalarB
         @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+        type TypeA {
+          a: Int @test @deprecated
+
+          b: Int
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          c: Int @test
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          d: Int
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+          @deprecated
+        }
+
+        type TypeB {
+          a: ID
+        }
 
         GRAPHQL;
         $actual = SchemaPrinter::doPrint(BuildSchema::build($schema), [

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1281,7 +1281,7 @@ class SchemaPrinterTest extends TestCase
         $text = str_pad('a', 80, 'a');
         $schema = /** @lang GraphQL */ <<<GRAPHQL
             directive @test(
-              value: String
+              value: String @test(value: "{$text}")
             ) on SCHEMA |
                 SCALAR |
                 OBJECT |
@@ -1352,9 +1352,26 @@ class SchemaPrinterTest extends TestCase
             input InputB @test(value: "{$text}") {
               a: ID
             }
+
+            type Query {
+              a(a: String, b: String, c: String): Boolean @test
+              b("desc" a: String): Boolean @test(value: "{$text}")
+              c(a: String @test(value: "{$text}")): Boolean
+              d(
+                a: String @test
+                b: String @test(value: "{$text}")
+                "{$text}"
+                c: String @test
+                "{$text}"
+                d: String = "123" @test(value: "{$text}")
+              ): Boolean
+            }
             GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
-            directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+            directive @test(
+              value: String
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            ) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
             enum EnumA @test {
               a @test @deprecated
@@ -1425,6 +1442,39 @@ class SchemaPrinterTest extends TestCase
             interface InterfaceB implements InterfaceA
             @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
               a: ID
+            }
+
+            type Query {
+              a(a: String, b: String, c: String): Boolean @test
+
+              b(
+                """desc"""
+                a: String
+              ): Boolean
+              @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+              c(
+                a: String
+                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              ): Boolean
+
+              d(
+                a: String @test
+
+                b: String
+                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+                """
+                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                """
+                c: String @test
+
+                """
+                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                """
+                d: String = "123"
+                @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+              ): Boolean
             }
 
             scalar ScalarA @test

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1296,9 +1296,36 @@ class SchemaPrinterTest extends TestCase
 
         scalar ScalarA @test
         scalar ScalarB @test(value: "{$text}")
+
+        enum EnumA {
+          a @test @deprecated
+          b @test(value: "{$text}")
+          "{$text}"
+          c @test
+          "{$text}"
+          d @test(value: "{$text}")
+        }
         GRAPHQL;
         $expected = <<<'GRAPHQL'
         directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        enum EnumA {
+          a @test @deprecated
+
+          b
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          c @test
+
+          """
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          """
+          d
+          @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        }
 
         scalar ScalarA @test
 

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1309,6 +1309,14 @@ class SchemaPrinterTest extends TestCase
         enum EnumB @test(value: "{$text}") {
           a
         }
+
+        interface InterfaceA @test {
+          a: ID
+        }
+
+        interface InterfaceB @test(value: "{$text}") {
+          a: ID
+        }
         GRAPHQL;
         $expected = /** @lang GraphQL */ <<<'GRAPHQL'
         directive @test(value: String) on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
@@ -1335,6 +1343,15 @@ class SchemaPrinterTest extends TestCase
         enum EnumB
         @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
           a
+        }
+
+        interface InterfaceA @test {
+          a: ID
+        }
+
+        interface InterfaceB
+        @test(value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+          a: ID
         }
 
         scalar ScalarA @test


### PR DESCRIPTION
## Features: 

* Seems no API breaking changes (but output for long lines may be a bit different, see below);
* By default it has the same behavior as before; directives printing should be enabled explicitly via `printDirectives` option;
* Supported location: `ARGUMENT_DEFINITION`, `ENUM`, `ENUM_VALUE`, `FIELD_DEFINITION`, `INPUT_FIELD_DEFINITION`, `INPUT_OBJECT`, `INTERFACE`, `OBJECT`, `SCALAR`, `UNION`;
* Long directives (= with a lot of arguments) will be split into multiple lines
* Long list of arguments will be split into multiple lines 🆕
* Long List values (`[1,2,3]`) will be split into multiple lines 🆕
* Better separation for children with long-line/description 🆕


```graphql
# Example
input InputB
@test(
  value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
) {
  a: [String] = [
    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
  ]
}

# Before
enum Color {
  RED

  """Not a creative color"""
  GREEN
  BLUE
}

#After
enum Color {
  RED

  """Not a creative color"""
  GREEN

  BLUE
}
```

Closes: #552, #875 