### PR TITLE
Ensure `InputObjectType::parseValue()` works with literals and extended schemas

### DIFF
--- a/src/Utils/AST.php
+++ b/src/Utils/AST.php
@@ -432,7 +432,7 @@ class AST
                 $coercedObj[$fieldName] = $fieldValue;
             }
 
-            return $coercedObj;
+            return $type->parseValue($coercedObj);
         }
 
         if ($type instanceof EnumType) {

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -253,7 +253,7 @@ class SchemaExtender
             'fields' => fn (): array => $this->extendInputFieldMap($type),
             'astNode' => $type->astNode,
             'extensionASTNodes' => $extensionASTNodes,
-            'parseValue' => $type->config['parseValue'] ?? null
+            'parseValue' => [$type, 'parseValue']
         ]);
     }
 

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -253,7 +253,7 @@ class SchemaExtender
             'fields' => fn (): array => $this->extendInputFieldMap($type),
             'astNode' => $type->astNode,
             'extensionASTNodes' => $extensionASTNodes,
-            'parseValue' => [$type, 'parseValue']
+            'parseValue' => [$type, 'parseValue'],
         ]);
     }
 

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -253,6 +253,7 @@ class SchemaExtender
             'fields' => fn (): array => $this->extendInputFieldMap($type),
             'astNode' => $type->astNode,
             'extensionASTNodes' => $extensionASTNodes,
+            'parseValue' => $type->config['parseValue'] ?? null
         ]);
     }
 

--- a/tests/Type/InputObjectTypeTest.php
+++ b/tests/Type/InputObjectTypeTest.php
@@ -54,7 +54,7 @@ final class StoryFiltersInputExtended
 
     public Tag $tag;
 
-    public $valueFromExtended;
+    public ?string $valueFromExtended;
 
     public function __construct(string $author, bool $popular, Tag $tag, ?string $valueFromExtended)
     {
@@ -337,8 +337,6 @@ QUERY;
             Assert::assertEquals('John', $args['input']->author);
             Assert::assertTrue($args['input']->popular);
             Assert::assertEquals('value', $args['input']->valueFromExtended);
-
-            Assert::assertInstanceOf(Tag::class, $args['input']->tag);
             Assert::assertEquals('foo', $args['input']->tag->name);
             Assert::assertEquals('bar', $args['input']->tag->value);
 

--- a/tests/Type/InputObjectTypeTest.php
+++ b/tests/Type/InputObjectTypeTest.php
@@ -123,15 +123,14 @@ final class InputObjectTypeTest extends TestCase
 
         $schema = new Schema(['mutation' => $mutation]);
 
-        $query = /** @lang GraphQL */ '
-            mutation ($input: StoryFiltersInput!) {
-                action(input: $input)
-            }
-        ';
-
         $result = GraphQL::executeQuery(
             $schema,
-            $query,
+            /** @lang text */ 
+            '
+                mutation ($input: StoryFiltersInput!) {
+                    action(input: $input)
+                }
+            ',
             null,
             null,
             [
@@ -150,7 +149,6 @@ final class InputObjectTypeTest extends TestCase
             ['data' => ['action' => true]],
             $result->toArray()
         );
-        GraphQL::executeQuery($schema, $query);
     }
 
     public function testParseValueFromLiterals(): void
@@ -296,7 +294,7 @@ final class InputObjectTypeTest extends TestCase
 
         $result = GraphQL::executeQuery(
             $schema,
-            /** @lang GraphQL */ 
+            /** @lang GraphQL */
             '
                 mutation ($authorName: ID!, $tagName: String!) {
                     action(input: {
@@ -354,15 +352,14 @@ final class InputObjectTypeTest extends TestCase
 
         $schema = new Schema(['mutation' => $mutation]);
 
-        $query = /** @lang GraphQL */ '
-            mutation ($input: StoryFiltersInput) {
-                action(input: $input)
-            }
-        ';
-
         $result = GraphQL::executeQuery(
             $schema,
-            $query,
+            /** @lang GraphQL */ 
+            '
+                mutation ($input: StoryFiltersInput) {
+                    action(input: $input)
+                }
+            ',
             null,
             null,
             [
@@ -374,7 +371,6 @@ final class InputObjectTypeTest extends TestCase
             ['data' => ['action' => true]],
             $result->toArray()
         );
-        GraphQL::executeQuery($schema, $query);
     }
 
     public function testParseValueWithExtendedSchema(): void
@@ -436,7 +432,7 @@ final class InputObjectTypeTest extends TestCase
 
         $result = GraphQL::executeQuery(
             $schema,
-            /** @lang GraphQL */ 
+            /** @lang GraphQL */
             '
                 mutation ($input: StoryFiltersInput!) {
                     action(input: $input)

--- a/tests/Type/InputObjectTypeTest.php
+++ b/tests/Type/InputObjectTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace GraphQL\Tests\Type;
 
+use GraphQL\Error\DebugFlag;
 use GraphQL\Examples\Blog\Types;
 use GraphQL\GraphQL;
 use GraphQL\Language\AST\TypeDefinitionNode;
@@ -203,7 +204,8 @@ final class InputObjectTypeTest extends TestCase
         GraphQL::executeQuery($schema, $query);
     }
 
-    private function prepareExtendedSchema() {
+    private function prepareExtendedSchema()
+    {
         $schema = <<<SCHEMA
 schema {
   mutation: Mutation
@@ -294,7 +296,7 @@ SCHEMA;
 
         self::assertEquals(
             ['data' => ['action' => true]],
-            $result->toArray()
+            $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)
         );
     }
 
@@ -320,7 +322,33 @@ QUERY;
 
         self::assertEquals(
             ['data' => ['action' => true]],
-            $result->toArray()
+            $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)
+        );
+    }
+
+    public function testParseWithExtendedSchemaAndVariablesAndLiterals(): void
+    {
+        $schema = $this->prepareExtendedSchema();
+
+        $query = <<<QUERY
+mutation DoAction(\$authorName: ID!, \$tagName: String!) {
+    action(input: {
+        author: \$authorName
+        popular: true,
+        valueFromExtended: null
+        tag: {
+            name: \$tagName
+            value: "bar"
+        }
+    })
+}
+QUERY;
+
+        $result = GraphQL::executeQuery($schema, $query, null, null, ['authorName' => 'John', 'tagName' => 'foo']);
+
+        self::assertEquals(
+            ['data' => ['action' => true]],
+            $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)
         );
     }
 }


### PR DESCRIPTION
Fixes #1178