### PR TITLE
fix: allow to have queryplans with different options

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -111,11 +111,6 @@ class ResolveInfo
     public array $variableValues = [];
 
     /**
-     * Lazily initialized.
-     */
-    private QueryPlan $queryPlan;
-
-    /**
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<int, string|int> $path
      *
@@ -207,18 +202,14 @@ class ResolveInfo
      */
     public function lookAhead(array $options = []): QueryPlan
     {
-        if (! isset($this->queryPlan)) {
-            $this->queryPlan = new QueryPlan(
-                $this->parentType,
-                $this->schema,
-                $this->fieldNodes,
-                $this->variableValues,
-                $this->fragments,
-                $options
-            );
-        }
-
-        return $this->queryPlan;
+        return new QueryPlan(
+            $this->parentType,
+            $this->schema,
+            $this->fieldNodes,
+            $this->variableValues,
+            $this->fragments,
+            $options
+        );
     }
 
     /**

--- a/tests/Server/QueryExecutionTest.php
+++ b/tests/Server/QueryExecutionTest.php
@@ -117,7 +117,7 @@ class QueryExecutionTest extends ServerTestCase
         $result = $this->executeQuery($query)->toArray();
         self::assertArraySubset($expected, $result);
 
-        self::assertEquals(44, $result['errors'][0]['extensions']['line'] ?? null);
+        self::assertEquals(38, $result['errors'][0]['extensions']['line'] ?? null);
 
         self::assertStringContainsString('tests/Server/ServerTestCase.php', $result['errors'][0]['extensions']['file'] ?? '');
     }


### PR DESCRIPTION
Currently, I'm unable to instantiate two different query plans.