### PR TITLE
ObjectType > Make `fields` optional

### DIFF
--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -59,7 +59,7 @@ use function is_string;
  *   name?: string|null,
  *   description?: string|null,
  *   resolveField?: FieldResolver,
- *   fields: (callable(): iterable<mixed>)|iterable<mixed>,
+ *   fields?: (callable(): iterable<mixed>)|iterable<mixed>,
  *   interfaces?: iterable<InterfaceTypeReference>|callable(): iterable<InterfaceTypeReference>,
  *   isTypeOf?: (callable(mixed $objectValue, mixed $context, ResolveInfo $resolveInfo): (bool|Deferred|null))|null,
  *   astNode?: ObjectTypeDefinitionNode|null,


### PR DESCRIPTION
Just like everything else. It can default to an empty array.