### PR TITLE
Fix problems found by the newest version of PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,16 +51,6 @@ parameters:
 			path: src/Executor/ReferenceExecutor.php
 
 		-
-			message: "#^Method GraphQL\\\\Language\\\\AST\\\\Node\\:\\:cloneValue\\(\\) should return TCloneable of GraphQL\\\\Language\\\\AST\\\\Location\\|GraphQL\\\\Language\\\\AST\\\\NodeList\\<TNode of GraphQL\\\\Language\\\\AST\\\\Node\\>\\|string\\|TNode of GraphQL\\\\Language\\\\AST\\\\Node but returns GraphQL\\\\Language\\\\AST\\\\Location\\|string\\.$#"
-			count: 1
-			path: src/Language/AST/Node.php
-
-		-
-			message: "#^Method GraphQL\\\\Language\\\\AST\\\\Node\\:\\:cloneValue\\(\\) should return TCloneable of GraphQL\\\\Language\\\\AST\\\\Location\\|GraphQL\\\\Language\\\\AST\\\\NodeList\\<TNode of GraphQL\\\\Language\\\\AST\\\\Node\\>\\|string\\|TNode of GraphQL\\\\Language\\\\AST\\\\Node but returns TCloneable of TNode of GraphQL\\\\Language\\\\AST\\\\Node\\.$#"
-			count: 1
-			path: src/Language/AST/Node.php
-
-		-
 			message: "#^Unable to resolve the template type TCloneable in call to method static method GraphQL\\\\Language\\\\AST\\\\Node\\:\\:cloneValue\\(\\)$#"
 			count: 1
 			path: src/Language/AST/Node.php
@@ -69,11 +59,6 @@ parameters:
 			message: "#^Variable property access on TCloneable of TNode of GraphQL\\\\Language\\\\AST\\\\Node\\.$#"
 			count: 1
 			path: src/Language/AST/Node.php
-
-		-
-			message: "#^Parameter \\#4 \\$replacement of function array_splice expects array\\|string, array\\<T of GraphQL\\\\Language\\\\AST\\\\Node\\>\\|T of GraphQL\\\\Language\\\\AST\\\\Node\\|null given\\.$#"
-			count: 1
-			path: src/Language/AST/NodeList.php
 
 		-
 			message: "#^Parameter \\#1 \\$list of method GraphQL\\\\Language\\\\Printer\\:\\:printList\\(\\) expects GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\Node\\>, GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\DefinitionNode&GraphQL\\\\Language\\\\AST\\\\Node\\> given\\.$#"

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -291,16 +291,14 @@ class FormattedError
                 $safeErr['line'] = $err['line'];
             }
 
-            if (isset($err['function'])) {
-                $func = $err['function'];
-                $args = array_map([self::class, 'printVar'], $err['args'] ?? []);
-                $funcStr = $func . '(' . implode(', ', $args) . ')';
+            $func = $err['function'];
+            $args = array_map([self::class, 'printVar'], $err['args'] ?? []);
+            $funcStr = $func . '(' . implode(', ', $args) . ')';
 
-                if (isset($err['class'])) {
-                    $safeErr['call'] = $err['class'] . '::' . $funcStr;
-                } else {
-                    $safeErr['function'] = $funcStr;
-                }
+            if (isset($err['class'])) {
+                $safeErr['call'] = $err['class'] . '::' . $funcStr;
+            } else {
+                $safeErr['function'] = $funcStr;
             }
 
             $formatted[] = $safeErr;

--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -196,7 +196,6 @@ class EnumType extends Type implements InputType, OutputType, LeafType, Nullable
         Utils::assertValidName($this->name);
 
         $values = $this->config['values'] ?? null;
-        // @phpstan-ignore-next-line should not happen if used correctly
         if (! is_iterable($values) && ! is_callable($values)) {
             $notIterable = Utils::printSafe($values);
 

--- a/src/Type/Definition/InputObjectType.php
+++ b/src/Type/Definition/InputObjectType.php
@@ -158,7 +158,6 @@ class InputObjectType extends Type implements InputType, NullableType, NamedType
             $fields = $fields();
         }
 
-        // @phpstan-ignore-next-line should not happen if used correctly
         if (! is_iterable($fields)) {
             $invalidFields = Utils::printSafe($fields);
 

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -96,7 +96,6 @@ class UnionType extends Type implements AbstractType, OutputType, CompositeType,
                 $types = $types();
             }
 
-            // @phpstan-ignore-next-line should not happen if used correctly
             if (! is_iterable($types)) {
                 throw new InvariantViolation(
                     "Must provide iterable of types or a callable which returns such an iterable for Union {$this->name}."


### PR DESCRIPTION
The current master is failing as PHPStan got smarter in the newest versions.

Not 100% sure about the change to `FormattedError.php`. Context in phpstan/phpstan-src#914.