### PR TITLE
Run phpstan only on one php version

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,13 +11,6 @@ jobs:
     name: "Static Analysis with PHPStan"
     runs-on: "ubuntu-20.04"
 
-    strategy:
-      matrix:
-        php-version:
-          - "7.4"
-          - "8.0"
-          - "8.1"
-
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v2"
@@ -26,7 +19,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "${{ matrix.php-version }}"
+          php-version: "7.4"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"
@@ -39,11 +32,6 @@ jobs:
     name: "Static Analysis with Psalm"
     runs-on: "ubuntu-20.04"
 
-    strategy:
-      matrix:
-        php-version:
-          - "8.1"
-
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v2"
@@ -52,7 +40,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "${{ matrix.php-version }}"
+          php-version: "7.4"
           tools: "cs2pr"
 
       - name: "Install dependencies with Composer"


### PR DESCRIPTION
Running phpstan 3 times produces 3 inline comments

<img width="859" alt="image" src="https://user-images.githubusercontent.com/327717/165047044-38d8db5c-95ab-4576-8a2a-cd5e0ad4f66a.png">

Those can be e.g. filtered to be produced by a single PHP version run only but I wonder what is the reason to run in on multiple versions in the first place. AFAIK it will not show different errors when run on different php versions since we have PHP 7.4 code.