### PR TITLE
Avoid calling defined functions named like lazily loaded types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Calling `Schema::getType()` on a schema built from SDL returns `null` for unknown types (#1068)
 - Avoid crash on typeless inline fragment when using `QueryComplexity` rule
 - Avoid calling `FormattedError::addDebugEntries()` twice when using default error formatting
+- Avoid calling defined functions named like lazily loaded types
 
 ### Removed
 

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -1025,7 +1025,7 @@ class ReferenceExecutor implements ExecutorImplementation
 
         if ($typeCandidate === null) {
             $runtimeType = static::defaultTypeResolver($result, $exeContext->contextValue, $info, $returnType);
-        } elseif (is_callable($typeCandidate)) {
+        } elseif (!is_string($typeCandidate) && is_callable($typeCandidate)) {
             $runtimeType = $typeCandidate();
         } else {
             $runtimeType = $typeCandidate;


### PR DESCRIPTION
As requested, this adds a failing test for #1193

Proposed solution:
Add a !is_string check to [line 1028 from the ReferenceExecutor.](https://github.com/webonyx/graphql-php/blob/d0b7c5270e155c9d7369c5d35dd4731d98e8ba52/src/Executor/ReferenceExecutor.php#L1028)
```PHP
if ($typeCandidate === null) {
    $runtimeType = static::defaultTypeResolver($result, $exeContext->contextValue, $info, $returnType);
/** added !is_string check**/
} elseif (is_callable($typeCandidate) && !is_string($typeCandidate)) {
    $runtimeType = $typeCandidate();
} else {
    $runtimeType = $typeCandidate;
}
```

Resolves https://github.com/webonyx/graphql-php/issues/1193