### PR TITLE
Using `${var}` in strings is deprecated, use `{$var}` instead.

### DIFF
--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -179,7 +179,7 @@ class ValuesOfCorrectType extends ValidationRule
     public static function badValueMessage($typeName, $valueName, $message = null)
     {
         return sprintf('Expected type %s, found %s', $typeName, $valueName) .
-            ($message ? "; ${message}" : '.');
+            ($message ? "; {$message}" : '.');
     }
 
     /**


### PR DESCRIPTION
See issue #1259.