### PR TITLE
Add `TypeInfo::getFieldDefStack()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object
 - Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 - Allow constructing `EnumType` from PHP enum
-- Add `TypeInfo::getParentTypeStack()`
+- Add `TypeInfo::getParentTypeStack()` and `TypeInfo::getFieldDefStack()`
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object
 - Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 - Allow constructing `EnumType` from PHP enum
-- Add `getParentTypeStack()` method to `TypeInfo.php`
+- Add `TypeInfo::getParentTypeStack()`
 
 ### Optimized
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Add `parseValue` config option to InputObjectType to parse input value to custom value object
 - Add option `sortTypes` to have `SchemaPrinter` order types alphabetically
 - Allow constructing `EnumType` from PHP enum
+- Add `getParentTypeStack()` method to `TypeInfo.php`
 
 ### Optimized
 

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -77,6 +77,14 @@ class TypeInfo
     }
 
     /**
+     * @return array<int, FieldDefinition|null>
+     */
+    public function getFieldDefStack(): array
+    {
+        return $this->fieldDefStack;
+    }
+
+    /**
      * Given root type scans through all fields to find nested types.
      *
      * Returns array where keys are for type name

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -69,6 +69,14 @@ class TypeInfo
     }
 
     /**
+     * @return array<int, (CompositeType&Type)|null>
+     */
+    public function getParentTypeStack(): array
+    {
+        return $this->parentTypeStack;
+    }
+
+    /**
      * Given root type scans through all fields to find nested types.
      *
      * Returns array where keys are for type name


### PR DESCRIPTION
Hi,
The data inside `fieldDefStack` is much similar to the data inside `ResolveInfo->path`, and it is much easier to create the path to the field with it.