### PR TITLE
Add `TypeInfo::getParentTypeStack()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object
 - Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 - Allow constructing `EnumType` from PHP enum
-- Add `getParentTypeStack()` method to `TypeInfo.php`
+- Add `TypeInfo::getParentTypeStack()`
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object
 - Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 - Allow constructing `EnumType` from PHP enum
+- Add `getParentTypeStack()` method to `TypeInfo.php`
 
 ### Optimized
 

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -69,6 +69,14 @@ class TypeInfo
     }
 
     /**
+     * @return array<int, (CompositeType&Type)|null>
+     */
+    public function getParentTypeStack(): array
+    {
+        return $this->parentTypeStack;
+    }
+
+    /**
      * Given root type scans through all fields to find nested types.
      *
      * Returns array where keys are for type name


### PR DESCRIPTION
Hi,
The TypeInfo can be used in Visitor and in my use case I need the path to the current node. The information is already on private property there and I only need to get it.