### PR TITLE
PHP 8.2 support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
         env: [
           'EXECUTOR= DEPENDENCIES=--prefer-lowest',
           'EXECUTOR=coroutine DEPENDENCIES=--prefer-lowest',

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -19,6 +19,7 @@ use function sprintf;
 /**
  * @todo Move complexity-related code to it's own place
  */
+#[\AllowDynamicProperties]
 class FieldDefinition
 {
     public const DEFAULT_COMPLEXITY_FN = 'GraphQL\Type\Definition\FieldDefinition::defaultComplexity';

--- a/src/Type/Definition/InputObjectField.php
+++ b/src/Type/Definition/InputObjectField.php
@@ -13,6 +13,7 @@ use GraphQL\Utils\Utils;
 use function array_key_exists;
 use function sprintf;
 
+#[\AllowDynamicProperties]
 class InputObjectField
 {
     /** @var string */

--- a/src/Utils/BreakingChangesFinder.php
+++ b/src/Utils/BreakingChangesFinder.php
@@ -103,7 +103,7 @@ class BreakingChangesFinder
 
             $breakingChanges[] = [
                 'type'        => self::BREAKING_CHANGE_TYPE_REMOVED,
-                'description' => "${typeName} was removed.",
+                'description' => sprintf('%s was removed.', $typeName),
             ];
         }
 
@@ -141,7 +141,7 @@ class BreakingChangesFinder
             $schemaBTypeKindName = self::typeKindName($schemaBType);
             $breakingChanges[]   = [
                 'type'        => self::BREAKING_CHANGE_TYPE_CHANGED_KIND,
-                'description' => "${typeName} changed from ${schemaATypeKindName} to ${schemaBTypeKindName}.",
+                'description' => sprintf('%s changed from %s to %s.', $typeName, $schemaATypeKindName, $schemaBTypeKindName),
             ];
         }
 
@@ -209,7 +209,7 @@ class BreakingChangesFinder
                 if (! isset($newTypeFieldsDef[$fieldName])) {
                     $breakingChanges[] = [
                         'type'        => self::BREAKING_CHANGE_FIELD_REMOVED,
-                        'description' => "${typeName}.${fieldName} was removed.",
+                        'description' => sprintf('%s.%s was removed.', $typeName, $fieldName),
                     ];
                 } else {
                     $oldFieldType = $oldTypeFieldsDef[$fieldName]->getType();
@@ -227,7 +227,7 @@ class BreakingChangesFinder
                             : $newFieldType;
                         $breakingChanges[]  = [
                             'type'        => self::BREAKING_CHANGE_FIELD_CHANGED_KIND,
-                            'description' => "${typeName}.${fieldName} changed type from ${oldFieldTypeString} to ${newFieldTypeString}.",
+                            'description' => sprintf('%s.%s changed type from %s to %s.', $typeName, $fieldName, $oldFieldTypeString, $newFieldTypeString),
                         ];
                     }
                 }
@@ -298,7 +298,7 @@ class BreakingChangesFinder
                 if (! isset($newTypeFieldsDef[$fieldName])) {
                     $breakingChanges[] = [
                         'type'        => self::BREAKING_CHANGE_FIELD_REMOVED,
-                        'description' => "${typeName}.${fieldName} was removed.",
+                        'description' => sprintf('%s.%s was removed.', $typeName, $fieldName),
                     ];
                 } else {
                     $oldFieldType = $oldTypeFieldsDef[$fieldName]->getType();
@@ -321,7 +321,7 @@ class BreakingChangesFinder
                         }
                         $breakingChanges[] = [
                             'type'        => self::BREAKING_CHANGE_FIELD_CHANGED_KIND,
-                            'description' => "${typeName}.${fieldName} changed type from ${oldFieldTypeString} to ${newFieldTypeString}.",
+                            'description' => sprintf('%s.%s changed type from %s to %s.', $typeName, $fieldName, $oldFieldTypeString, $newFieldTypeString),
                         ];
                     }
                 }
@@ -336,12 +336,12 @@ class BreakingChangesFinder
                 if ($fieldDef->isRequired()) {
                     $breakingChanges[] = [
                         'type'        => self::BREAKING_CHANGE_REQUIRED_INPUT_FIELD_ADDED,
-                        'description' => "A required field ${fieldName} on input type ${newTypeName} was added.",
+                        'description' => sprintf('A required field %s on input type %s was added.', $fieldName, $newTypeName),
                     ];
                 } else {
                     $dangerousChanges[] = [
                         'type'        => self::DANGEROUS_CHANGE_OPTIONAL_INPUT_FIELD_ADDED,
-                        'description' => "An optional field ${fieldName} on input type ${newTypeName} was added.",
+                        'description' => sprintf('An optional field %s on input type %s was added.', $fieldName, $newTypeName),
                     ];
                 }
             }
@@ -525,12 +525,12 @@ class BreakingChangesFinder
                             $newArgType        = $newArgDef->getType();
                             $breakingChanges[] = [
                                 'type'        => self::BREAKING_CHANGE_ARG_CHANGED_KIND,
-                                'description' => "${typeName}.${fieldName} arg ${oldArgName} has changed type from ${oldArgType} to ${newArgType}",
+                                'description' => sprintf('%s.%s arg %s has changed type from %s to %s', $typeName, $fieldName, $oldArgName, $oldArgType, $newArgType),
                             ];
                         } elseif ($oldArgDef->defaultValueExists() && $oldArgDef->defaultValue !== $newArgDef->defaultValue) {
                             $dangerousChanges[] = [
                                 'type'        => self::DANGEROUS_CHANGE_ARG_DEFAULT_VALUE_CHANGED,
-                                'description' => "${typeName}.${fieldName} arg ${oldArgName} has changed defaultValue",
+                                'description' => sprintf('%s.%s arg %s has changed defaultValue', $typeName, $fieldName, $oldArgName),
                             ];
                         }
                     } else {
@@ -563,12 +563,12 @@ class BreakingChangesFinder
                         if ($newTypeFieldArgDef->isRequired()) {
                             $breakingChanges[] = [
                                 'type'        => self::BREAKING_CHANGE_REQUIRED_ARG_ADDED,
-                                'description' => "A required arg ${newArgName} on ${newTypeName}.${fieldName} was added",
+                                'description' => sprintf('A required arg %s on %s.%s was added', $newArgName, $newTypeName, $fieldName),
                             ];
                         } else {
                             $dangerousChanges[] = [
                                 'type'        => self::DANGEROUS_CHANGE_OPTIONAL_ARG_ADDED,
-                                'description' => "An optional arg ${newArgName} on ${newTypeName}.${fieldName} was added",
+                                'description' => sprintf('An optional arg %s on %s.%s was added', $newArgName, $newTypeName, $fieldName),
                             ];
                         }
                     }

--- a/src/Utils/BuildClientSchema.php
+++ b/src/Utils/BuildClientSchema.php
@@ -29,6 +29,7 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function json_encode;
+use function sprintf;
 
 class BuildClientSchema
 {
@@ -187,7 +188,7 @@ class BuildClientSchema
     {
         if (! isset($this->typeMap[$typeName])) {
             throw new InvariantViolation(
-                "Invalid or incomplete schema, unknown type: ${typeName}. Ensure that a full introspection query is used in order to build a client schema."
+                sprintf('Invalid or incomplete schema, unknown type: %s. Ensure that a full introspection query is used in order to build a client schema.', $typeName)
             );
         }
 

--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -179,7 +179,7 @@ class ValuesOfCorrectType extends ValidationRule
     public static function badValueMessage($typeName, $valueName, $message = null)
     {
         return sprintf('Expected type %s, found %s', $typeName, $valueName) .
-            ($message ? "; ${message}" : '.');
+            ($message ? sprintf('; %s', $message) : '.');
     }
 
     /**


### PR DESCRIPTION
Add the `#[\AllowDynamicProperties]` attribute to squash deprecation warning for [dynamic properties](https://php.watch/versions/8.2/dynamic-properties-deprecated) e.g. `$this->$name = $value;` within `__set()` method

Change deprecated string interpolation `"${var}"` to `sprintf()` -  I did not use `"$var"` or `"{$var}" syntax as that failed linting e.g. `Squiz.Strings.DoubleQuoteUsage.ContainsVar e.g. Variable "$message" not allowed in double quoted`

Adds PHP 8.2 to CI matrix
