### PR TITLE
Fix problems found by the newest version of PHPStan

### DIFF
--- a/src/Language/Parser.php
+++ b/src/Language/Parser.php
@@ -605,7 +605,6 @@ class Parser
      */
     private function parseVariableDefinitions(): NodeList
     {
-        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
         return $this->peek(Token::PAREN_L)
             ? $this->many(
                 Token::PAREN_L,
@@ -703,7 +702,6 @@ class Parser
             ? fn (): ArgumentNode => $this->parseConstArgument()
             : fn (): ArgumentNode => $this->parseArgument();
 
-        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
         return $this->peek(Token::PAREN_L)
             ? $this->many(Token::PAREN_L, $parseFn, Token::PAREN_R)
             : new NodeList([]);
@@ -1224,7 +1222,6 @@ class Parser
      */
     private function parseArgumentsDefinition(): NodeList
     {
-        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
         return $this->peek(Token::PAREN_L)
             ? $this->many(
                 Token::PAREN_L,
@@ -1340,7 +1337,6 @@ class Parser
      */
     private function parseEnumValuesDefinition(): NodeList
     {
-        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
         return $this->peek(Token::BRACE_L)
             ? $this->many(
                 Token::BRACE_L,
@@ -1388,7 +1384,6 @@ class Parser
      */
     private function parseInputFieldsDefinition(): NodeList
     {
-        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
         return $this->peek(Token::BRACE_L)
             ? $this->many(
                 Token::BRACE_L,

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -218,7 +218,6 @@ class Printer
                 return 'fragment ' . $this->p($node->name)
                     . $this->wrap(
                         '(',
-                        // @phpstan-ignore-next-line generic type of empty NodeList is not recognized
                         $this->printList($node->variableDefinitions ?? new NodeList([]), ', '),
                         ')'
                     )

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -49,8 +49,6 @@ class QueryComplexity extends QuerySecurityRule
     public function getVisitor(QueryValidationContext $context): array
     {
         $this->context = $context;
-
-        // @phpstan-ignore-next-line Initializing with an empty array does not set the generic type
         $this->variableDefs = new NodeList([]);
         $this->fieldNodeAndDefs = new ArrayObject();
 

--- a/tests/Language/NodeListTest.php
+++ b/tests/Language/NodeListTest.php
@@ -51,6 +51,7 @@ final class NodeListTest extends TestCase
 
     public function testPushNodes(): void
     {
+        /** @var NodeList<NameNode> $nodeList */
         $nodeList = new NodeList([]);
         self::assertCount(0, $nodeList);
 

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -236,7 +236,6 @@ class VisitorTest extends ValidatorTestCase
                     'enter' => function (DocumentNode $node) use ($ast): DocumentNode {
                         $this->checkVisitorFnArgs($ast, func_get_args());
                         $tmp = clone $node;
-                        // @phpstan-ignore-next-line generic type of empty NodeList is not initialized
                         $tmp->definitions = new NodeList([]);
                         $tmp->didEnter = true;
 


### PR DESCRIPTION
Again, the current master is failing as a result of changes in the latest PHPStan release. This fixes the code to be compatible with https://github.com/phpstan/phpstan/releases/tag/1.4.8.