### PR TITLE
Extract check for unique directive names into separate rule

### DIFF
--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -104,12 +104,6 @@ class SchemaExtender
                 static::assertTypeMatchesExtension($existingType, $def);
                 static::$typeExtensionsMap[$extendedTypeName][] = $def;
             } elseif ($def instanceof DirectiveDefinitionNode) {
-                $directiveName = $def->name->value;
-                $existingDirective = $schema->getDirective($directiveName);
-                if ($existingDirective !== null) {
-                    throw new Error('Directive "' . $directiveName . '" already exists in the schema. It cannot be redefined.', [$def]);
-                }
-
                 $directiveDefinitions[] = $def;
             }
         }

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -47,6 +47,7 @@ use GraphQL\Validator\Rules\ValidationRule;
 use GraphQL\Validator\Rules\ValuesOfCorrectType;
 use GraphQL\Validator\Rules\VariablesAreInputTypes;
 use GraphQL\Validator\Rules\VariablesInAllowedPosition;
+use function implode;
 
 /**
  * Implements the "Validation" section of the spec.
@@ -304,11 +305,11 @@ class DocumentValidator
      */
     private static function combineErrorMessages(array $errors): string
     {
-        $str = '';
+        $messages = [];
         foreach ($errors as $error) {
-            $str .= $error->getMessage() . "\n\n";
+            $messages[] = $error->getMessage();
         }
 
-        return $str;
+        return implode("\n\n", $messages);
     }
 }

--- a/src/Validator/DocumentValidator.php
+++ b/src/Validator/DocumentValidator.php
@@ -34,6 +34,7 @@ use GraphQL\Validator\Rules\QuerySecurityRule;
 use GraphQL\Validator\Rules\ScalarLeafs;
 use GraphQL\Validator\Rules\SingleFieldSubscription;
 use GraphQL\Validator\Rules\UniqueArgumentNames;
+use GraphQL\Validator\Rules\UniqueDirectiveNames;
 use GraphQL\Validator\Rules\UniqueDirectivesPerLocation;
 use GraphQL\Validator\Rules\UniqueEnumValueNames;
 use GraphQL\Validator\Rules\UniqueFragmentNames;
@@ -203,6 +204,7 @@ class DocumentValidator
             LoneSchemaDefinition::class => new LoneSchemaDefinition(),
             UniqueOperationTypes::class => new UniqueOperationTypes(),
             UniqueTypeNames::class => new UniqueTypeNames(),
+            UniqueDirectiveNames::class => new UniqueDirectiveNames(),
             KnownTypeNames::class => new KnownTypeNames(),
             KnownDirectives::class => new KnownDirectives(),
             KnownArgumentNamesOnDirectives::class => new KnownArgumentNamesOnDirectives(),

--- a/src/Validator/Rules/UniqueDirectiveNames.php
+++ b/src/Validator/Rules/UniqueDirectiveNames.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace GraphQL\Validator\Rules;
 

--- a/src/Validator/Rules/UniqueDirectiveNames.php
+++ b/src/Validator/Rules/UniqueDirectiveNames.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Validator\Rules;
+
+use function array_key_exists;
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\Visitor;
+use GraphQL\Language\VisitorOperation;
+use GraphQL\Validator\SDLValidationContext;
+
+/**
+ * Unique directive names.
+ *
+ * A GraphQL document is only valid if all defined directives have unique names.
+ */
+class UniqueDirectiveNames extends ValidationRule
+{
+    public function getSDLVisitor(SDLValidationContext $context): array
+    {
+        $schema = $context->getSchema();
+        /** @var array<string, NameNode> $knownDirectiveNames */
+        $knownDirectiveNames = [];
+        $checkDirectiveName = static function ($node) use ($context, $schema, &$knownDirectiveNames): ?VisitorOperation {
+            $directiveName = $node->name->value;
+
+            if ($schema !== null && $schema->getDirective($directiveName) !== null) {
+                $context->reportError(
+                    new Error(
+                        'Directive "@' . $directiveName . '" already exists in the schema. It cannot be redefined.',
+                        $node->name,
+                    ),
+                );
+
+                return null;
+            }
+
+            if (array_key_exists($directiveName, $knownDirectiveNames)) {
+                $context->reportError(
+                    new Error(
+                        'There can be only one directive named "@' . $directiveName . '".',
+                        [
+                            $knownDirectiveNames[$directiveName],
+                            $node->name,
+                        ]
+                    ),
+                );
+            } else {
+                $knownDirectiveNames[$directiveName] = $node->name;
+            }
+
+            return Visitor::skipNode();
+        };
+
+        return [
+            NodeKind::DIRECTIVE_DEFINITION => $checkDirectiveName,
+        ];
+    }
+}

--- a/src/Validator/Rules/UniqueDirectiveNames.php
+++ b/src/Validator/Rules/UniqueDirectiveNames.php
@@ -19,41 +19,41 @@ class UniqueDirectiveNames extends ValidationRule
     public function getSDLVisitor(SDLValidationContext $context): array
     {
         $schema = $context->getSchema();
+
         /** @var array<string, NameNode> $knownDirectiveNames */
         $knownDirectiveNames = [];
-        $checkDirectiveName = static function ($node) use ($context, $schema, &$knownDirectiveNames): ?VisitorOperation {
-            $directiveName = $node->name->value;
-
-            if ($schema !== null && $schema->getDirective($directiveName) !== null) {
-                $context->reportError(
-                    new Error(
-                        'Directive "@' . $directiveName . '" already exists in the schema. It cannot be redefined.',
-                        $node->name,
-                    ),
-                );
-
-                return null;
-            }
-
-            if (isset($knownDirectiveNames[$directiveName])) {
-                $context->reportError(
-                    new Error(
-                        'There can be only one directive named "@' . $directiveName . '".',
-                        [
-                            $knownDirectiveNames[$directiveName],
-                            $node->name,
-                        ]
-                    ),
-                );
-            } else {
-                $knownDirectiveNames[$directiveName] = $node->name;
-            }
-
-            return Visitor::skipNode();
-        };
 
         return [
-            NodeKind::DIRECTIVE_DEFINITION => $checkDirectiveName,
+            NodeKind::DIRECTIVE_DEFINITION => static function ($node) use ($context, $schema, &$knownDirectiveNames): ?VisitorOperation {
+                $directiveName = $node->name->value;
+
+                if ($schema !== null && $schema->getDirective($directiveName) !== null) {
+                    $context->reportError(
+                        new Error(
+                            'Directive "@' . $directiveName . '" already exists in the schema. It cannot be redefined.',
+                            $node->name,
+                        ),
+                    );
+
+                    return null;
+                }
+
+                if (isset($knownDirectiveNames[$directiveName])) {
+                    $context->reportError(
+                        new Error(
+                            'There can be only one directive named "@' . $directiveName . '".',
+                            [
+                                $knownDirectiveNames[$directiveName],
+                                $node->name,
+                            ]
+                        ),
+                    );
+                } else {
+                    $knownDirectiveNames[$directiveName] = $node->name;
+                }
+
+                return Visitor::skipNode();
+            },
         ];
     }
 }

--- a/src/Validator/Rules/UniqueDirectiveNames.php
+++ b/src/Validator/Rules/UniqueDirectiveNames.php
@@ -2,7 +2,6 @@
 
 namespace GraphQL\Validator\Rules;
 
-use function array_key_exists;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\NodeKind;
@@ -36,7 +35,7 @@ class UniqueDirectiveNames extends ValidationRule
                 return null;
             }
 
-            if (array_key_exists($directiveName, $knownDirectiveNames)) {
+            if (isset($knownDirectiveNames[$directiveName])) {
                 $context->reportError(
                     new Error(
                         'There can be only one directive named "@' . $directiveName . '".',

--- a/tests/Type/ValidationTest.php
+++ b/tests/Type/ValidationTest.php
@@ -2941,7 +2941,7 @@ class ValidationTest extends TestCaseBase
     
           directive @testA on SCHEMA
           directive @testA on SCHEMA
-        ');
+        ', null, ['assumeValidSDL' => true]);
         $this->assertMatchesValidationMessage(
             $schema->validate(),
             [

--- a/tests/Utils/SchemaExtenderLegacyTest.php
+++ b/tests/Utils/SchemaExtenderLegacyTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\TestCase;
  * Their counterparts have been removed from `extendSchema-test.js` and moved elsewhere,
  * but these changes to `graphql-js` haven't been reflected in `graphql-php` yet.
  * TODO align with:
- *   - https://github.com/graphql/graphql-js/commit/c1745228b2ae5ec89b8de36ea766d544607e21ea
  *   - https://github.com/graphql/graphql-js/commit/e6a3f08cc92594f68a6e61d3d4b46a6d279f845e.
  */
 class SchemaExtenderLegacyTest extends TestCase
@@ -187,29 +186,6 @@ class SchemaExtenderLegacyTest extends TestCase
         $extendedSchema->assertValid();
 
         return $extendedSchema;
-    }
-
-    // Extract check for unique directive names into separate rule
-
-    /**
-     * @see it('does not allow replacing a custom directive')
-     */
-    public function testDoesNotAllowReplacingACustomDirective(): void
-    {
-        $extendedSchema = $this->extendTestSchema('
-          directive @meow(if: Boolean!) on FIELD | FRAGMENT_SPREAD
-        ');
-
-        $replacementAST = Parser::parse('
-            directive @meow(if: Boolean!) on FIELD | QUERY
-        ');
-
-        try {
-            SchemaExtender::extend($extendedSchema, $replacementAST);
-            self::fail();
-        } catch (Error $error) {
-            self::assertEquals('Directive "meow" already exists in the schema. It cannot be redefined.', $error->getMessage());
-        }
     }
 
     /**

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -1390,7 +1390,7 @@ EOF
             $this->extendTestSchema($sdl);
             self::fail();
         } catch (Error $error) {
-            self::assertSame('Directive "include" already exists in the schema. It cannot be redefined.', $error->getMessage());
+            self::assertSame('Directive "@include" already exists in the schema. It cannot be redefined.', $error->getMessage());
         }
     }
 

--- a/tests/Validator/UniqueDirectiveNamesTest.php
+++ b/tests/Validator/UniqueDirectiveNamesTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQL\Tests\Validator;
+
+use GraphQL\Type\Schema;
+use GraphQL\Utils\BuildSchema;
+use GraphQL\Validator\Rules\UniqueDirectiveNames;
+
+class UniqueDirectiveNamesTest extends ValidatorTestCase
+{
+    /**
+     * @param array<int, array<string, mixed>> $errors
+     */
+    private function expectSDLErrors(string $sdlString, ?Schema $schema, array $errors): void
+    {
+        $this->expectSDLErrorsFromRule(new UniqueDirectiveNames(), $sdlString, $schema, $errors);
+    }
+
+    /**
+     * @see describe('Validate: Unique directive names')
+     * @see it('no directive')
+     */
+    public function testNoDirective(): void
+    {
+        $this->expectValidSDL(
+            new UniqueDirectiveNames(),
+            '
+      type Foo
+            '
+        );
+    }
+
+    /**
+     * @see it('one directive')
+     */
+    public function testOneDirective(): void
+    {
+        $this->expectValidSDL(
+            new UniqueDirectiveNames(),
+            '
+      directive @foo on SCHEMA
+            '
+        );
+    }
+
+    /**
+     * @see it('many directives')
+     */
+    public function testManyDirectives(): void
+    {
+        $this->expectValidSDL(
+            new UniqueDirectiveNames(),
+            '
+      directive @foo on SCHEMA
+      directive @bar on SCHEMA
+      directive @baz on SCHEMA
+            '
+        );
+    }
+
+    /**
+     * @see it('directive and non-directive definitions named the same')
+     */
+    public function testDirectiveAndNonDirectiveDefinitionsNamedTheSame(): void
+    {
+        $this->expectValidSDL(
+            new UniqueDirectiveNames(),
+            '
+      query foo { __typename }
+      fragment foo on foo { __typename }
+      type foo
+
+      directive @foo on SCHEMA
+            '
+        );
+    }
+
+    /**
+     * @see it('directives named the same')
+     */
+    public function testDirectivesNamedTheSame(): void
+    {
+        $this->expectSDLErrors(
+            '
+      directive @foo on SCHEMA
+
+      directive @foo on SCHEMA
+            ',
+            null,
+            [
+                [
+                    'message' => 'There can be only one directive named "@foo".',
+                    'locations' => [
+                        ['line' => 2, 'column' => 18],
+                        ['line' => 4, 'column' => 18],
+                    ],
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @see it('adding new directive to existing schema')
+     */
+    public function testAddingNewDirectiveToExistingSchema(): void
+    {
+        $schema = BuildSchema::build('directive @foo on SCHEMA');
+
+        $this->expectValidSDL(new UniqueDirectiveNames(), 'directive @bar on SCHEMA', $schema);
+    }
+
+    /**
+     * @see it('adding new directive with standard name to existing schema')
+     */
+    public function testAddingNewDirectiveWithStandardNameToExistingSchema(): void
+    {
+        $schema = BuildSchema::build('type foo');
+
+        $this->expectSDLErrors(
+            'directive @skip on SCHEMA',
+            $schema,
+            [
+                [
+                    'message' => 'Directive "@skip" already exists in the schema. It cannot be redefined.',
+                    'locations' => [
+                        ['line' => 1, 'column' => 12],
+                    ],
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @see it('adding new directive to existing schema with same-named type')
+     */
+    public function testAddingNewDirectiveToExistingSchemaWithSameNamedType(): void
+    {
+        $schema = BuildSchema::build('type foo');
+
+        $this->expectValidSDL(new UniqueDirectiveNames(), 'directive @foo on SCHEMA', $schema);
+    }
+
+    /**
+     * @see it('adding conflicting directives to existing schema')
+     */
+    public function testAddingConflictingDirectivesToExistingSchema(): void
+    {
+        $schema = BuildSchema::build('directive @foo on SCHEMA');
+
+        $this->expectSDLErrors(
+            'directive @foo on SCHEMA',
+            $schema,
+            [
+                [
+                    'message' => 'Directive "@foo" already exists in the schema. It cannot be redefined.',
+                    'locations' => [['line' => 1, 'column' => 12]],
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Validator/UniqueDirectiveNamesTest.php
+++ b/tests/Validator/UniqueDirectiveNamesTest.php
@@ -6,7 +6,7 @@ use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use GraphQL\Validator\Rules\UniqueDirectiveNames;
 
-class UniqueDirectiveNamesTest extends ValidatorTestCase
+final class UniqueDirectiveNamesTest extends ValidatorTestCase
 {
     /**
      * @param array<int, array<string, mixed>> $errors

--- a/tests/Validator/UniqueDirectiveNamesTest.php
+++ b/tests/Validator/UniqueDirectiveNamesTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace GraphQL\Tests\Validator;
 


### PR DESCRIPTION
Introduces `UniqueDirectiveNames` validation rule.

Corresponding change in the reference implementation: https://github.com/graphql/graphql-js/commit/c1745228b2ae5ec89b8de36ea766d544607e21ea