### PR TITLE
Replace AST interfaces `@property` declarations with methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Store rules exclusively by class name in `DocumentValidator`
 - Reorder standard types as described in the GraphQL specification
 - Improve runtime performance by moving checks for duplicate/mismatching type instances to `assert()` or schema validation
-- Replace `HasSelectionSet::$selectionSet` to `HasSelectionSet::getSelectionSet()`
-- Replace `TypeDefinitionNode::$name` to `TypeDefinitionNode::getName()`
-- Replace `TypeExtensionNode::$name` to `TypeExtensionNode::getName()`
+- Replace `HasSelectionSet::$selectionSet` with `HasSelectionSet::getSelectionSet()`
+- Replace `TypeDefinitionNode::$name` with `TypeDefinitionNode::getName()`
+- Replace `TypeExtensionNode::$name` with `TypeExtensionNode::getName()`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ You can find and compare releases at the [GitHub release page](https://github.co
 - Store rules exclusively by class name in `DocumentValidator`
 - Reorder standard types as described in the GraphQL specification
 - Improve runtime performance by moving checks for duplicate/mismatching type instances to `assert()` or schema validation
+- Replace `HasSelectionSet::$selectionSet` to `HasSelectionSet::getSelectionSet()`
+- Replace `TypeDefinitionNode::$name` to `TypeDefinitionNode::getName()`
+- Replace `TypeExtensionNode::$name` to `TypeExtensionNode::getName()`
 
 ### Added
 

--- a/src/Language/AST/EnumTypeDefinitionNode.php
+++ b/src/Language/AST/EnumTypeDefinitionNode.php
@@ -15,4 +15,9 @@ class EnumTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $values;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/EnumTypeExtensionNode.php
+++ b/src/Language/AST/EnumTypeExtensionNode.php
@@ -13,4 +13,9 @@ class EnumTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<EnumValueDefinitionNode> */
     public NodeList $values;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/FragmentDefinitionNode.php
+++ b/src/Language/AST/FragmentDefinitionNode.php
@@ -24,4 +24,9 @@ class FragmentDefinitionNode extends Node implements ExecutableDefinitionNode, H
     public NodeList $directives;
 
     public SelectionSetNode $selectionSet;
+
+    public function getSelectionSet(): SelectionSetNode
+    {
+        return $this->selectionSet;
+    }
 }

--- a/src/Language/AST/HasSelectionSet.php
+++ b/src/Language/AST/HasSelectionSet.php
@@ -5,9 +5,8 @@ namespace GraphQL\Language\AST;
 /**
  * export type DefinitionNode = OperationDefinitionNode
  *                        | FragmentDefinitionNode.
- *
- * @property SelectionSetNode $selectionSet
  */
 interface HasSelectionSet
 {
+    public function getSelectionSet(): SelectionSetNode;
 }

--- a/src/Language/AST/InputObjectTypeDefinitionNode.php
+++ b/src/Language/AST/InputObjectTypeDefinitionNode.php
@@ -15,4 +15,9 @@ class InputObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $fields;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/InputObjectTypeExtensionNode.php
+++ b/src/Language/AST/InputObjectTypeExtensionNode.php
@@ -13,4 +13,9 @@ class InputObjectTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<InputValueDefinitionNode> */
     public NodeList $fields;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/InterfaceTypeDefinitionNode.php
+++ b/src/Language/AST/InterfaceTypeDefinitionNode.php
@@ -18,4 +18,9 @@ class InterfaceTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $fields;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/InterfaceTypeExtensionNode.php
+++ b/src/Language/AST/InterfaceTypeExtensionNode.php
@@ -16,4 +16,9 @@ class InterfaceTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<FieldDefinitionNode> */
     public NodeList $fields;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/ObjectTypeDefinitionNode.php
+++ b/src/Language/AST/ObjectTypeDefinitionNode.php
@@ -18,4 +18,9 @@ class ObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $fields;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/ObjectTypeExtensionNode.php
+++ b/src/Language/AST/ObjectTypeExtensionNode.php
@@ -16,4 +16,9 @@ class ObjectTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<FieldDefinitionNode> */
     public NodeList $fields;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -23,4 +23,9 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
     public NodeList $directives;
 
     public SelectionSetNode $selectionSet;
+
+    public function getSelectionSet(): SelectionSetNode
+    {
+        return $this->selectionSet;
+    }
 }

--- a/src/Language/AST/ScalarTypeDefinitionNode.php
+++ b/src/Language/AST/ScalarTypeDefinitionNode.php
@@ -12,4 +12,9 @@ class ScalarTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $directives;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/ScalarTypeExtensionNode.php
+++ b/src/Language/AST/ScalarTypeExtensionNode.php
@@ -10,4 +10,9 @@ class ScalarTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<DirectiveNode> */
     public NodeList $directives;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/TypeDefinitionNode.php
+++ b/src/Language/AST/TypeDefinitionNode.php
@@ -9,9 +9,8 @@ namespace GraphQL\Language\AST;
  * | UnionTypeDefinitionNode
  * | EnumTypeDefinitionNode
  * | InputObjectTypeDefinitionNode.
- *
- * @property NameNode $name
  */
 interface TypeDefinitionNode extends TypeSystemDefinitionNode
 {
+    public function getName(): NameNode;
 }

--- a/src/Language/AST/TypeExtensionNode.php
+++ b/src/Language/AST/TypeExtensionNode.php
@@ -10,9 +10,8 @@ namespace GraphQL\Language\AST;
  * | UnionTypeExtensionNode
  * | EnumTypeExtensionNode
  * | InputObjectTypeExtensionNode;.
- *
- * @property NameNode $name
  */
 interface TypeExtensionNode extends TypeSystemExtensionNode
 {
+    public function getName(): NameNode;
 }

--- a/src/Language/AST/UnionTypeDefinitionNode.php
+++ b/src/Language/AST/UnionTypeDefinitionNode.php
@@ -15,4 +15,9 @@ class UnionTypeDefinitionNode extends Node implements TypeDefinitionNode
     public NodeList $types;
 
     public ?StringValueNode $description = null;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Language/AST/UnionTypeExtensionNode.php
+++ b/src/Language/AST/UnionTypeExtensionNode.php
@@ -13,4 +13,9 @@ class UnionTypeExtensionNode extends Node implements TypeExtensionNode
 
     /** @var NodeList<NamedTypeNode> */
     public NodeList $types;
+
+    public function getName(): NameNode
+    {
+        return $this->name;
+    }
 }

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -188,11 +188,17 @@ class ASTDefinitionBuilder
      */
     public function buildType($ref): Type
     {
-        if (is_string($ref)) {
-            return $this->internalBuildType($ref);
+        $type = null;
+
+        if ($ref instanceof TypeDefinitionNode) {
+            $type = $this->internalBuildType($ref->getName()->value, $ref);
+        } elseif ($ref instanceof NamedTypeNode) {
+            $type = $this->internalBuildType($ref->name->value, $ref);
+        } else {
+            $type = $this->internalBuildType($ref);
         }
 
-        return $this->internalBuildType($ref->name->value, $ref);
+        return $type;
     }
 
     /**

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -153,13 +153,11 @@ class BuildSchema
                     $schemaDef = $definition;
                     break;
                 case $definition instanceof TypeDefinitionNode:
-                    /** @var string $name Necessary assertion for PHPStan + PHP 8.2 */
-                    $name = $definition->name->value;
+                    $name = $definition->getName()->value;
                     $typeDefinitionsMap[$name] = $definition;
                     break;
                 case $definition instanceof TypeExtensionNode:
-                    /** @var string $name Necessary assertion for PHPStan + PHP 8.2 */
-                    $name = $definition->name->value;
+                    $name = $definition->getName()->value;
                     $typeExtensionsMap[$name][] = $definition;
                     break;
                 case $definition instanceof DirectiveDefinitionNode:
@@ -228,7 +226,7 @@ class BuildSchema
             ->setDirectives($directives)
             ->setAstNode($schemaDef)
             ->setTypes(fn (): array => \array_map(
-                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->name->value),
+                static fn (TypeDefinitionNode $def): Type => $definitionBuilder->buildType($def->getName()->value),
                 $typeDefinitionsMap,
             ))
         );

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -104,12 +104,10 @@ class SchemaExtender
             } elseif ($def instanceof SchemaExtensionNode) {
                 $schemaExtensions[] = $def;
             } elseif ($def instanceof TypeDefinitionNode) {
-                /** @var string $name Necessary assertion for PHPStan + PHP 8.2 */
-                $name = $def->name->value;
+                $name = $def->getName()->value;
                 $typeDefinitionMap[$name] = $def;
             } elseif ($def instanceof TypeExtensionNode) {
-                /** @var string $name Necessary assertion for PHPStan + PHP 8.2 */
-                $name = $def->name->value;
+                $name = $def->getName()->value;
                 $this->typeExtensionsMap[$name][] = $def;
             } elseif ($def instanceof DirectiveDefinitionNode) {
                 $directiveDefinitions[] = $def;

--- a/src/Validator/QueryValidationContext.php
+++ b/src/Validator/QueryValidationContext.php
@@ -200,8 +200,7 @@ class QueryValidationContext implements ValidationContext
         if ($spreads === null) {
             $spreads = [];
 
-            /** @var array<int, SelectionSetNode> $setsToVisit */
-            $setsToVisit = [$node->selectionSet];
+            $setsToVisit = [$node->getSelectionSet()];
             while (\count($setsToVisit) > 0) {
                 $set = \array_pop($setsToVisit);
 

--- a/src/Validator/QueryValidationContext.php
+++ b/src/Validator/QueryValidationContext.php
@@ -12,7 +12,6 @@ use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\OperationDefinitionNode;
-use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Language\AST\VariableNode;
 use GraphQL\Language\Visitor;
 use GraphQL\Type\Definition\Argument;

--- a/src/Validator/Rules/ExecutableDefinitions.php
+++ b/src/Validator/Rules/ExecutableDefinitions.php
@@ -35,7 +35,7 @@ class ExecutableDefinitions extends ValidationRule
                                 $definition instanceof TypeDefinitionNode || $definition instanceof TypeExtensionNode,
                                 'only other option'
                             );
-                            $defName = "\"{$definition->name->value}\"";
+                            $defName = "\"{$definition->getName()->value}\"";
                         }
 
                         $context->reportError(new Error(

--- a/src/Validator/Rules/KnownTypeNames.php
+++ b/src/Validator/Rules/KnownTypeNames.php
@@ -43,7 +43,7 @@ class KnownTypeNames extends ValidationRule
         $definedTypes = [];
         foreach ($context->getDocument()->definitions as $def) {
             if ($def instanceof TypeDefinitionNode) {
-                $definedTypes[] = $def->name->value;
+                $definedTypes[] = $def->getName()->value;
             }
         }
 

--- a/src/Validator/Rules/PossibleTypeExtensions.php
+++ b/src/Validator/Rules/PossibleTypeExtensions.php
@@ -33,8 +33,7 @@ class PossibleTypeExtensions extends ValidationRule
         $definedTypes = [];
         foreach ($context->getDocument()->definitions as $def) {
             if ($def instanceof TypeDefinitionNode) {
-                /** @var string $name Necessary assertion for PHPStan + PHP 8.2 */
-                $name = $def->name->value;
+                $name = $def->getName()->value;
                 $definedTypes[$name] = $def;
             }
         }


### PR DESCRIPTION
Interfaces cannot have properties. Moreover,

1) `@property` doesn't work in PHPStan on PHP 8.2 (https://github.com/phpstan/phpstan/issues/8501)
2) psalm report "ERROR: [NoInterfaceProperties](https://psalm.dev/028) - 33:6 - Interfaces cannot have properties" (https://psalm.dev/r/68960d2827)

So probably will be better to use methods.