### PR TITLE
Fix PHP 8.2 deprecation of "static" in callables

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -282,7 +282,7 @@ class SchemaPrinter
                 return strlen($arg->description ?? '') === 0;
             }
         )) {
-            return '(' . implode(', ', array_map('static::printInputValue', $args)) . ')';
+            return '(' . implode(', ', array_map([static::class, 'printInputValue'], $args)) . ')';
         }
 
         return sprintf(


### PR DESCRIPTION
fix PHP 8.2 use of "static" in callables is deprecated

See: https://php.watch/versions/8.2/partially-supported-callable-deprecation