### PR TITLE
Call `EnumType::parseLiteral` from `AST` to support PHP enums/objects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -276,11 +276,6 @@ parameters:
 			path: src/Utils/AST.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, GraphQL\\\\Type\\\\Definition\\\\EnumValueDefinition\\|null given\\.$#"
-			count: 1
-			path: src/Utils/AST.php
-
-		-
 			message: "#^Only booleans are allowed in &&, array\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Utils/AST.php

--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -182,7 +182,7 @@ class EnumType extends Type implements InputType, OutputType, LeafType, Nullable
     /**
      * @param mixed[]|null $variables
      *
-     * @return null
+     * @return mixed
      *
      * @throws Exception
      */

--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -442,15 +442,11 @@ class AST
         }
 
         if ($type instanceof EnumType) {
-            if (! $valueNode instanceof EnumValueNode) {
+            try {
+                return $type->parseLiteral($valueNode, $variables);
+            } catch (Throwable $error) {
                 return $undefined;
             }
-            $enumValue = $type->getValue($valueNode->value);
-            if (! $enumValue) {
-                return $undefined;
-            }
-
-            return $enumValue->value;
         }
 
         if ($type instanceof ScalarType) {

--- a/tests/Type/TestClasses/OtherEnum.php
+++ b/tests/Type/TestClasses/OtherEnum.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Type\TestClasses;
+
+use function assert;
+use function in_array;
+
+class OtherEnum
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        assert(in_array($value, ['ONE', 'TWO', 'THREE'], true));
+
+        $this->value = $value;
+    }
+
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Type/TestClasses/OtherEnumType.php
+++ b/tests/Type/TestClasses/OtherEnumType.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Type\TestClasses;
+
+use GraphQL\Language\AST\Node;
+use GraphQL\Type\Definition\EnumType;
+
+class OtherEnumType extends EnumType
+{
+    public function __construct()
+    {
+        $config = [
+            'name'   => 'OtherEnum',
+            'values' => [
+                'ONE',
+                'TWO',
+                'THREE',
+            ],
+        ];
+        parent::__construct($config);
+    }
+
+    /**
+     * @param mixed[]|null $variables
+     */
+    public function parseLiteral(Node $valueNode, ?array $variables = null)
+    {
+        $value = parent::parseLiteral($valueNode, $variables);
+
+        return new OtherEnum($value);
+    }
+
+    public function serialize($value)
+    {
+        if ($value instanceof OtherEnum) {
+            $value = $value->getValue();
+        }
+
+        return parent::serialize($value);
+    }
+}


### PR DESCRIPTION
Somehow, this call was missing. It is defined in `EnumType` but was never used.

To make it possible to convert enum string values to PHP objects (or enums in PHP 8.1) we need
to call it.

This allows developers to override the `parseLiteral` method and do the conversion there.

See the example in the test.