### PR TITLE
Use return instead of phpstan-return

### DIFF
--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -70,7 +70,7 @@ class NodeList implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param int|string $offset
      *
-     * @phpstan-return T
+     * @return T
      */
     #[ReturnTypeWillChange]
     public function offsetGet($offset)// : Node


### PR DESCRIPTION
This stops the Deprecation Helper from Symfony PHPUnit Bridge to stop complaining:
```
  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "GraphQL\Language\AST\NodeList" now to avoid errors or add an explicit @return annotation to suppress this message.
```