### PR TITLE
Add methods for properties in interface `NamedType`

### DIFF
--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -226,4 +226,15 @@ class EnumType extends Type implements InputType, OutputType, LeafType, Nullable
             ? null
             : ' Did you mean the enum value ' . Utils::quotedOrList($suggestions) . '?';
     }
+
+    public function astNode(): ?EnumTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, EnumTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/src/Type/Definition/InputObjectType.php
+++ b/src/Type/Definition/InputObjectType.php
@@ -183,4 +183,15 @@ class InputObjectType extends Type implements InputType, NullableType, NamedType
             $field->assertValid($this);
         }
     }
+
+    public function astNode(): ?InputObjectTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, InputObjectTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -87,4 +87,15 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
 
         $this->assertValidInterfaces();
     }
+
+    public function astNode(): ?InterfaceTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, InterfaceTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/src/Type/Definition/NamedType.php
+++ b/src/Type/Definition/NamedType.php
@@ -32,4 +32,14 @@ interface NamedType
      * Is this type a built-in type?
      */
     public function isBuiltInType(): bool;
+
+    public function name(): string;
+
+    public function description(): ?string;
+
+    /** @return (Node&TypeDefinitionNode)|null */
+    public function astNode(): ?Node;
+
+    /** @return array<int, Node&TypeExtensionNode> */
+    public function extensionASTNodes(): array;
 }

--- a/src/Type/Definition/NamedTypeImplementation.php
+++ b/src/Type/Definition/NamedTypeImplementation.php
@@ -44,4 +44,14 @@ trait NamedTypeImplementation
     {
         return \array_key_exists($this->name, Type::builtInTypes());
     }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function description(): ?string
+    {
+        return $this->description;
+    }
 }

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -150,4 +150,15 @@ class ObjectType extends Type implements OutputType, CompositeType, NullableType
 
         $this->assertValidInterfaces();
     }
+
+    public function astNode(): ?ObjectTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, ObjectTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/src/Type/Definition/PhpEnumType.php
+++ b/src/Type/Definition/PhpEnumType.php
@@ -34,7 +34,7 @@ class PhpEnumType extends EnumType
         foreach ($reflection->getCases() as $case) {
             $enumDefinitions[$case->name] = [
                 'value' => $case->getValue(),
-                'description' => $this->description($case),
+                'description' => $this->extractDescription($case),
                 'deprecationReason' => $this->deprecationReason($case),
             ];
         }
@@ -42,7 +42,7 @@ class PhpEnumType extends EnumType
         parent::__construct([
             'name' => $this->baseName($enum),
             'values' => $enumDefinitions,
-            'description' => $this->description($reflection),
+            'description' => $this->extractDescription($reflection),
         ]);
     }
 
@@ -66,7 +66,7 @@ class PhpEnumType extends EnumType
         return end($parts);
     }
 
-    protected function description(\ReflectionClassConstant|\ReflectionClass $reflection): ?string
+    protected function extractDescription(\ReflectionClassConstant|\ReflectionClass $reflection): ?string
     {
         $attributes = $reflection->getAttributes(Description::class);
 

--- a/src/Type/Definition/ScalarType.php
+++ b/src/Type/Definition/ScalarType.php
@@ -60,4 +60,15 @@ abstract class ScalarType extends Type implements OutputType, InputType, LeafTyp
     {
         Utils::assertValidName($this->name);
     }
+
+    public function astNode(): ?ScalarTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, ScalarTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -124,4 +124,15 @@ class UnionType extends Type implements AbstractType, OutputType, CompositeType,
             throw new InvariantViolation("{$this->name} must provide \"resolveType\" as a callable, but got: {$notCallable}");
         }
     }
+
+    public function astNode(): ?UnionTypeDefinitionNode
+    {
+        return $this->astNode;
+    }
+
+    /** @return array<int, UnionTypeExtensionNode> */
+    public function extensionASTNodes(): array
+    {
+        return $this->extensionASTNodes;
+    }
 }

--- a/tests/Type/DefinitionTest.php
+++ b/tests/Type/DefinitionTest.php
@@ -817,6 +817,62 @@ final class DefinitionTest extends TestCaseBase
     }
 
     /**
+     * @dataProvider providerPropertyAccessMethodsGiveCorrectValues
+     */
+    public function testPropertyAccessMethodsGiveCorrectValues(NamedType $type): void
+    {
+        self::assertSame($type->name, $type->name());
+        self::assertSame($type->description, $type->description());
+        self::assertSame($type->astNode, $type->astNode());
+        self::assertSame($type->extensionASTNodes, $type->extensionASTNodes());
+    }
+
+    /**
+     * @return \Generator<array-key, array{NamedType}>
+     */
+    public function providerPropertyAccessMethodsGiveCorrectValues(): \Generator
+    {
+        $description = 'To the quartered rhubarb add lobster, lettuce, eggs sauce and bitter strudel.';
+
+        yield [new EnumType([
+            'name' => 'EnumType',
+            'description' => $description,
+            'values' => [
+                'A' => ['value' => 1],
+            ],
+        ])];
+
+        yield [new InputObjectType([
+            'name' => 'InputObjectType',
+            'description' => $description,
+            'fields' => ['a' => Type::string()],
+        ])];
+
+        yield [new InterfaceType([
+            'name' => 'InterfaceType',
+            'description' => $description,
+            'fields' => ['a' => Type::string()],
+        ])];
+
+        yield [new ObjectType([
+            'name' => 'ObjectType',
+            'description' => $description,
+            'fields' => ['a' => Type::string()],
+        ])];
+
+        yield [new CustomScalarType([
+            'name' => 'ScalarType',
+            'description' => $description,
+        ])];
+
+        yield [new UnionType([
+            'name' => 'InterfaceType',
+            'description' => $description,
+            'types' => [],
+        ])];
+    }
+
+    /**
      * @see it('accepts an Object type with a field function')
      */
     public function testAcceptsAnObjectTypeWithAFieldFunction(): void


### PR DESCRIPTION
Since dynamic properties are to be removed in PHP 9, we should start working on replacing them.

E.g. this https://github.com/webonyx/graphql-php/pull/1252 is not really sufficient either as graphql-php now gives mixed errors on dynamic properties to consumers.

Also, `AllowDynamicProperties` attribute is supported only on classes, not interfaces.

--------

I have implemented basic getters for `NamedType` as an example how it should look in the future. WDYT?