### PR TITLE
Allow retrieving directive values from type definitions

### DIFF
--- a/src/Executor/Values.php
+++ b/src/Executor/Values.php
@@ -15,6 +15,7 @@ use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Language\AST\NullValueNode;
+use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\VariableDefinitionNode;
 use GraphQL\Language\AST\VariableNode;
 use GraphQL\Language\Printer;
@@ -131,7 +132,7 @@ class Values
      *
      * If the directive does not exist on the node, returns undefined.
      *
-     * @param FragmentSpreadNode|FieldNode|InlineFragmentNode|EnumValueDefinitionNode|FieldDefinitionNode $node
+     * @param FragmentSpreadNode|FieldNode|InlineFragmentNode|EnumValueDefinitionNode|FieldDefinitionNode|TypeDefinitionNode $node
      * @param array<string, mixed>|null $variableValues
      *
      * @return array<string, mixed>|null


### PR DESCRIPTION
When using `Values::getDirectiveValues()` with a  type definition `$info->returnType->astNode`; PHPStan was giving the following error:

`Parameter #2 $node of static method GraphQL\Executor\Values::getDirectiveValues() expects GraphQL\Language\AST\EnumValueDefinitionNode|GraphQL\Language\AST\FieldDefinitionNode|GraphQL\Language\AST\FieldNode|GraphQL\Language\AST\FragmentSpreadNode|GraphQL\Language\AST\InlineFragmentNode, GraphQL\Language\AST\TypeDefinitionNode given.`

It should be possible to retrieve directive values from type definitions, e.g: `type Test @testDirective(testValue: "test")`