### PR TITLE
Avoid calling `FormattedError::addDebugEntries()` twice when using default error formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Clone `NodeList` in `Node::cloneDeep()`
 - Calling `Schema::getType()` on a schema built from SDL returns `null` for unknown types (#1068)
 - Avoid crash on typeless inline fragment when using `QueryComplexity` rule
+- Avoid calling `FormattedError::addDebugEntries()` twice when using default error formatting
 
 ### Removed
 

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -245,7 +245,12 @@ class FormattedError
      */
     public static function prepareFormatter(?callable $formatter, int $debug): callable
     {
-        $formatter ??= [self::class, 'createFromException'];
+        // Prevents double work of adding debug entries
+        if(null !== $formatter && $debug !== DebugFlag::NONE) {
+            $formatter = static fn (Throwable $e): array => self::addDebugEntries($formatter($e), $e, $debug);
+        } else {
+            $formatter = [self::class, 'createFromException'];
+        }
 
         return $formatter;
     }

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -245,14 +245,9 @@ class FormattedError
      */
     public static function prepareFormatter(?callable $formatter, int $debug): callable
     {
-        // Prevents double work of adding debug entries
-        if(null !== $formatter && $debug !== DebugFlag::NONE) {
-            $formatter = static fn (Throwable $e): array => self::addDebugEntries($formatter($e), $e, $debug);
-        } else {
-            $formatter = [self::class, 'createFromException'];
-        }
-
-        return $formatter;
+        return null === $formatter
+            ? static fn (Throwable $e): array => static::createFromException($e, $debug)
+            : static fn (Throwable $e): array => static::addDebugEntries($formatter($e), $e, $debug);
     }
 
     /**

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -247,10 +247,6 @@ class FormattedError
     {
         $formatter ??= [self::class, 'createFromException'];
 
-        if ($debug !== DebugFlag::NONE) {
-            $formatter = static fn (Throwable $e): array => self::addDebugEntries($formatter($e), $e, $debug);
-        }
-
         return $formatter;
     }
 


### PR DESCRIPTION
Its already added inside `createFromException`

https://github.com/webonyx/graphql-php/blob/master/src/Error/FormattedError.php#L182-L184