### PR TITLE
Fix schema built from SDL to return null for unknown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Preserve extended methods from class-based types in `SchemaExtender::extend()`
 - Fix printing of empty types (#940)
 - Clone `NodeList` in `Node::cloneDeep()`
+- Calling `Schema::getType()` on a schema built from SDL returns `null` for unknown types (#1068)
 
 ### Removed
 

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -146,20 +146,20 @@ class ASTDefinitionBuilder
             return Type::nonNull($this->buildWrappedType($typeNode->type));
         }
 
-        return $this->buildTypeFromNamedType($typeNode); // TODO: getNamedType()
+        return $this->buildType($typeNode); // TODO: getNamedType()
     }
 
-//    /**
-//     * @param string|(Node&NamedTypeNode)|(Node&TypeDefinitionNode) $ref
-//     */
-//    public function buildType($ref): Type
-//    {
-//        if (is_string($ref)) {
-//            return $this->internalBuildType($ref);
-//        }
-//
-//        return $this->internalBuildType($ref->name->value, $ref);
-//    }
+    /**
+     * @param string|(Node&NamedTypeNode)|(Node&TypeDefinitionNode) $ref
+     */
+    public function buildType($ref): Type
+    {
+        if (is_string($ref)) {
+            return $this->internalBuildType($ref);
+        }
+
+        return $this->internalBuildType($ref->name->value, $ref);
+    }
 
     /**
      * Calling this method is an equivalent of `typeMap[typeName]` in `graphql-js`.
@@ -169,25 +169,7 @@ class ASTDefinitionBuilder
      */
     public function maybeBuildType(string $name): ?Type
     {
-        return isset($this->typeDefinitionsMap[$name]) ? $this->buildTypeFromName($name) : null;
-    }
-
-    public function buildTypeFromName(string $name): Type
-    {
-        return $this->internalBuildType($name);
-    }
-
-    public function buildTypeFromNamedType(NamedTypeNode $node): Type
-    {
-        return $this->internalBuildType($node->name->value);
-    }
-
-    /**
-     * @param TypeDefinitionNode&Node $node
-     */
-    public function buildTypeFromTypeDefinition(TypeDefinitionNode $node): Type
-    {
-        return $this->internalBuildType($node->name->value, $node);
+        return isset($this->typeDefinitionsMap[$name]) ? $this->buildType($name) : null;
     }
 
     /**
@@ -345,7 +327,7 @@ class ASTDefinitionBuilder
 
         $interfaces = [];
         foreach ($def->interfaces as $interface) {
-            $interfaces[] = $this->buildTypeFromNamedType($interface); // TODO: getNamedType($interface)
+            $interfaces[] = $this->buildType($interface); // TODO: getNamedType($interface)
         }
 
         // @phpstan-ignore-next-line generic type will be validated during schema validation
@@ -393,7 +375,7 @@ class ASTDefinitionBuilder
             'types' => function () use ($def): array {
                 $types = [];
                 foreach ($def->types as $type) {
-                    $types[] = $this->buildTypeFromNamedType($type); // TODO: getNamedType($type)
+                    $types[] = $this->buildType($type); // TODO: getNamedType($type)
                 }
 
                 /** @var array<int, ObjectType> $types */

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -169,7 +169,9 @@ class ASTDefinitionBuilder
      */
     public function maybeBuildType(string $name): ?Type
     {
-        return isset($this->typeDefinitionsMap[$name]) ? $this->buildType($name) : null;
+        return isset($this->typeDefinitionsMap[$name])
+            ? $this->buildType($name)
+            : null
     }
 
     /**

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -146,7 +146,7 @@ class ASTDefinitionBuilder
             return Type::nonNull($this->buildWrappedType($typeNode->type));
         }
 
-        return $this->buildType($typeNode); // TODO: getNamedType()
+        return $this->buildType($typeNode);
     }
 
     /**
@@ -327,7 +327,7 @@ class ASTDefinitionBuilder
 
         $interfaces = [];
         foreach ($def->interfaces as $interface) {
-            $interfaces[] = $this->buildType($interface); // TODO: getNamedType($interface)
+            $interfaces[] = $this->buildType($interface);
         }
 
         // @phpstan-ignore-next-line generic type will be validated during schema validation
@@ -375,7 +375,7 @@ class ASTDefinitionBuilder
             'types' => function () use ($def): array {
                 $types = [];
                 foreach ($def->types as $type) {
-                    $types[] = $this->buildType($type); // TODO: getNamedType($type)
+                    $types[] = $this->buildType($type);
                 }
 
                 /** @var array<int, ObjectType> $types */

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -211,7 +211,7 @@ class BuildSchema
             'directives' => $directives,
             'astNode' => $schemaDef,
             'types' => fn (): array => array_map( // TODO: $definitionBuilder->buildAllTypes()?
-                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildTypeFromName($def->name->value), // TODO: buildTypeFromTypeDefinition()?
+                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->name->value), // TODO: buildTypeFromTypeDefinition()?
                 $this->nodeMap,
             ),
         ]);

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -156,6 +156,7 @@ class BuildSchema
         $operationTypes = null !== $schemaDef
             ? $this->getOperationTypes($schemaDef)
             : [
+                // TODO: simplify
                 'query' => isset($this->nodeMap['Query']) ? 'Query' : null,
                 'mutation' => isset($this->nodeMap['Mutation']) ? 'Mutation' : null,
                 'subscription' => isset($this->nodeMap['Subscription']) ? 'Subscription' : null,
@@ -163,7 +164,7 @@ class BuildSchema
 
         $definitionBuilder = new ASTDefinitionBuilder(
             $this->nodeMap,
-            static function (string $typeName): void {
+            static function (string $typeName): Type {
                 throw self::unknownType($typeName);
             },
             $this->typeConfigDecorator
@@ -206,11 +207,11 @@ class BuildSchema
             'subscription' => isset($operationTypes['subscription'])
                 ? $definitionBuilder->buildType($operationTypes['subscription'])
                 : null,
-            'typeLoader' => static fn (string $name): Type => $definitionBuilder->buildType($name),
+            'typeLoader' => static fn (string $name): ?Type => $definitionBuilder->maybeBuildType($name),
             'directives' => $directives,
             'astNode' => $schemaDef,
-            'types' => fn (): array => array_map(
-                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->name->value),
+            'types' => fn (): array => array_map( // TODO: $definitionBuilder->buildAllTypes()?
+                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildTypeFromName($def->name->value), // TODO: buildTypeFromTypeDefinition()?
                 $this->nodeMap,
             ),
         ]);

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -156,10 +156,9 @@ class BuildSchema
         $operationTypes = null !== $schemaDef
             ? $this->getOperationTypes($schemaDef)
             : [
-                // TODO: simplify
-                'query' => isset($this->nodeMap['Query']) ? 'Query' : null,
-                'mutation' => isset($this->nodeMap['Mutation']) ? 'Mutation' : null,
-                'subscription' => isset($this->nodeMap['Subscription']) ? 'Subscription' : null,
+                'query' => 'Query',
+                'mutation' => 'Mutation',
+                'subscription' => 'Subscription',
             ];
 
         $definitionBuilder = new ASTDefinitionBuilder(
@@ -199,13 +198,13 @@ class BuildSchema
 
         return new Schema([
             'query' => isset($operationTypes['query'])
-                ? $definitionBuilder->buildType($operationTypes['query'])
+                ? $definitionBuilder->maybeBuildType($operationTypes['query'])
                 : null,
             'mutation' => isset($operationTypes['mutation'])
-                ? $definitionBuilder->buildType($operationTypes['mutation'])
+                ? $definitionBuilder->maybeBuildType($operationTypes['mutation'])
                 : null,
             'subscription' => isset($operationTypes['subscription'])
-                ? $definitionBuilder->buildType($operationTypes['subscription'])
+                ? $definitionBuilder->maybeBuildType($operationTypes['subscription'])
                 : null,
             'typeLoader' => static fn (string $name): ?Type => $definitionBuilder->maybeBuildType($name),
             'directives' => $directives,

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -210,8 +210,8 @@ class BuildSchema
             'typeLoader' => static fn (string $name): ?Type => $definitionBuilder->maybeBuildType($name),
             'directives' => $directives,
             'astNode' => $schemaDef,
-            'types' => fn (): array => array_map( // TODO: $definitionBuilder->buildAllTypes()?
-                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->name->value), // TODO: buildTypeFromTypeDefinition()?
+            'types' => fn (): array => array_map(
+                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->name->value),
                 $this->nodeMap,
             ),
         ]);

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -272,7 +272,7 @@ class SchemaExtender
                 assert($extension instanceof UnionTypeExtensionNode, 'proven by assertTypeMatchesExtension()');
 
                 foreach ($extension->types as $namedType) {
-                    $possibleTypes[] = static::$astBuilder->buildType($namedType); // TODO: getNamedType($namedType)
+                    $possibleTypes[] = static::$astBuilder->buildType($namedType);
                 }
             }
         }
@@ -301,7 +301,7 @@ class SchemaExtender
                 );
 
                 foreach ($extension->interfaces as $namedType) {
-                    $interface = static::$astBuilder->buildType($namedType); // TODO: getNamedType($namedType)
+                    $interface = static::$astBuilder->buildType($namedType);
                     assert($interface instanceof InterfaceType, 'we know this, but PHP templates cannot express it');
 
                     $interfaces[] = $interface;

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -272,7 +272,7 @@ class SchemaExtender
                 assert($extension instanceof UnionTypeExtensionNode, 'proven by assertTypeMatchesExtension()');
 
                 foreach ($extension->types as $namedType) {
-                    $possibleTypes[] = static::$astBuilder->buildTypeFromNamedType($namedType); // TODO: getNamedType($namedType)
+                    $possibleTypes[] = static::$astBuilder->buildType($namedType); // TODO: getNamedType($namedType)
                 }
             }
         }
@@ -301,7 +301,7 @@ class SchemaExtender
                 );
 
                 foreach ($extension->interfaces as $namedType) {
-                    $interface = static::$astBuilder->buildTypeFromNamedType($namedType); // TODO: getNamedType($namedType)
+                    $interface = static::$astBuilder->buildType($namedType); // TODO: getNamedType($namedType)
                     assert($interface instanceof InterfaceType, 'we know this, but PHP templates cannot express it');
 
                     $interfaces[] = $interface;
@@ -640,14 +640,14 @@ class SchemaExtender
 
         if (null !== $schemaDef) {
             foreach ($schemaDef->operationTypes as $operationType) {
-                $operationTypes[$operationType->operation] = static::$astBuilder->buildTypeFromNamedType($operationType->type);
+                $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
             }
         }
 
         foreach ($schemaExtensions as $schemaExtension) {
             if (isset($schemaExtension->operationTypes)) {
                 foreach ($schemaExtension->operationTypes as $operationType) {
-                    $operationTypes[$operationType->operation] = static::$astBuilder->buildTypeFromNamedType($operationType->type);
+                    $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
                 }
             }
         }
@@ -663,7 +663,7 @@ class SchemaExtender
 
         // Do the same with new types.
         foreach ($typeDefinitionMap as $type) {
-            $types[] = static::$astBuilder->buildTypeFromTypeDefinition($type);
+            $types[] = static::$astBuilder->buildType($type);
         }
 
         return new Schema([

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -272,7 +272,7 @@ class SchemaExtender
                 assert($extension instanceof UnionTypeExtensionNode, 'proven by assertTypeMatchesExtension()');
 
                 foreach ($extension->types as $namedType) {
-                    $possibleTypes[] = static::$astBuilder->buildType($namedType);
+                    $possibleTypes[] = static::$astBuilder->buildTypeFromNamedType($namedType); // TODO: getNamedType($namedType)
                 }
             }
         }
@@ -301,7 +301,7 @@ class SchemaExtender
                 );
 
                 foreach ($extension->interfaces as $namedType) {
-                    $interface = static::$astBuilder->buildType($namedType);
+                    $interface = static::$astBuilder->buildTypeFromNamedType($namedType); // TODO: getNamedType($namedType)
                     assert($interface instanceof InterfaceType, 'we know this, but PHP templates cannot express it');
 
                     $interfaces[] = $interface;
@@ -580,11 +580,7 @@ class SchemaExtender
                     ? $def->name->value
                     : null;
 
-                try {
-                    $type = $schema->getType($typeName);
-                } catch (Error $error) {
-                    $type = null;
-                }
+                $type = $schema->getType($typeName);
 
                 if (null !== $type) {
                     throw new Error('Type "' . $typeName . '" already exists in the schema. It cannot also be defined in this type definition.', [$def]);
@@ -644,14 +640,14 @@ class SchemaExtender
 
         if (null !== $schemaDef) {
             foreach ($schemaDef->operationTypes as $operationType) {
-                $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
+                $operationTypes[$operationType->operation] = static::$astBuilder->buildTypeFromNamedType($operationType->type);
             }
         }
 
         foreach ($schemaExtensions as $schemaExtension) {
             if (isset($schemaExtension->operationTypes)) {
                 foreach ($schemaExtension->operationTypes as $operationType) {
-                    $operationTypes[$operationType->operation] = static::$astBuilder->buildType($operationType->type);
+                    $operationTypes[$operationType->operation] = static::$astBuilder->buildTypeFromNamedType($operationType->type);
                 }
             }
         }
@@ -667,7 +663,7 @@ class SchemaExtender
 
         // Do the same with new types.
         foreach ($typeDefinitionMap as $type) {
-            $types[] = static::$astBuilder->buildType($type);
+            $types[] = static::$astBuilder->buildTypeFromTypeDefinition($type);
         }
 
         return new Schema([

--- a/tests/Type/SchemaTest.php
+++ b/tests/Type/SchemaTest.php
@@ -123,4 +123,12 @@ class SchemaTest extends TestCase
         self::assertArrayHasKey('DirInput', $typeMap);
         self::assertArrayHasKey('WrappedDirInput', $typeMap);
     }
+
+    /**
+     * @see https://github.com/webonyx/graphql-php/issues/997
+     */
+    public function testSchemaReturnsNullForNonexistentType(): void
+    {
+        self::assertNull($this->schema->getType('UnknownType'));
+    }
 }

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -887,6 +887,15 @@ type Query {
 ', null, ['assumeValidSDL' => true])->assertValid();
     }
 
+    /**
+     * @see https://github.com/webonyx/graphql-php/issues/997
+     */
+    public function testBuiltSchemaReturnsNullForNonexistentType(): void
+    {
+        $schema = BuildSchema::build('type KnownType');
+        self::assertNull($schema->getType('UnknownType'));
+    }
+
     public function testSupportsTypeConfigDecorator(): void
     {
         $body = '


### PR DESCRIPTION
Fixes #997 (and unblocks #998 and #999).

### History background
The implementation of `BuildSchema`, `SchemaExtender` and `ASTDefinitionBuilder` roughly matches their counterparts from `graphql-js` v14.0.

However, during the lifetime of v14, the JS code underwent significant changes. In the final version 14.7, `buildASTSchema()`, `extendSchema()` and `ASTDefinitionBuilder` looks much different then they did in v14.0. For the context of this PR, the most important changes (https://github.com/graphql/graphql-js/commit/afc6b7c04708068e3733d8e85882e4b2e4ef58e5) were that  `ASTDefinitionBuilder`'s constructor didn't accept `typeDefinitionsMap` param any more, and that the original single method `buildType()` was replaced with a new `buildType()` and `getNamedType()`. Each was used in a different context, and only the latter could throw the `"Unknown type"` error.

These changes to the reference implementation have never been reflected in `graphql-php`.

### Implementation notes
The context is everything. Sometimes it's okay for the builder to return `null` instead of throwing `"Unknown type"` error – like in this case when it's requested to build a type that isn't defined in the SDL schema.

To handle this explicitly, I added the new `maybeBuildType(string $name): ?Type`  method to the builder.

`graphql-js` (v14.2+) builds `typeMap` with all types from SDL ahead. Then calling `typeMap[typeName]` returns either a type or `undefined`.

The new `maybeBuildType()` provides similar functionality for the lazy environment where we don't have such a map and where the individual types are built from the SDL schema on demand.

### Additional notes
In v15, `graphql-js` has undergone even more significant changes and `ASTDefinitionBuilder` has been removed completely (https://github.com/graphql/graphql-js/commit/3948aa20d9c38c5d4aff06f1b3af2538b20f909a). 
To ensure future compatibility with the reference implementation, it would be worth considering reimplementing schema builder and extender completely.
