### PR TITLE
Fix compatiblity of methods with native return type in PHP 8.1

### DIFF
--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -9,6 +9,7 @@ use GraphQL\Language\AST\Node;
 use GraphQL\Language\Source;
 use GraphQL\Language\SourceLocation;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use Throwable;
 use Traversable;
 
@@ -299,6 +300,7 @@ class Error extends Exception implements JsonSerializable, ClientAware, Provides
      * @return array<string, mixed> data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return FormattedError::createFromException($this);

--- a/src/Language/SourceLocation.php
+++ b/src/Language/SourceLocation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQL\Language;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class SourceLocation implements JsonSerializable
 {
@@ -40,6 +41,7 @@ class SourceLocation implements JsonSerializable
     /**
      * @return array{line: int, column: int}
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Introspection;
 use GraphQL\Utils\Utils;
 use JsonSerializable;
 use ReflectionClass;
+use ReturnTypeWillChange;
 
 use function array_keys;
 use function array_merge;
@@ -287,6 +288,7 @@ abstract class Type implements JsonSerializable
         Utils::assertValidName($this->name);
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): string
     {
         return $this->toString();


### PR DESCRIPTION
This pull request (PR) provides fixes for the extension to make it compatible with PHP 8.1.
The fixes provides backward compatibility with previous versions PHP.

Return types have been fixed using attribute #[\ReturnTypeWillChange], please see this [link](https://php.watch/versions/8.1/ReturnTypeWillChange)