### PR TITLE
Use `"` instead of `"""` for single line descriptions

### DIFF
--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -139,10 +139,13 @@ class BlockString
             : $value;
         if ($printAsMultipleLines) {
             $result .= "\n";
+            $quoting = '"""';
+        } else {
+            $quoting = '"';
         }
 
-        return '"""'
-            . str_replace('"""', '\\"""', $result)
-            . '"""';
+        return $quoting
+            . str_replace($quoting, '\\' . $quoting, $result)
+            . $quoting;
     }
 }

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -410,7 +410,7 @@ class Printer
 
             case $node instanceof StringValueNode:
                 if ($node->block) {
-                    return BlockString::print($node->value, $isDescription ? '' : '  ');
+                    return BlockString::print($node->value, $isDescription ? '' : '  ', true);
                 }
 
                 return json_encode($node->value, JSON_THROW_ON_ERROR);

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -191,7 +191,7 @@ class BlockStringTest extends TestCase
     {
         $str = 'one liner';
 
-        self::assertEquals('"""one liner"""', BlockString::print($str));
+        self::assertEquals('"one liner"', BlockString::print($str));
         self::assertEquals("\"\"\"\none liner\n\"\"\"", BlockString::print($str, '', true));
     }
 
@@ -202,7 +202,7 @@ class BlockStringTest extends TestCase
     {
         $str = '    space-led string';
 
-        self::assertEquals('"""    space-led string"""', BlockString::print($str));
+        self::assertEquals('"    space-led string"', BlockString::print($str));
         self::assertEquals("\"\"\"    space-led string\n\"\"\"", BlockString::print($str, '', true));
     }
 
@@ -257,7 +257,7 @@ class BlockStringTest extends TestCase
     {
         $str = '';
 
-        self::assertEquals('""""""', BlockString::print($str));
+        self::assertEquals('""', BlockString::print($str));
         self::assertEquals("\"\"\"\n\n\"\"\"", BlockString::print($str, '', true));
     }
 }

--- a/tests/Language/SchemaPrinterTest.php
+++ b/tests/Language/SchemaPrinterTest.php
@@ -63,9 +63,13 @@ of the `Foo` type.
 """
 type Foo implements Bar & Baz & Two {
   one: Type
-  """This is a description of the `two` field."""
+  """
+  This is a description of the `two` field.
+  """
   two(
-    """This is a description of the `argument` argument."""
+    """
+    This is a description of the `argument` argument.
+    """
     argument: InputType!
   ): Type
   three(argument: InputType, other: String): Int

--- a/tests/Language/schema-kitchen-sink.graphql
+++ b/tests/Language/schema-kitchen-sink.graphql
@@ -14,9 +14,7 @@ of the `Foo` type.
 """
 type Foo implements Bar & Baz & Two {
 one: Type
-"""
-This is a description of the `two` field.
-"""
+"""This is a description of the `two` field."""
 two(
   """
   This is a description of the `argument` argument.

--- a/tests/Type/PhpEnumTypeTest.php
+++ b/tests/Type/PhpEnumTypeTest.php
@@ -34,9 +34,9 @@ final class PhpEnumTypeTest extends TestCaseBase
         $enumType = new PhpEnumType(PhpEnum::class);
         self::assertSame(
             <<<'GRAPHQL'
-"""foo"""
+"foo"
 enum PhpEnum {
-  """bar"""
+  "bar"
   A
   B @deprecated
   C @deprecated(reason: "baz")
@@ -51,9 +51,9 @@ GRAPHQL,
         $enumType = new PhpEnumType(DocBlockPhpEnum::class);
         self::assertSame(
             <<<'GRAPHQL'
-"""foo"""
+"foo"
 enum DocBlockPhpEnum {
-  """preferred"""
+  "preferred"
   A
 
   """

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -233,42 +233,42 @@ final class BuildSchemaTest extends TestCaseBase
             }
         */
         $sdl = <<<GRAPHQL
-            """This is a directive"""
+            "This is a directive"
             directive @foo(
-              """It has an argument"""
+              "It has an argument"
               arg: Int
             ) on FIELD
             
-            """Who knows what inside this scalar?"""
+            "Who knows what inside this scalar?"
             scalar MysteryScalar
             
-            """This is a input object type"""
+            "This is a input object type"
             input FooInput {
-              """It has a field"""
+              "It has a field"
               field: Int
             }
             
-            """This is a interface type"""
+            "This is a interface type"
             interface Energy {
-              """It also has a field"""
+              "It also has a field"
               str: String
             }
             
-            """There is nothing inside!"""
+            "There is nothing inside!"
             union BlackHole
 
-            """With an enum"""
+            "With an enum"
             enum Color {
               RED
             
-              """Not a creative color"""
+              "Not a creative color"
               GREEN
               BLUE
             }
             
-            """What a great type"""
+            "What a great type"
             type Query {
-              """And a field to boot"""
+              "And a field to boot"
               str: String
             }
             

--- a/tests/Utils/SchemaExtenderTest.php
+++ b/tests/Utils/SchemaExtenderTest.php
@@ -146,7 +146,7 @@ final class SchemaExtenderTest extends TestCaseBase
           type SomeObject implements AnotherInterface & SomeInterface {
             self: SomeObject
             tree: [SomeObject]!
-            """Old field description."""
+            "Old field description."
             oldField: String
           }
 
@@ -160,7 +160,7 @@ final class SchemaExtenderTest extends TestCaseBase
         ');
         $extensionSDL = '
           extend type SomeObject {
-            """New field description."""
+            "New field description."
             newField(arg: Boolean): String
           }
         ';
@@ -172,9 +172,9 @@ final class SchemaExtenderTest extends TestCaseBase
 type SomeObject implements AnotherInterface & SomeInterface {
   self: SomeObject
   tree: [SomeObject]!
-  """Old field description."""
+  "Old field description."
   oldField: String
-  """New field description."""
+  "New field description."
   newField(arg: Boolean): String
 }
 GRAPHQL,
@@ -201,7 +201,7 @@ GRAPHQL,
         self::assertSame(
             <<<GRAPHQL
               type Query {
-                """Actually use this description."""
+                "Actually use this description."
                 newField: String
               }
               GRAPHQL,
@@ -296,13 +296,13 @@ GRAPHQL,
           directive @foo(arg: SomeEnum) on SCHEMA
 
           enum SomeEnum {
-            """Old value description."""
+            "Old value description."
             OLD_VALUE
           }
         ');
         $extendAST = Parser::parse('
           extend enum SomeEnum {
-            """New value description."""
+            "New value description."
             NEW_VALUE
           }
         ');
@@ -312,9 +312,9 @@ GRAPHQL,
         self::assertSame(
             <<<GRAPHQL
               enum SomeEnum {
-                """Old value description."""
+                "Old value description."
                 OLD_VALUE
-                """New value description."""
+                "New value description."
                 NEW_VALUE
               }
               GRAPHQL,
@@ -387,13 +387,13 @@ GRAPHQL,
           directive @foo(arg: SomeInput) on SCHEMA
 
           input SomeInput {
-            """Old field description."""
+            "Old field description."
             oldField: String
           }
         ');
         $extendAST = Parser::parse('
           extend input SomeInput {
-            """New field description."""
+            "New field description."
             newField: String
           }
         ');
@@ -403,9 +403,9 @@ GRAPHQL,
         self::assertSame(
             <<<GRAPHQL
               input SomeInput {
-                """Old field description."""
+                "Old field description."
                 oldField: String
-                """New field description."""
+                "New field description."
                 newField: String
               }
               GRAPHQL,
@@ -1391,7 +1391,7 @@ GRAPHQL,
             }
         ');
         $extensionSDL = <<<GRAPHQL
-            """New directive."""
+            "New directive."
             directive @new(enable: Boolean!, tag: String) repeatable on QUERY | FIELD
             GRAPHQL;
         $extendedSchema = SchemaExtender::extend($schema, Parser::parse($extensionSDL));

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -262,10 +262,10 @@ final class SchemaPrinterTest extends TestCase
             type Foo {
               one: String
 
-              """This is two"""
+              "This is two"
               two: String
 
-              """This is three"""
+              "This is three"
               three: String
 
               four: String
@@ -488,16 +488,16 @@ final class SchemaPrinterTest extends TestCase
             <<<'GRAPHQL'
             type Query {
               singleField(
-                """This is the first argument"""
+                "This is the first argument"
                 argOne: Int
 
-                """This is the second argument"""
+                "This is the second argument"
                 argTwo: String
 
                 argThree: Boolean
                 argFour: Boolean
 
-                """This is the fifth argument"""
+                "This is the fifth argument"
                 argFive: String
               ): String
             }
@@ -902,7 +902,7 @@ final class SchemaPrinterTest extends TestCase
             <<<'GRAPHQL'
             directive @simpleDirective on FIELD
 
-            """Complex Directive"""
+            "Complex Directive"
             directive @complexDirective(stringArg: String, intArg: Int = -1) repeatable on FIELD | QUERY
 
             GRAPHQL,
@@ -923,7 +923,7 @@ final class SchemaPrinterTest extends TestCase
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
             type Query {
-              """"""
+              ""
               singleField: String
             }
 
@@ -945,7 +945,7 @@ final class SchemaPrinterTest extends TestCase
         self::assertPrintedSchemaEquals(
             <<<'GRAPHQL'
             type Query {
-              """This field is awesome"""
+              "This field is awesome"
               singleField: String
             }
 
@@ -967,7 +967,7 @@ final class SchemaPrinterTest extends TestCase
       Directs the executor to include this field or fragment only when the `if` argument is true.
       """
       directive @include(
-        """Included when true."""
+        "Included when true."
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
@@ -975,11 +975,11 @@ final class SchemaPrinterTest extends TestCase
       Directs the executor to skip this field or fragment when the `if` argument is true.
       """
       directive @skip(
-        """Skipped when true."""
+        "Skipped when true."
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-      """Marks an element of a GraphQL schema as no longer supported."""
+      "Marks an element of a GraphQL schema as no longer supported."
       directive @deprecated(
         """
         Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).
@@ -991,10 +991,10 @@ final class SchemaPrinterTest extends TestCase
       A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
       """
       type __Schema {
-        """A list of all types supported by this server."""
+        "A list of all types supported by this server."
         types: [__Type!]!
 
-        """The type that query operations will be rooted at."""
+        "The type that query operations will be rooted at."
         queryType: __Type!
 
         """
@@ -1007,7 +1007,7 @@ final class SchemaPrinterTest extends TestCase
         """
         subscriptionType: __Type
 
-        """A list of all directives supported by this server."""
+        "A list of all directives supported by this server."
         directives: [__Directive!]!
       }
 
@@ -1028,9 +1028,9 @@ final class SchemaPrinterTest extends TestCase
         ofType: __Type
       }
 
-      """An enum describing what kind of type a given `__Type` is."""
+      "An enum describing what kind of type a given `__Type` is."
       enum __TypeKind {
-        """Indicates this type is a scalar."""
+        "Indicates this type is a scalar."
         SCALAR
 
         """
@@ -1043,10 +1043,10 @@ final class SchemaPrinterTest extends TestCase
         """
         INTERFACE
 
-        """Indicates this type is a union. `possibleTypes` is a valid field."""
+        "Indicates this type is a union. `possibleTypes` is a valid field."
         UNION
 
-        """Indicates this type is an enum. `enumValues` is a valid field."""
+        "Indicates this type is an enum. `enumValues` is a valid field."
         ENUM
 
         """
@@ -1054,10 +1054,10 @@ final class SchemaPrinterTest extends TestCase
         """
         INPUT_OBJECT
 
-        """Indicates this type is a list. `ofType` is a valid field."""
+        "Indicates this type is a list. `ofType` is a valid field."
         LIST
 
-        """Indicates this type is a non-null. `ofType` is a valid field."""
+        "Indicates this type is a non-null. `ofType` is a valid field."
         NON_NULL
       }
 
@@ -1114,61 +1114,61 @@ final class SchemaPrinterTest extends TestCase
       A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
       """
       enum __DirectiveLocation {
-        """Location adjacent to a query operation."""
+        "Location adjacent to a query operation."
         QUERY
 
-        """Location adjacent to a mutation operation."""
+        "Location adjacent to a mutation operation."
         MUTATION
 
-        """Location adjacent to a subscription operation."""
+        "Location adjacent to a subscription operation."
         SUBSCRIPTION
 
-        """Location adjacent to a field."""
+        "Location adjacent to a field."
         FIELD
 
-        """Location adjacent to a fragment definition."""
+        "Location adjacent to a fragment definition."
         FRAGMENT_DEFINITION
 
-        """Location adjacent to a fragment spread."""
+        "Location adjacent to a fragment spread."
         FRAGMENT_SPREAD
 
-        """Location adjacent to an inline fragment."""
+        "Location adjacent to an inline fragment."
         INLINE_FRAGMENT
 
-        """Location adjacent to a variable definition."""
+        "Location adjacent to a variable definition."
         VARIABLE_DEFINITION
 
-        """Location adjacent to a schema definition."""
+        "Location adjacent to a schema definition."
         SCHEMA
 
-        """Location adjacent to a scalar definition."""
+        "Location adjacent to a scalar definition."
         SCALAR
 
-        """Location adjacent to an object type definition."""
+        "Location adjacent to an object type definition."
         OBJECT
 
-        """Location adjacent to a field definition."""
+        "Location adjacent to a field definition."
         FIELD_DEFINITION
 
-        """Location adjacent to an argument definition."""
+        "Location adjacent to an argument definition."
         ARGUMENT_DEFINITION
 
-        """Location adjacent to an interface definition."""
+        "Location adjacent to an interface definition."
         INTERFACE
 
-        """Location adjacent to a union definition."""
+        "Location adjacent to a union definition."
         UNION
 
-        """Location adjacent to an enum definition."""
+        "Location adjacent to an enum definition."
         ENUM
 
-        """Location adjacent to an enum value definition."""
+        "Location adjacent to an enum value definition."
         ENUM_VALUE
 
-        """Location adjacent to an input object type definition."""
+        "Location adjacent to an input object type definition."
         INPUT_OBJECT
 
-        """Location adjacent to an input object field definition."""
+        "Location adjacent to an input object field definition."
         INPUT_FIELD_DEFINITION
       }
 


### PR DESCRIPTION
I've checked the spec and it says to use single double quotes to quote single line descriptions.

See https://spec.graphql.org/October2021/#sec-Descriptions