### PR TITLE
Support non-JSON ServerRequestInterface

### DIFF
--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -525,11 +525,9 @@ class Helper
 
                 $this->assertJsonObjectOrArray($bodyParams);
             } else {
-                parse_str((string) $request->getBody(), $bodyParams);
-
-                if (! is_array($bodyParams)) {
-                    throw new RequestError('Unexpected content type: ' . Utils::printSafeJson($contentType[0]));
-                }
+                $bodyParams = $request instanceof ServerRequestInterface
+                    ? $request->getParsedBody()
+                    : $this->decodeContent((string) $request->getBody(), $contentType[0]);
             }
         }
 
@@ -553,6 +551,22 @@ class Helper
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new RequestError('Expected JSON object or array for "application/json" request, but failed to parse because: ' . json_last_error_msg());
+        }
+
+        return $bodyParams;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws RequestError
+     */
+    protected function decodeContent(string $rawBody, string $contentType): array
+    {
+        parse_str($rawBody, $bodyParams);
+
+        if (! is_array($bodyParams)) {
+            throw new RequestError('Unexpected content type: ' . Utils::printSafeJson($contentType));
         }
 
         return $bodyParams;

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -525,9 +525,11 @@ class Helper
 
                 $this->assertJsonObjectOrArray($bodyParams);
             } else {
-                $bodyParams = $request instanceof ServerRequestInterface
-                    ? $request->getParsedBody()
-                    : $this->decodeContent((string) $request->getBody(), $contentType[0]);
+                if ($request instanceof ServerRequestInterface) {
+                    $bodyParams = $request->getParsedBody();
+                }
+
+                $bodyParams ??= $this->decodeContent((string) $request->getBody(), $contentType[0]);
             }
         }
 

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -111,7 +111,8 @@ class RequestParsingTest extends TestCase
         $parsed = [
             'raw' => $this->parseRawFormUrlencodedRequest($post),
             'psr' => $this->parsePsrFormUrlEncodedRequest($post),
-            'serverRequest' => $this->parsePsrFormUrlEncodedServerRequest($post),
+            'serverRequest' => $this->parsePsrFormUrlEncodedServerRequest($post, false),
+            'parsedServerRequest' => $this->parsePsrFormUrlEncodedServerRequest($post, true),
         ];
 
         foreach ($parsed as $method => $parsedBody) {
@@ -157,17 +158,22 @@ class RequestParsingTest extends TestCase
         );
     }
 
-    private function parsePsrFormUrlEncodedServerRequest($postValue)
+    private function parsePsrFormUrlEncodedServerRequest($postValue, bool $parsed)
     {
         $helper = new Helper();
 
-        return $helper->parsePsrRequest(
-            (new ServerRequest(
-                'POST',
-                '',
-                ['Content-Type' => 'application/x-www-form-urlencoded'],
-            ))->withParsedBody($postValue)
+        $request = new ServerRequest(
+            'POST',
+            '',
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            $parsed ? null : http_build_query($postValue),
         );
+
+        if ($parsed) {
+            $request = $request->withParsedBody($postValue);
+        }
+
+        return $helper->parsePsrRequest($request);
     }
 
     public function testParsesGetRequest(): void

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -10,6 +10,7 @@ use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
 use InvalidArgumentException;
 use Nyholm\Psr7\Request;
+use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Stream;
 use Nyholm\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
@@ -110,6 +111,7 @@ class RequestParsingTest extends TestCase
         $parsed = [
             'raw' => $this->parseRawFormUrlencodedRequest($post),
             'psr' => $this->parsePsrFormUrlEncodedRequest($post),
+            'serverRequest' => $this->parsePsrFormUrlEncodedServerRequest($post),
         ];
 
         foreach ($parsed as $method => $parsedBody) {
@@ -152,6 +154,19 @@ class RequestParsingTest extends TestCase
                 ['Content-Type' => 'application/x-www-form-urlencoded'],
                 http_build_query($postValue)
             )
+        );
+    }
+
+    private function parsePsrFormUrlEncodedServerRequest($postValue)
+    {
+        $helper = new Helper();
+
+        return $helper->parsePsrRequest(
+            (new ServerRequest(
+                'POST',
+                '',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+            ))->withParsedBody($postValue)
         );
     }
 


### PR DESCRIPTION
In #598, use of `ServerRequestInterface::getParsedBody()` has been replaced with inlined parsing of `RequestInterface::getBody()`.

Later, it has been reintroduced (cf. #715), but for JSON requests only.

Therefore, this Pull Request aims to restore use of `getParsedBody()` when available, in fallback case as well (commonly `application/x-www-form-urlencoded`).