### PR TITLE
Add Path type to ResolveInfo

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -52,6 +52,7 @@ use Throwable;
 
 /**
  * @phpstan-import-type FieldResolver from Executor
+ * @phpstan-import-type Path from ResolveInfo
  * @phpstan-type Fields ArrayObject<string, ArrayObject<int, FieldNode>>
  */
 class ReferenceExecutor implements ExecutorImplementation
@@ -571,6 +572,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param mixed                       $rootValue
      * @param array<int, string|int>      $path
+     * @phpstan-param Path                $path
      * @param ArrayObject<int, FieldNode> $fieldNodes
      *
      * @return array<mixed>|Throwable|mixed|null
@@ -703,6 +705,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
+     * @phpstan-param Path                $path
      * @param mixed                       $result
      *
      * @return array<mixed>|Promise|stdClass|null

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -573,6 +573,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param mixed                       $rootValue
      * @param array<int, string|int>      $path
      * @phpstan-param Path                $path
+     *
      * @param ArrayObject<int, FieldNode> $fieldNodes
      *
      * @return array<mixed>|Throwable|mixed|null
@@ -706,6 +707,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
      * @phpstan-param Path                $path
+     *
      * @param mixed                       $result
      *
      * @return array<mixed>|Promise|stdClass|null

--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -118,6 +118,7 @@ class ResolveInfo
      * @param iterable<int, FieldNode>              $fieldNodes
      * @param array<int, string|int>                $path
      * @phpstan-param Path                          $path
+     *
      * @param array<string, FragmentDefinitionNode> $fragments
      * @param mixed|null                            $rootValue
      * @param array<string, mixed>                  $variableValues

--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -17,6 +17,7 @@ use GraphQL\Type\Schema;
  * Passed as 4th argument to every field resolver. See [docs on field resolving (data fetching)](data-fetching.md).
  *
  * @phpstan-import-type QueryPlanOptions from QueryPlan
+ * @phpstan-type Path array<int, string|int>
  */
 class ResolveInfo
 {
@@ -63,6 +64,7 @@ class ResolveInfo
      * @api
      *
      * @var array<int, string|int>
+     * @phpstan-var Path
      */
     public array $path;
 
@@ -115,6 +117,7 @@ class ResolveInfo
     /**
      * @param iterable<int, FieldNode>              $fieldNodes
      * @param array<int, string|int>                $path
+     * @phpstan-param Path                          $path
      * @param array<string, FragmentDefinitionNode> $fragments
      * @param mixed|null                            $rootValue
      * @param array<string, mixed>                  $variableValues


### PR DESCRIPTION
I'm starting to work with Path in my projects and don't really want to use `array<int, string|int>` everywhere. E.g. when we start using `list` type, I'd like it to change automatically with graphql-php version bump. Therefore, I'm introducing Path type I can import from this lib.