### PR TITLE
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add SDL validation rule `UniqueTypeNames` (#998)
 - Add support for SDL validation to `KnownTypeNames` rule (#999)
 - Add SDL validation rule `UniqueArgumentDefinitionNames` (#1136)
+- Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 
 ### Optimized
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -34,8 +34,7 @@ use function str_replace;
 /**
  * Prints the contents of a Schema in schema definition language.
  *
- * @phpstan-type Options array{}
- * @psalm-type Options array<never, never>
+ * @phpstan-type Options array{sortTypes?: bool}
  */
 class SchemaPrinter
 {
@@ -115,6 +114,10 @@ class SchemaPrinter
     {
         $directives = array_filter($schema->getDirectives(), $directiveFilter);
         $types = array_filter($schema->getTypeMap(), $typeFilter);
+
+        if (isset($options['sortTypes']) && $options['sortTypes'] === true) {
+            ksort($types);
+        }
 
         $elements = [static::printSchemaDefinition($schema)];
 

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -6,7 +6,6 @@ use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
-use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -6,6 +6,7 @@ use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
@@ -17,15 +18,20 @@ use GraphQL\Utils\SchemaPrinter;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @phpstan-import-type Options from SchemaPrinter
+ *
  * @see describe('Type System Printer', () => {
  */
 final class SchemaPrinterTest extends TestCase
 {
-    private static function assertPrintedSchemaEquals(string $expected, Schema $schema): void
+    /**
+     * @param Options $options
+     */
+    private static function assertPrintedSchemaEquals(string $expected, Schema $schema, array $options = []): void
     {
-        $printedSchema = SchemaPrinter::doPrint($schema);
+        $printedSchema = SchemaPrinter::doPrint($schema, $options);
         $builtSchema = BuildSchema::build($printedSchema);
-        $cycledSchema = SchemaPrinter::doPrint($builtSchema);
+        $cycledSchema = SchemaPrinter::doPrint($builtSchema, $options);
 
         self::assertEquals($printedSchema, $cycledSchema);
         self::assertEquals($expected, $printedSchema);
@@ -1169,5 +1175,35 @@ final class SchemaPrinterTest extends TestCase
 
       GRAPHQL;
         self::assertEquals($expected, $output);
+    }
+
+    public function testPrintSchemaWithSortedTypes(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new EnumType(['name' => 'SomeEnum', 'values' => []]),
+                new InputObjectType(['name' => 'InputObject', 'fields' => []]),
+                new InterfaceType(['name' => 'FooInterface', 'fields' => []]),
+                new ObjectType(['name' => 'Abc', 'fields' => []]),
+                new UnionType(['name' => 'Union', 'types' => []]),
+            ],
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            type Abc
+
+            interface FooInterface
+
+            input InputObject
+            
+            enum SomeEnum
+
+            union Union
+
+            GRAPHQL,
+            $schema,
+            ['sortTypes' => true]
+        );
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1176,6 +1176,9 @@ final class SchemaPrinterTest extends TestCase
         self::assertEquals($expected, $output);
     }
 
+    /**
+     * Additional functionality not present in the reference implementation.
+     */
     public function testPrintSchemaWithSortedTypes(): void
     {
         $schema = new Schema([


### PR DESCRIPTION
This was removed in 9791dc1e1be817f44e41dfdb01abc98b108f6f92 but for some projects
it is useful to keep the schema sorted.