### PR TITLE
Simplify Schema::getType()

### DIFF
--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -256,6 +256,7 @@ class Schema
         if (isset($this->resolvedTypes[$name])) {
             return $this->resolvedTypes[$name];
         }
+
         $introspectionTypes = Introspection::getTypes();
         if (isset($introspectionTypes[$name])) {
             return $introspectionTypes[$name];

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -253,26 +253,25 @@ class Schema
      */
     public function getType(string $name): ?Type
     {
-        if (! isset($this->resolvedTypes[$name])) {
-            $introspectionTypes = Introspection::getTypes();
-            if (isset($introspectionTypes[$name])) {
-                return $introspectionTypes[$name];
-            }
-
-            $standardTypes = Type::getStandardTypes();
-            if (isset($standardTypes[$name])) {
-                return $standardTypes[$name];
-            }
-
-            $type = $this->loadType($name);
-            if ($type === null) {
-                return null;
-            }
-
-            return $this->resolvedTypes[$name] = self::resolveType($type);
+        if (isset($this->resolvedTypes[$name])) {
+            return $this->resolvedTypes[$name];
+        }
+        $introspectionTypes = Introspection::getTypes();
+        if (isset($introspectionTypes[$name])) {
+            return $introspectionTypes[$name];
         }
 
-        return $this->resolvedTypes[$name];
+        $standardTypes = Type::getStandardTypes();
+        if (isset($standardTypes[$name])) {
+            return $standardTypes[$name];
+        }
+
+        $type = $this->loadType($name);
+        if ($type === null) {
+            return null;
+        }
+
+        return $this->resolvedTypes[$name] = self::resolveType($type);
     }
 
     public function hasType(string $name): bool


### PR DESCRIPTION
i'v flat the getType method in Schema class
test: tests/Type/SchemaTest.php "testSchemaReturnsNullForNonexistentType" 