### PR TITLE
Accept AST where field arguments are not given

### DIFF
--- a/src/Executor/Values.php
+++ b/src/Executor/Values.php
@@ -192,7 +192,7 @@ class Values
             return [];
         }
 
-        $argumentNodes    = $node->arguments;
+        $argumentNodes    = $node->arguments ?? [];
         $argumentValueMap = [];
         foreach ($argumentNodes as $argumentNode) {
             $argumentValueMap[$argumentNode->name->value] = $argumentNode->value;


### PR DESCRIPTION
Hey folks, long time no PR!

So I've spent the last week or so working with a tool called [codegen](https://github.com/dotansimha/graphql-code-generator). It parses your code for graphql queries, and bakes them into a typescript file as ASTs. There seems to be a quirk (I'm still debugging) in that if you have a schema with a field that has optional arguments, then there is no "arguments" field in the generated AST.

For example, imagine that we have a schema with optional arguments on collectionItems, and want to query it like this:
```graphql
  query noArgs($skuId: ID) {
    sku(id: $skuId) {
      collectionItems {
        id
      }
    }
  }
```

Compare the AST generated by graphql-php:...
![image](https://user-images.githubusercontent.com/773172/210875047-22ef2c32-a80a-453f-b45f-5b09d695cad6.png)

... to the one generated by codegen:

```ts
// AST generated by codegen
export const NoArgsDocument = {
  kind: "Document",
  definitions: [
    {
      kind: "OperationDefinition",
      operation: "query",
      name: { kind: "Name", value: "noArgs" },
      variableDefinitions: [
        {
          kind: "VariableDefinition",
          variable: {
            kind: "Variable",
            name: { kind: "Name", value: "skuId" },
          },
          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
        },
      ],
      selectionSet: {
        kind: "SelectionSet",
        selections: [
          {
            kind: "Field",
            name: { kind: "Name", value: "sku" },
            arguments: [
              {
                kind: "Argument",
                name: { kind: "Name", value: "id" },
                value: {
                  kind: "Variable",
                  name: { kind: "Name", value: "skuId" },
                },
              },
            ],
            selectionSet: {
              kind: "SelectionSet",
              selections: [
                {
                  kind: "Field",
                  name: { kind: "Name", value: "collectionItems" },
                  // <--- no `arguments` property!
                  selectionSet: {
                    kind: "SelectionSet",
                    selections: [
                      { kind: "Field", name: { kind: "Name", value: "id" } },
                    ],
                  },
                },
              ],
            },
          },
        ],
      },
    },
  ],
} as unknown as DocumentNode<NoArgsQuery, NoArgsQueryVariables>;
```

See the difference? graphql-php inserts an `arguments` property on every field, whereas codegen only adds it if an argument is explicitly passed to the field in the query. The result is a runtime exception in `Values.php:197`.

I have no idea which approach is correct, but when I investigated the equivalent file in the upstream reference library, I found that they do a coalesce similar to what I'm proposing here, so hopefully that will simplify things:
https://github.com/graphql/graphql-js/blob/main/src/execution/values.ts#L161

Please let me know what you think.