### PR TITLE
Allow iterable in `PromiseAdapter::all()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Always convert promises through `PromiseAdapter::convertThenable()` before calling `->then()` on them
 - Use `JSON_THROW_ON_ERROR` in `json_encode()`
 - Validate some internal invariants through `assert()`
+- `PromiseAdapter::all()` accepts `iterable`
 
 ### Added
 

--- a/src/Executor/Promise/Adapter/AmpPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/AmpPromiseAdapter.php
@@ -8,8 +8,10 @@ use function Amp\Promise\all;
 use Amp\Promise as AmpPromise;
 use Amp\Success;
 use function array_replace;
+use function assert;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
+use function is_array;
 use Throwable;
 
 class AmpPromiseAdapter implements PromiseAdapter
@@ -77,8 +79,13 @@ class AmpPromiseAdapter implements PromiseAdapter
         return new Promise($promise, $this);
     }
 
-    public function all(array $promisesOrValues): Promise
+    public function all(iterable $promisesOrValues): Promise
     {
+        assert(
+            is_array($promisesOrValues),
+            'AmpPromiseAdapter::all(): Argument #1 ($promisesOrValues) must be of type array'
+        );
+
         /** @var array<AmpPromise<mixed>> $promises */
         $promises = [];
         foreach ($promisesOrValues as $key => $item) {

--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -52,8 +52,13 @@ class ReactPromiseAdapter implements PromiseAdapter
         return new Promise($promise, $this);
     }
 
-    public function all(array $promisesOrValues): Promise
+    public function all(iterable $promisesOrValues): Promise
     {
+        assert(
+            is_array($promisesOrValues),
+            'ReactPromiseAdapter::all(): Argument #1 ($promisesOrValues) must be of type array'
+        );
+
         // TODO: rework with generators when PHP minimum required version is changed to 5.5+
 
         foreach ($promisesOrValues as &$promiseOrValue) {

--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -2,12 +2,14 @@
 
 namespace GraphQL\Executor\Promise\Adapter;
 
+use function assert;
 use function count;
 use GraphQL\Deferred;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\Utils\Utils;
+use function is_array;
 use Throwable;
 
 /**
@@ -72,8 +74,13 @@ class SyncPromiseAdapter implements PromiseAdapter
         return new Promise($promise->reject($reason), $this);
     }
 
-    public function all(array $promisesOrValues): Promise
+    public function all(iterable $promisesOrValues): Promise
     {
+        assert(
+            is_array($promisesOrValues),
+            'SyncPromiseAdapter::all(): Argument #1 ($promisesOrValues) must be of type array'
+        );
+
         $all = new SyncPromise();
 
         $total = count($promisesOrValues);

--- a/src/Executor/Promise/PromiseAdapter.php
+++ b/src/Executor/Promise/PromiseAdapter.php
@@ -63,12 +63,12 @@ interface PromiseAdapter
     public function createRejected(Throwable $reason): Promise;
 
     /**
-     * Given an array of promises (or values), returns a promise that is fulfilled when all the
-     * items in the array are fulfilled.
+     * Given an iterable of promises (or values), returns a promise that is fulfilled when all the
+     * items in the iterable are fulfilled.
      *
-     * @param array<Promise|mixed> $promisesOrValues
+     * @param iterable<Promise|mixed> $promisesOrValues
      *
      * @api
      */
-    public function all(array $promisesOrValues): Promise;
+    public function all(iterable $promisesOrValues): Promise;
 }


### PR DESCRIPTION
I need to write my own PromiseAdapter that can index by other types than `int|string` (since array is used to index values in SyncPromiseAdapter).

My `$promisesOrValues` is of type \Ds\Map. Widening the interface method arg would allow me to pass it into my implementation.