### PR TITLE
Add ReturnTypeWillChange attribute to disable deprecation warnings on PHP 8.1

### DIFF
--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -359,6 +359,7 @@ abstract class Type implements JsonSerializable
     /**
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toString();


### PR DESCRIPTION
Hi,

I realize this is a really old version, but it is one of the dependencies in our stack which we want to run on PHP 8.1 (and which otherwise works fine on 8.1), and the deprecation emmited by PHP 8.1 is breaking some of our GraphQL responses.

There may be more of these needed, but I haven't run into them so far.

Would it be possible to tag a quick patch release with this fix?

Thanks!