### PR TITLE
Add support for type extensions to schema build

### DIFF
--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -288,12 +288,13 @@ class ASTDefinitionBuilder
         $name = $def->name->value;
         /** @var array<int, ObjectTypeExtensionNode> $extensionASTNodes (proven by schema validation) */
         $extensionASTNodes = $this->typeExtensionsMap[$name] ?? [];
+        $allNodes = [$def, ...$extensionASTNodes];
 
         return new ObjectType([
             'name' => $name,
             'description' => $def->description->value ?? null,
-            'fields' => fn (): array => $this->makeFieldDefMap([$def, ...$extensionASTNodes]),
-            'interfaces' => fn (): array => $this->makeImplementedInterfaces([$def, ...$extensionASTNodes]),
+            'fields' => fn (): array => $this->makeFieldDefMap($allNodes),
+            'interfaces' => fn (): array => $this->makeImplementedInterfaces($allNodes),
             'astNode' => $def,
             'extensionASTNodes' => $extensionASTNodes,
         ]);
@@ -379,12 +380,13 @@ class ASTDefinitionBuilder
         $name = $def->name->value;
         /** @var array<int, InterfaceTypeExtensionNode> $extensionASTNodes (proven by schema validation) */
         $extensionASTNodes = $this->typeExtensionsMap[$name] ?? [];
+        $allNodes = [$def, ...$extensionASTNodes];
 
         return new InterfaceType([
             'name' => $name,
             'description' => $def->description->value ?? null,
-            'fields' => fn (): array => $this->makeFieldDefMap([$def, ...$extensionASTNodes]),
-            'interfaces' => fn (): array => $this->makeImplementedInterfaces([$def, ...$extensionASTNodes]),
+            'fields' => fn (): array => $this->makeFieldDefMap($allNodes),
+            'interfaces' => fn (): array => $this->makeImplementedInterfaces($allNodes),
             'astNode' => $def,
             'extensionASTNodes' => $extensionASTNodes,
         ]);

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -148,9 +148,7 @@ class BuildSchema
                     $typeDefinitionsMap[$definition->name->value] = $definition;
                     break;
                 case $definition instanceof TypeExtensionNode:
-                    $extendedTypeName = $definition->name->value;
-                    $existingTypeExtensions = $typeExtensionsMap[$extendedTypeName] ?? [];
-                    $typeExtensionsMap[$extendedTypeName] = [...$existingTypeExtensions, $definition];
+                    $typeExtensionsMap[$definition->name->value][] = $definition;
                     break;
                 case $definition instanceof DirectiveDefinitionNode:
                     $directiveDefs[] = $definition;

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -8,6 +8,7 @@ use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\SchemaDefinitionNode;
 use GraphQL\Language\AST\TypeDefinitionNode;
+use GraphQL\Language\AST\TypeExtensionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Language\Source;
 use GraphQL\Type\Definition\Directive;
@@ -135,6 +136,8 @@ class BuildSchema
         $schemaDef = null;
         $this->nodeMap = [];
 
+        /** @var array<string, array<int, TypeExtensionNode>> $typeExtensionsMap */
+        $typeExtensionsMap = [];
         /** @var array<int, DirectiveDefinitionNode> $directiveDefs */
         $directiveDefs = [];
 
@@ -145,6 +148,11 @@ class BuildSchema
                     break;
                 case $definition instanceof TypeDefinitionNode:
                     $this->nodeMap[$definition->name->value] = $definition;
+                    break;
+                case $definition instanceof TypeExtensionNode:
+                    $extendedTypeName = $definition->name->value;
+                    $existingTypeExtensions = $typeExtensionsMap[$extendedTypeName] ?? [];
+                    $typeExtensionsMap[$extendedTypeName] = [...$existingTypeExtensions, $definition];
                     break;
                 case $definition instanceof DirectiveDefinitionNode:
                     $directiveDefs[] = $definition;

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -112,6 +112,7 @@ class SchemaExtender
 
         static::$astBuilder = new ASTDefinitionBuilder(
             $typeDefinitionMap,
+            [],
             static function (string $typeName) use ($schema): Type {
                 $existingType = $schema->getType($typeName);
                 if ($existingType === null) {

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -752,8 +752,8 @@ type Query {
             directive @bar on SCALAR
         ");
 
-        /** @var ScalarType $someScalar */
         $someScalar = $schema->getType('SomeScalar');
+        assert($someScalar instanceof ScalarType);
 
         $expectedSomeScalarSDL = <<<'GRAPHQL'
             scalar SomeScalar
@@ -790,8 +790,8 @@ type Query {
             interface Baz
         ");
 
-        /** @var ObjectType $someObject */
         $someObject = $schema->getType('SomeObject');
+        assert($someObject instanceof ObjectType);
 
         $expectedSomeObjectSDL = <<<'GRAPHQL'
             type SomeObject implements Foo & Bar & Baz {
@@ -827,8 +827,8 @@ type Query {
 
         $schema = BuildSchema::build($interfaceSDL);
 
-        /** @var InterfaceType $someInterface */
         $someInterface = $schema->getType('SomeInterface');
+        assert($someInterface instanceof InterfaceType);
 
         $expectedSomeInterfaceSDL = <<<'GRAPHQL'
             interface SomeInterface {
@@ -863,8 +863,8 @@ type Query {
             type ThirdType
         ");
 
-        /** @var UnionType $someUnion */
         $someUnion = $schema->getType('SomeUnion');
+        assert($someUnion instanceof UnionType);
 
         $expectedSomeUnionSDL = <<<'GRAPHQL'
             union SomeUnion = FirstType | SecondType | ThirdType
@@ -896,8 +896,8 @@ type Query {
 
         $schema = BuildSchema::build($enumSDL);
 
-        /** @var EnumType $someEnum */
         $someEnum = $schema->getType('SomeEnum');
+        assert($someEnum instanceof EnumType);
 
         $expectedSomeEnumSDL = <<<'GRAPHQL'
             enum SomeEnum {
@@ -933,8 +933,8 @@ type Query {
 
         $schema = BuildSchema::build($inputSDL);
 
-        /** @var InputObjectType $someInput */
         $someInput = $schema->getType('SomeInput');
+        assert($someInput instanceof InputObjectType);
 
         $expectedSomeInputSDL = <<<'GRAPHQL'
             input SomeInput {

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -990,20 +990,20 @@ interface Hello {
         $schema->getTypeMap();
         self::assertEquals(['Query', 'Color', 'Hello'], $decorated);
 
-        [$defaultConfig, $node, $allNodesMap] = $calls[0];
+        [$defaultConfig, $node, $allNodesMap] = $calls[0]; // type Query
         self::assertInstanceOf(ObjectTypeDefinitionNode::class, $node);
         self::assertEquals('Query', $defaultConfig['name']);
         self::assertInstanceOf(Closure::class, $defaultConfig['fields']);
         self::assertInstanceOf(Closure::class, $defaultConfig['interfaces']);
         self::assertArrayHasKey('description', $defaultConfig);
-        self::assertCount(5, $defaultConfig);
+        self::assertCount(6, $defaultConfig);
         self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
 
         $query = $schema->getType('Query');
         self::assertInstanceOf(ObjectType::class, $query);
         self::assertEquals('My description of Query', $query->description);
 
-        [$defaultConfig, $node, $allNodesMap] = $calls[1];
+        [$defaultConfig, $node, $allNodesMap] = $calls[1]; // enum Color
         self::assertInstanceOf(EnumTypeDefinitionNode::class, $node);
         self::assertEquals('Color', $defaultConfig['name']);
         $enumValue = [
@@ -1018,20 +1018,20 @@ interface Hello {
             ],
             $defaultConfig['values']
         );
-        self::assertCount(4, $defaultConfig); // 3 + astNode
+        self::assertCount(5, $defaultConfig); // 3 + astNode + extensionASTNodes
         self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
 
         $color = $schema->getType('Color');
         self::assertInstanceOf(EnumType::class, $color);
         self::assertEquals('My description of Color', $color->description);
 
-        [$defaultConfig, $node, $allNodesMap] = $calls[2];
+        [$defaultConfig, $node, $allNodesMap] = $calls[2]; // interface Hello
         self::assertInstanceOf(InterfaceTypeDefinitionNode::class, $node);
         self::assertEquals('Hello', $defaultConfig['name']);
         self::assertInstanceOf(Closure::class, $defaultConfig['fields']);
         self::assertArrayHasKey('description', $defaultConfig);
         self::assertArrayHasKey('interfaces', $defaultConfig);
-        self::assertCount(5, $defaultConfig);
+        self::assertCount(6, $defaultConfig);
         self::assertEquals(array_keys($allNodesMap), ['Query', 'Color', 'Hello']);
 
         $hello = $schema->getType('Hello');


### PR DESCRIPTION
Type extensions (e.g. `extend type MyType { newField: String }`) currently works only with the schema extender, they are silently ignored by the schema builder (types are not extended, `extensionASTNodes` is not set). This PR fixes that and adds support for type extensions to schema build.

Similar changes in the reference implementation: https://github.com/graphql/graphql-js/commit/1283c8431b561c529adfdfc0ade845fad2a09ade

Tests by origin from `graphql-js` come from #928 and #929; this PR brings these two a bit closer to closing.

I'll later do a similar change for schema extension.  

(Draft PR for now as I still need to self-review, but should be good in general.)