### PR TITLE
Fix printing of single line descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix printing of single line descriptions with backslashes
+
+### Changed
+
+- Print long argument lists on multiple lines
+- Print space between object value brackets
+
 ## v15.0.0
 
 ### Changed

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -6,6 +6,7 @@ use GraphQL\Executor\ExecutionResult;
 use GraphQL\Language\Source;
 use GraphQL\Language\SourceLocation;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Utils\Utils;
 
 /**
  * This class is used for [default error formatting](error-handling.md).
@@ -82,17 +83,15 @@ class FormattedError
         $nextLineNum = (string) ($contextLine + 1);
         $padLen = \strlen($nextLineNum);
 
-        $lines = \preg_split('/\r\n|[\n\r]/', $source->body);
-        \assert(\is_array($lines), 'given the regex is valid');
-
-        $lines[0] = self::whitespace($source->locationOffset->column - 1) . $lines[0];
+        $lines = Utils::splitLines($source->body);
+        $lines[0] = self::spaces($source->locationOffset->column - 1) . $lines[0];
 
         $outputLines = [
             "{$source->name} ({$contextLine}:{$contextColumn})",
-            $line >= 2 ? (self::lpad($padLen, $prevLineNum) . ': ' . $lines[$line - 2]) : null,
-            self::lpad($padLen, $lineNum) . ': ' . $lines[$line - 1],
-            self::whitespace(2 + $padLen + $contextColumn - 1) . '^',
-            $line < \count($lines) ? self::lpad($padLen, $nextLineNum) . ': ' . $lines[$line] : null,
+            $line >= 2 ? (self::leftPad($padLen, $prevLineNum) . ': ' . $lines[$line - 2]) : null,
+            self::leftPad($padLen, $lineNum) . ': ' . $lines[$line - 1],
+            self::spaces(2 + $padLen + $contextColumn - 1) . '^',
+            $line < \count($lines) ? self::leftPad($padLen, $nextLineNum) . ': ' . $lines[$line] : null,
         ];
 
         return \implode("\n", \array_filter($outputLines));
@@ -105,14 +104,14 @@ class FormattedError
             : 0;
     }
 
-    private static function whitespace(int $len): string
+    private static function spaces(int $length): string
     {
-        return \str_repeat(' ', $len);
+        return \str_repeat(' ', $length);
     }
 
-    private static function lpad(int $len, string $str): string
+    private static function leftPad(int $length, string $str): string
     {
-        return self::whitespace($len - \mb_strlen($str)) . $str;
+        return self::spaces($length - \mb_strlen($str)) . $str;
     }
 
     /**

--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -14,9 +14,7 @@ class BlockString
      */
     public static function dedentValue(string $rawString): string
     {
-        // Expand a block string's raw value into independent lines.
-        $lines = \preg_split('/\\r\\n|[\\n\\r]/', $rawString);
-        assert(is_array($lines), 'given the regex is valid');
+        $lines = Utils::splitLines($rawString);
 
         // Remove common indentation from all lines but first.
         $commonIndent = self::getIndentation($rawString);
@@ -101,43 +99,53 @@ class BlockString
      * trailing blank line. However, if a block string starts with whitespace and is
      * a single-line, adding a leading blank line would strip that whitespace.
      */
-    public static function print(
-        string $value,
-        string $indentation = '',
-        bool $preferMultipleLines = false
-    ): string {
-        $valueLength = \mb_strlen($value);
-        $isSingleLine = \strpos($value, "\n") === false;
-        $hasLeadingSpace = $value !== '' && ($value[0] === ' ' || $value[0] === '\t');
-        $hasTrailingQuote = $value !== '' && $value[$valueLength - 1] === '"';
-        $hasTrailingSlash = $value !== '' && $value[$valueLength - 1] === '\\';
-        $printAsMultipleLines
-            = ! $isSingleLine
-            || $hasTrailingQuote
-            || $hasTrailingSlash
-            || $preferMultipleLines;
+    public static function print(string $value): string {
+        $escapedValue = str_replace('"""', '\\"""', $value);
+
+        // Expand a block string's raw value into independent lines.
+        $lines = Utils::splitLines($escapedValue);
+        $isSingleLine = count($lines) === 1;
+
+        // If common indentation is found we can fix some of those cases by adding leading new line
+        $forceLeadingNewLine = count($lines) > 1;
+        foreach ($lines as $i => $line) {
+            if ($i === 0) {
+                continue;
+            }
+
+            if ($line !== '' && \preg_match('/^\s/', $line) !== 1) {
+                $forceLeadingNewLine = false;
+            }
+        }
+
+        // Trailing triple quotes just looks confusing but doesn't force trailing new line
+        $hasTrailingTripleQuotes = \preg_match('/\\\\"""$/', $escapedValue) === 1;
+
+        // Trailing quote (single or double) or slash forces trailing new line
+        $hasTrailingQuote = \preg_match('/"$/', $value) === 1 && ! $hasTrailingTripleQuotes;
+        $hasTrailingSlash = \preg_match('/\\\\$/', $value) === 1;
+        $forceTrailingNewline = $hasTrailingQuote || $hasTrailingSlash;
+
+        // add leading and trailing new lines only if it improves readability
+        $printAsMultipleLines = ! $isSingleLine
+            || mb_strlen($value) > 70
+            || $forceTrailingNewline
+            || $forceLeadingNewLine
+            || $hasTrailingTripleQuotes;
 
         $result = '';
+
         // Format a multi-line block quote to account for leading space.
-        if (
-            $printAsMultipleLines
-            && ! ($isSingleLine && $hasLeadingSpace)
-        ) {
-            $result .= "\n" . $indentation;
+        $skipLeadingNewLine = $isSingleLine && \preg_match('/^\s/', $value) === 1;
+        if (($printAsMultipleLines && !$skipLeadingNewLine) || $forceLeadingNewLine) {
+            $result .= "\n";
         }
 
-        $result .= $indentation !== ''
-            ? \str_replace("\n", "\n" . $indentation, $value)
-            : $value;
+        $result .= $escapedValue;
         if ($printAsMultipleLines) {
             $result .= "\n";
-            $quoting = '"""';
-        } else {
-            $quoting = '"';
         }
 
-        return $quoting
-            . \str_replace($quoting, '\\' . $quoting, $result)
-            . $quoting;
+        return '"""' . $result . '"""';
     }
 }

--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -99,7 +99,8 @@ class BlockString
      * trailing blank line. However, if a block string starts with whitespace and is
      * a single-line, adding a leading blank line would strip that whitespace.
      */
-    public static function print(string $value): string {
+    public static function print(string $value): string
+    {
         $escapedValue = str_replace('"""', '\\"""', $value);
 
         // Expand a block string's raw value into independent lines.
@@ -137,7 +138,7 @@ class BlockString
 
         // Format a multi-line block quote to account for leading space.
         $skipLeadingNewLine = $isSingleLine && \preg_match('/^\s/', $value) === 1;
-        if (($printAsMultipleLines && !$skipLeadingNewLine) || $forceLeadingNewLine) {
+        if (($printAsMultipleLines && ! $skipLeadingNewLine) || $forceLeadingNewLine) {
             $result .= "\n";
         }
 

--- a/src/Language/BlockString.php
+++ b/src/Language/BlockString.php
@@ -12,7 +12,7 @@ class BlockString
      *
      * This implements the GraphQL spec's BlockStringValue() static algorithm.
      */
-    public static function dedentValue(string $rawString): string
+    public static function dedentBlockStringLines(string $rawString): string
     {
         $lines = Utils::splitLines($rawString);
 

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -572,7 +572,7 @@ class Lexer
                         $line,
                         $col,
                         $prev,
-                        BlockString::dedentValue($value)
+                        BlockString::dedentBlockStringLines($value)
                     );
                 }
 

--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -483,7 +483,7 @@ class Lexer
                             throw new SyntaxError(
                                 $this->source,
                                 $position - 1,
-                                'Invalid character escape sequence: \\u' . $hex
+                                "Invalid character escape sequence: \\u{$hex}"
                             );
                         }
 
@@ -515,10 +515,11 @@ class Lexer
                     case null:
                         continue 2;
                     default:
+                        $chr = Utils::chr($code);
                         throw new SyntaxError(
                             $this->source,
                             $this->position - 1,
-                            'Invalid character escape sequence: \\' . Utils::chr($code)
+                            "Invalid character escape sequence: \\{$chr}"
                         );
                 }
 

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -356,7 +356,7 @@ class Printer
                 );
 
             case $node instanceof ObjectValueNode:
-                return '{' . $this->printList($node->fields, ', ') . '}';
+                return "{ {$this->printList($node->fields, ', ')} }";
 
             case $node instanceof OperationDefinitionNode:
                 $op = $node->operation;

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -190,13 +190,26 @@ class Printer
                 );
 
             case $node instanceof FieldNode:
+                $prefix = $this->wrap('', $node->alias->value ?? null, ': ') . $this->p($node->name);
+
+                $argsLine = $prefix . $this->wrap(
+                    '(',
+                    $this->printList($node->arguments, ', '),
+                    ')'
+                );
+                if (strlen($argsLine) > 80) {
+                    $argsLine = $prefix . $this->wrap(
+                        "(\n",
+                            $this->indent(
+                                $this->printList($node->arguments, "\n")
+                            ),
+                            "\n)"
+                    );
+                }
+
                 return $this->join(
                     [
-                        $this->wrap('', $node->alias->value ?? null, ': ') . $this->p($node->name) . $this->wrap(
-                            '(',
-                            $this->printList($node->arguments, ', '),
-                            ')'
-                        ),
+                        $argsLine,
                         $this->printList($node->directives, ' '),
                         $this->p($node->selectionSet),
                     ],
@@ -354,7 +367,7 @@ class Printer
 
                 // Anonymous queries with no directives or variable definitions can use
                 // the query short form.
-                return (\strlen($name) === 0) && (\strlen($directives) === 0) && $varDefs === '' && $op === 'query'
+                return $name === '' && $directives === '' && $varDefs === '' && $op === 'query'
                     ? $selectionSet
                     : $this->join([$op, $this->join([$name, $varDefs]), $directives, $selectionSet], ' ');
 
@@ -403,7 +416,7 @@ class Printer
 
             case $node instanceof StringValueNode:
                 if ($node->block) {
-                    return BlockString::print($node->value, $isDescription ? '' : '  ', true);
+                    return BlockString::print($node->value);
                 }
 
                 return \json_encode($node->value, JSON_THROW_ON_ERROR);
@@ -416,8 +429,8 @@ class Printer
                         'union',
                         $this->p($node->name),
                         $this->printList($node->directives, ' '),
-                        \strlen($typesStr) > 0
-                            ? '= ' . $typesStr
+                        $typesStr !== ''
+                            ? "= {$typesStr}"
                             : '',
                     ],
                     ' '
@@ -431,8 +444,8 @@ class Printer
                         'extend union',
                         $this->p($node->name),
                         $this->printList($node->directives, ' '),
-                        \strlen($typesStr) > 0
-                            ? '= ' . $typesStr
+                        $typesStr !== ''
+                            ? "= {$typesStr}"
                             : '',
                     ],
                     ' '

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -200,10 +200,10 @@ class Printer
                 if (strlen($argsLine) > 80) {
                     $argsLine = $prefix . $this->wrap(
                         "(\n",
-                            $this->indent(
-                                $this->printList($node->arguments, "\n")
-                            ),
-                            "\n)"
+                        $this->indent(
+                            $this->printList($node->arguments, "\n")
+                        ),
+                        "\n)"
                     );
                 }
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -211,27 +211,20 @@ class SchemaPrinter
             return '';
         }
 
-        $preferMultipleLines = \mb_strlen($description) > 70;
-        $blockString = BlockString::print($description, '', $preferMultipleLines);
         $prefix = $indentation !== '' && ! $firstInBlock
-            ? "\n" . $indentation
+            ? "\n{$indentation}"
             : $indentation;
 
-        return $prefix . \str_replace("\n", "\n" . $indentation, $blockString) . "\n";
-    }
-
-    protected static function printDescriptionWithComments(string $description, string $indentation, bool $firstInBlock): string
-    {
-        $comment = $indentation !== '' && ! $firstInBlock ? "\n" : '';
-        foreach (\explode("\n", $description) as $line) {
-            if ($line === '') {
-                $comment .= $indentation . "#\n";
-            } else {
-                $comment .= $indentation . '# ' . $line . "\n";
-            }
+        if (count(Utils::splitLines($description)) === 1) {
+            $description = \json_encode($description, JSON_THROW_ON_ERROR);
+        } else {
+            $description = BlockString::print($description);
+            $description = $indentation !== ''
+                ? \str_replace("\n", "\n{$indentation}", $description)
+                : $description;
         }
 
-        return $comment;
+        return "{$prefix}{$description}\n";
     }
 
     /**

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -307,4 +307,17 @@ class Utils
 
         return null;
     }
+
+    /**
+     * Split a string that has either Unix, Windows or Mac style newlines into lines.
+     *
+     * @return list<string>
+     */
+    public static function splitLines(string $value): array
+    {
+        $lines = \preg_split("/\r\n|\r|\n/", $value);
+        assert(is_array($lines), 'given the regex is valid');
+
+        return $lines;
+    }
 }

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -38,7 +38,8 @@ final class BlockStringTest extends TestCase
              a
             b
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
              a
               b
             GRAPHQL
@@ -56,7 +57,8 @@ final class BlockStringTest extends TestCase
             a
              b
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             
              a
               b
@@ -68,7 +70,8 @@ final class BlockStringTest extends TestCase
              a
             b
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             
               a
              b
@@ -81,7 +84,8 @@ final class BlockStringTest extends TestCase
              b
             c
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             
               a
              b
@@ -119,7 +123,6 @@ final class BlockStringTest extends TestCase
         );
     }
 
-
     /**
      * @see it('dedent do not take empty lines into account', () => {
      */
@@ -131,7 +134,8 @@ final class BlockStringTest extends TestCase
             
             b
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             a
             
              b
@@ -144,7 +148,8 @@ final class BlockStringTest extends TestCase
             
             b
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             a
             
               b
@@ -166,7 +171,8 @@ final class BlockStringTest extends TestCase
             Yours,
               GraphQL.
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             
                 Hello,
                   World!
@@ -191,7 +197,8 @@ final class BlockStringTest extends TestCase
             Yours,
               GraphQL.
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
             
             
                 Hello,
@@ -241,7 +248,8 @@ final class BlockStringTest extends TestCase
             Yours,
               GraphQL.
             GRAPHQL,
-            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            BlockString::dedentBlockStringLines(
+                <<<'GRAPHQL'
                 Hello,
                   World!
             
@@ -337,7 +345,8 @@ final class BlockStringTest extends TestCase
     public function testDoNotEscapeCharacters(): void
     {
         $str = "\" \\ / \u{8} \f \n \r \t"; // \u{8} === \b
-        self::assertSame(<<<EOF
+        self::assertSame(
+            <<<EOF
             """
             {$str}
             """
@@ -361,7 +370,8 @@ final class BlockStringTest extends TestCase
     public function testByDefaultPrintBlockStringsEndingWithTripleQuotationAsMultiLine(): void
     {
         $str = 'triple quotation """';
-        self::assertSame(<<<EOF
+        self::assertSame(
+            <<<EOF
             """
             triple quotation \\"""
             """
@@ -385,7 +395,8 @@ final class BlockStringTest extends TestCase
     public function testCorrectlyPrintsSingleLineWithLeadingSpaceAndQuotation(): void
     {
         $str = '    space-led value "quoted string"';
-        self::assertSame(<<<'EOF'
+        self::assertSame(
+            <<<'EOF'
             """    space-led value "quoted string"
             """
             EOF,
@@ -399,7 +410,8 @@ final class BlockStringTest extends TestCase
     public function testCorrectlyPrintsSingleLineWithTrailingBackslash(): void
     {
         $str = 'backslash \\';
-        self::assertSame(<<<EOF
+        self::assertSame(
+            <<<EOF
             """
             backslash \\
             """
@@ -417,7 +429,8 @@ final class BlockStringTest extends TestCase
         no indent
          with indent
         EOF;
-        self::assertSame(<<<EOF
+        self::assertSame(
+            <<<EOF
             """
             no indent
              with indent

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -12,51 +12,202 @@ final class BlockStringTest extends TestCase
         return \implode("\n", $args);
     }
 
-    // describe('dedentBlockStringValue')
+    /**
+     * @see describe('dedentBlockStringLines', () => {
+     * @see it('handles empty string', () => {
+     */
+    public function testHandlesEmptyString(): void
+    {
+        self::assertSame(
+            '',
+            BlockString::dedentBlockStringLines('')
+        );
+    }
+
+    /**
+     * @see it('does not dedent first line', () => {
+     */
+    public function testDoesNotDedentFirstLine(): void
+    {
+        self::assertSame(
+            '  a',
+            BlockString::dedentBlockStringLines('  a')
+        );
+        self::assertSame(
+            <<<'GRAPHQL'
+             a
+            b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+             a
+              b
+            GRAPHQL
+            )
+        );
+    }
+
+    /**
+     * @see it('removes minimal indentation length', () => {
+     */
+    public function testRemovesMinimalIndentationLength(): void
+    {
+        self::assertSame(
+            <<<'GRAPHQL'
+            a
+             b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            
+             a
+              b
+            GRAPHQL
+            )
+        );
+        self::assertSame(
+            <<<'GRAPHQL'
+             a
+            b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            
+              a
+             b
+            GRAPHQL
+            )
+        );
+        self::assertSame(
+            <<<'GRAPHQL'
+              a
+             b
+            c
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            
+              a
+             b
+            c
+            GRAPHQL
+            )
+        );
+    }
+
+    /**
+     * @see it('dedent both tab and space as single character', () => {
+     */
+    public function testDedentBothTabAndSpaceAsSingleCharacter(): void
+    {
+        self::assertSame(
+            <<<GRAPHQL
+            a
+                     b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines("\n\ta\n          b")
+        );
+        self::assertSame(
+            <<<GRAPHQL
+            a
+                    b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines("\n\t a\n          b")
+        );
+        self::assertSame(
+            <<<GRAPHQL
+            a
+                   b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines("\n \t a\n          b")
+        );
+    }
+
+
+    /**
+     * @see it('dedent do not take empty lines into account', () => {
+     */
+    public function testDedentDoNotTakeEmptyLinesIntoAccount(): void
+    {
+        self::assertSame(
+            <<<'GRAPHQL'
+            a
+            
+            b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            a
+            
+             b
+            GRAPHQL
+            )
+        );
+        self::assertSame(
+            <<<'GRAPHQL'
+            a
+            
+            b
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            a
+            
+              b
+            GRAPHQL
+            )
+        );
+    }
 
     /**
      * @see it('removes uniform indentation from a string')
      */
     public function testRemovesUniformIndentationFromAString(): void
     {
-        $rawValue = self::joinLines(
-            '',
-            '    Hello,',
-            '      World!',
-            '',
-            '    Yours,',
-            '      GraphQL.',
-        );
         self::assertSame(
-            self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
-            BlockString::dedentValue($rawValue)
+            <<<'GRAPHQL'
+            Hello,
+              World!
+            
+            Yours,
+              GraphQL.
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            
+                Hello,
+                  World!
+            
+                Yours,
+                  GraphQL.
+            GRAPHQL
+            )
         );
     }
 
     /**
-     * @see it('removes empty leading and trailing lines')
+     * @see it('removes empty leading and trailing lines', () => {
      */
     public function testRemovesEmptyLeadingAndTrailingLines(): void
     {
-        $rawValue = self::joinLines(
-            '',
-            '',
-            '    Hello,',
-            '      World!',
-            '',
-            '    Yours,',
-            '      GraphQL.',
-            '',
-            '',
-        );
         self::assertSame(
-            self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
-            BlockString::dedentValue($rawValue)
+            <<<'GRAPHQL'
+            Hello,
+              World!
+            
+            Yours,
+              GraphQL.
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+            
+            
+                Hello,
+                  World!
+            
+                Yours,
+                  GraphQL.
+            
+            
+            GRAPHQL
+            )
         );
     }
 
     /**
-     * @see it('removes blank leading and trailing lines')
+     * @see it('removes blank leading and trailing lines', () => {
      */
     public function testRemovesBlankLeadingAndTrailingLines(): void
     {
@@ -73,25 +224,33 @@ final class BlockStringTest extends TestCase
         );
         self::assertSame(
             self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
-            BlockString::dedentValue($rawValue)
+            BlockString::dedentBlockStringLines($rawValue)
         );
     }
 
     /**
-     * @see it('retains indentation from first line')
+     * @see it('retains indentation from first line', () => {
      */
     public function testRetainsIndentationFromFirstLine(): void
     {
-        $rawValue = self::joinLines(
-            '    Hello,',
-            '      World!',
-            '',
-            '    Yours,',
-            '      GraphQL.',
-        );
         self::assertSame(
-            self::joinLines('    Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
-            BlockString::dedentValue($rawValue)
+            <<<'GRAPHQL'
+                Hello,
+              World!
+            
+            Yours,
+              GraphQL.
+            GRAPHQL,
+            BlockString::dedentBlockStringLines(<<<'GRAPHQL'
+                Hello,
+                  World!
+            
+                Yours,
+                  GraphQL.
+              
+                
+            GRAPHQL
+            )
         );
     }
 
@@ -117,7 +276,7 @@ final class BlockStringTest extends TestCase
                 'Yours,     ',
                 '  GraphQL. ',
             ),
-            BlockString::dedentValue($rawValue)
+            BlockString::dedentBlockStringLines($rawValue)
         );
     }
 

--- a/tests/Language/BlockStringTest.php
+++ b/tests/Language/BlockStringTest.php
@@ -5,7 +5,7 @@ namespace GraphQL\Tests\Language;
 use GraphQL\Language\BlockString;
 use PHPUnit\Framework\TestCase;
 
-class BlockStringTest extends TestCase
+final class BlockStringTest extends TestCase
 {
     private static function joinLines(string ...$args): string
     {
@@ -27,7 +27,7 @@ class BlockStringTest extends TestCase
             '    Yours,',
             '      GraphQL.',
         );
-        self::assertEquals(
+        self::assertSame(
             self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
             BlockString::dedentValue($rawValue)
         );
@@ -49,7 +49,7 @@ class BlockStringTest extends TestCase
             '',
             '',
         );
-        self::assertEquals(
+        self::assertSame(
             self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
             BlockString::dedentValue($rawValue)
         );
@@ -71,7 +71,7 @@ class BlockStringTest extends TestCase
             '        ',
             '  ',
         );
-        self::assertEquals(
+        self::assertSame(
             self::joinLines('Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
             BlockString::dedentValue($rawValue)
         );
@@ -89,7 +89,7 @@ class BlockStringTest extends TestCase
             '    Yours,',
             '      GraphQL.',
         );
-        self::assertEquals(
+        self::assertSame(
             self::joinLines('    Hello,', '  World!', '', 'Yours,', '  GraphQL.'),
             BlockString::dedentValue($rawValue)
         );
@@ -109,7 +109,7 @@ class BlockStringTest extends TestCase
             '      GraphQL. ',
             '               ',
         );
-        self::assertEquals(
+        self::assertSame(
             self::joinLines(
                 'Hello,     ',
                 '  World!   ',
@@ -128,7 +128,7 @@ class BlockStringTest extends TestCase
      */
     public function testReturnsZeroForAnEmptyString(): void
     {
-        self::assertEquals(0, BlockString::getIndentation(''));
+        self::assertSame(0, BlockString::getIndentation(''));
     }
 
     /**
@@ -136,8 +136,8 @@ class BlockStringTest extends TestCase
      */
     public function testDoNotTakeFirstLineIntoAccount(): void
     {
-        self::assertEquals(0, BlockString::getIndentation('  a'));
-        self::assertEquals(2, BlockString::getIndentation(" a\n  b"));
+        self::assertSame(0, BlockString::getIndentation('  a'));
+        self::assertSame(2, BlockString::getIndentation(" a\n  b"));
     }
 
     /**
@@ -145,9 +145,9 @@ class BlockStringTest extends TestCase
      */
     public function testReturnsMinimalIndentationLength(): void
     {
-        self::assertEquals(1, BlockString::getIndentation("\n a\n  b"));
-        self::assertEquals(1, BlockString::getIndentation("\n  a\n b"));
-        self::assertEquals(0, BlockString::getIndentation("\n  a\n b\nc"));
+        self::assertSame(1, BlockString::getIndentation("\n a\n  b"));
+        self::assertSame(1, BlockString::getIndentation("\n  a\n b"));
+        self::assertSame(0, BlockString::getIndentation("\n  a\n b\nc"));
     }
 
     /**
@@ -155,9 +155,9 @@ class BlockStringTest extends TestCase
      */
     public function testCountBothTabAndSpaceAsSingleCharacter(): void
     {
-        self::assertEquals(1, BlockString::getIndentation("\n\ta\n          b"));
-        self::assertEquals(2, BlockString::getIndentation("\n\t a\n          b"));
-        self::assertEquals(3, BlockString::getIndentation("\n \t a\n          b"));
+        self::assertSame(1, BlockString::getIndentation("\n\ta\n          b"));
+        self::assertSame(2, BlockString::getIndentation("\n\t a\n          b"));
+        self::assertSame(3, BlockString::getIndentation("\n \t a\n          b"));
     }
 
     /**
@@ -165,33 +165,50 @@ class BlockStringTest extends TestCase
      */
     public function testDoNotTakeEmptyLinesIntoAccount(): void
     {
-        self::assertEquals(0, BlockString::getIndentation("a\n "));
-        self::assertEquals(0, BlockString::getIndentation("a\n\t"));
-        self::assertEquals(1, BlockString::getIndentation("a\n\n b"));
-        self::assertEquals(2, BlockString::getIndentation("a\n \n  b"));
+        self::assertSame(0, BlockString::getIndentation("a\n "));
+        self::assertSame(0, BlockString::getIndentation("a\n\t"));
+        self::assertSame(1, BlockString::getIndentation("a\n\n b"));
+        self::assertSame(2, BlockString::getIndentation("a\n \n  b"));
     }
 
-    // describe('printBlockString')
-
     /**
-     * @see it('do not escape characters')
+     * @see describe('printBlockString', () => {
+     * @see it('does not escape characters', () => {
      */
     public function testDoNotEscapeCharacters(): void
     {
         $str = "\" \\ / \u{8} \f \n \r \t"; // \u{8} === \b
-
-        self::assertEquals("\"\"\"\n" . $str . "\n\"\"\"", BlockString::print($str));
+        self::assertSame(<<<EOF
+            """
+            {$str}
+            """
+            EOF,
+            BlockString::print($str)
+        );
     }
 
     /**
-     * @see it('by default print block strings as single line')
+     * @see it('by default print block strings as single line', () => {
      */
     public function testByDefaultPrintBlockStringsAsSingleLine(): void
     {
         $str = 'one liner';
+        self::assertSame('"""one liner"""', BlockString::print($str));
+    }
 
-        self::assertEquals('"one liner"', BlockString::print($str));
-        self::assertEquals("\"\"\"\none liner\n\"\"\"", BlockString::print($str, '', true));
+    /**
+     * @see it('by default print block strings ending with triple quotation as multi-line', () => {
+     */
+    public function testByDefaultPrintBlockStringsEndingWithTripleQuotationAsMultiLine(): void
+    {
+        $str = 'triple quotation """';
+        self::assertSame(<<<EOF
+            """
+            triple quotation \\"""
+            """
+            EOF,
+            BlockString::print($str)
+        );
     }
 
     /**
@@ -200,20 +217,21 @@ class BlockStringTest extends TestCase
     public function testCorrectlyPrintsSingleLineWithLeadingSpace(): void
     {
         $str = '    space-led string';
-
-        self::assertEquals('"    space-led string"', BlockString::print($str));
-        self::assertEquals("\"\"\"    space-led string\n\"\"\"", BlockString::print($str, '', true));
+        self::assertSame('"""    space-led string"""', BlockString::print($str));
     }
 
     /**
-     * @see it('correctly prints single-line with leading space and quotation')
+     * @see it('correctly prints single-line with leading space and trailing quotation', () => {
      */
     public function testCorrectlyPrintsSingleLineWithLeadingSpaceAndQuotation(): void
     {
         $str = '    space-led value "quoted string"';
-
-        self::assertEquals("\"\"\"    space-led value \"quoted string\"\n\"\"\"", BlockString::print($str));
-        self::assertEquals("\"\"\"    space-led value \"quoted string\"\n\"\"\"", BlockString::print($str));
+        self::assertSame(<<<'EOF'
+            """    space-led value "quoted string"
+            """
+            EOF,
+            BlockString::print($str)
+        );
     }
 
     /**
@@ -222,9 +240,32 @@ class BlockStringTest extends TestCase
     public function testCorrectlyPrintsSingleLineWithTrailingBackslash(): void
     {
         $str = 'backslash \\';
+        self::assertSame(<<<EOF
+            """
+            backslash \\
+            """
+            EOF,
+            BlockString::print($str)
+        );
+    }
 
-        self::assertEquals("\"\"\"\nbackslash \\\n\"\"\"", BlockString::print($str));
-        self::assertEquals("\"\"\"\nbackslash \\\n\"\"\"", BlockString::print($str, '', true));
+    /**
+     * @see it('correctly prints multi-line with internal indent', () => {
+     */
+    public function testCorrectlyPrintsMultiLineWithInternalIndent(): void
+    {
+        $str = <<<EOF
+        no indent
+         with indent
+        EOF;
+        self::assertSame(<<<EOF
+            """
+            no indent
+             with indent
+            """
+            EOF,
+            BlockString::print($str)
+        );
     }
 
     /**
@@ -232,22 +273,21 @@ class BlockStringTest extends TestCase
      */
     public function testCorrectlyPrintsStringWithAFirstLineIndentation(): void
     {
-        $str = self::joinLines(
-            '    first  ',
-            '  line     ',
-            'indentation',
-            '     string',
-        );
-
-        self::assertEquals(
-            self::joinLines(
-                '"""',
-                '    first  ',
-                '  line     ',
-                'indentation',
-                '     string',
-                '"""',
-            ),
+        $str = <<<EOF
+            first  
+          line     
+        indentation
+             string
+        EOF;
+        self::assertSame(
+            <<<EOF
+            """
+                first  
+              line     
+            indentation
+                 string
+            """
+            EOF,
             BlockString::print($str)
         );
     }
@@ -255,8 +295,6 @@ class BlockStringTest extends TestCase
     public function testCorrectlyPrintsEmptyString(): void
     {
         $str = '';
-
-        self::assertEquals('""', BlockString::print($str));
-        self::assertEquals("\"\"\"\n\n\"\"\"", BlockString::print($str, '', true));
+        self::assertSame('""""""', BlockString::print($str));
     }
 }

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -58,7 +58,8 @@ final class PrinterTest extends TestCaseBase
     {
         $queryAstShorthanded = Parser::parse('query { id, name }');
 
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       {
         id
         name
@@ -69,7 +70,8 @@ final class PrinterTest extends TestCaseBase
         );
 
         $mutationAst = Parser::parse('mutation { id, name }');
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       mutation {
         id
         name
@@ -82,7 +84,8 @@ final class PrinterTest extends TestCaseBase
         $queryAstWithArtifacts = Parser::parse(
             'query ($foo: TestType) @testDirective { id, name }'
         );
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       query ($foo: TestType) @testDirective {
         id
         name
@@ -95,7 +98,8 @@ final class PrinterTest extends TestCaseBase
         $mutationAstWithArtifacts = Parser::parse(
             'mutation ($foo: TestType) @testDirective { id, name }'
         );
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       mutation ($foo: TestType) @testDirective {
         id
         name
@@ -130,7 +134,8 @@ final class PrinterTest extends TestCaseBase
         $queryAstWithVariableDirective = Parser::parse(
             'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }'
         );
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       query ($foo: TestType = { a: 123 } @testDirective(if: true) @test) {
         id
       }
@@ -148,7 +153,8 @@ final class PrinterTest extends TestCaseBase
         $queryASTWithMultipleArguments = Parser::parse(
             '{trip(wheelchair:false arriveBy:false){dateTime}}',
         );
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       {
         trip(wheelchair: false, arriveBy: false) {
           dateTime
@@ -168,7 +174,8 @@ final class PrinterTest extends TestCaseBase
         $queryASTWithMultipleArguments = Parser::parse(
             '{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}',
         );
-        self::assertSame(<<<'GRAPHQL'
+        self::assertSame(
+            <<<'GRAPHQL'
       {
         trip(
           wheelchair: false
@@ -225,7 +232,6 @@ fragment Foo($a: ComplexType, $b: Boolean = false) on TestType {
 }
 
 GRAPHQL
-
         );
     }
 

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -210,7 +210,10 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
 }
 
 fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: {key: "value", block: """
+  foo(
+    size: $size
+    bar: $b
+    obj: { key: "value", block: """
     block string uses \"""
   """})
 }

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -157,9 +157,9 @@ class PrinterTest extends TestCaseBase
     }
 
     /**
-     * @see it('prints kitchen sink')
+     * @see it('prints kitchen sink without altering ast', () => {
      */
-    public function testPrintsKitchenSink(): void
+    public function testPrintsKitchenSinkWithoutAlteringAST(): void
     {
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
         $ast = Parser::parse($kitchenSink);

--- a/tests/Language/SchemaPrinterTest.php
+++ b/tests/Language/SchemaPrinterTest.php
@@ -72,7 +72,7 @@ type Foo implements Bar & Baz & Two {
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
-  six(argument: InputType = {key: "value"}): Type
+  six(argument: InputType = { key: "value" }): Type
   seven(argument: Int = null): Type
 }
 

--- a/tests/Language/SchemaPrinterTest.php
+++ b/tests/Language/SchemaPrinterTest.php
@@ -38,9 +38,9 @@ final class SchemaPrinterTest extends TestCase
     }
 
     /**
-     * @see it('prints kitchen sink without altering ast')
+     * @see it('prints kitchen sink without altering ast', () => {
      */
-    public function testPrintsKitchenSink(): void
+    public function testPrintsKitchenSinkWithoutAlteringAST(): void
     {
         $ast = Parser::parse(file_get_contents(__DIR__ . '/schema-kitchen-sink.graphql'), ['noLocation' => true]);
 
@@ -64,13 +64,9 @@ of the `Foo` type.
 """
 type Foo implements Bar & Baz & Two {
   one: Type
-  """
-  This is a description of the `two` field.
-  """
+  """This is a description of the `two` field."""
   two(
-    """
-    This is a description of the `argument` argument.
-    """
+    """This is a description of the `argument` argument."""
     argument: InputType!
   ): Type
   three(argument: InputType, other: String): Int

--- a/tests/Language/SerializationTest.php
+++ b/tests/Language/SerializationTest.php
@@ -11,23 +11,22 @@ use PHPUnit\Framework\TestCase;
 
 use function Safe\file_get_contents;
 
-class SerializationTest extends TestCase
+final class SerializationTest extends TestCase
 {
     public function testSerializesAst(): void
     {
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
-        $ast = Parser::parse($kitchenSink);
+        $parsedAst = Parser::parse($kitchenSink);
         $expectedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink.ast'), true);
-        self::assertEquals($expectedAst, AST::toArray($ast));
+        self::assertEquals($expectedAst, AST::toArray($parsedAst));
     }
 
     public function testUnserializesAst(): void
     {
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
-        $serializedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink.ast'), true);
-        $actualAst = AST::fromArray($serializedAst);
         $parsedAst = Parser::parse($kitchenSink);
-        self::assertNodesAreEqual($parsedAst, $actualAst);
+        $serializedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink.ast'), true);
+        self::assertNodesAreEqual($parsedAst, AST::fromArray($serializedAst));
     }
 
     /**
@@ -55,7 +54,7 @@ class SerializationTest extends TestCase
                 self::assertNodesAreEqual($expectedValue, $actualValue, $tmpPath);
             } elseif ($expectedValue instanceof NodeList) {
                 self::assertInstanceOf(NodeList::class, $actualValue, $err);
-                self::assertEquals(\count($expectedValue), \count($actualValue), $err);
+                self::assertCount(\count($expectedValue), $actualValue, $err);
 
                 foreach ($expectedValue as $index => $listNode) {
                     $tmpPath2 = $tmpPath;
@@ -75,17 +74,16 @@ class SerializationTest extends TestCase
     public function testSerializeSupportsNoLocationOption(): void
     {
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
-        $ast = Parser::parse($kitchenSink, ['noLocation' => true]);
+        $parsedAst = Parser::parse($kitchenSink, ['noLocation' => true]);
         $expectedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink-noloc.ast'), true);
-        self::assertEquals($expectedAst, $ast->toArray());
+        self::assertEquals($expectedAst, $parsedAst->toArray());
     }
 
     public function testUnserializeSupportsNoLocationOption(): void
     {
         $kitchenSink = file_get_contents(__DIR__ . '/kitchen-sink.graphql');
-        $serializedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink-noloc.ast'), true);
-        $actualAst = AST::fromArray($serializedAst);
         $parsedAst = Parser::parse($kitchenSink, ['noLocation' => true]);
-        self::assertNodesAreEqual($parsedAst, $actualAst);
+        $serializedAst = \json_decode(file_get_contents(__DIR__ . '/kitchen-sink-noloc.ast'), true);
+        self::assertNodesAreEqual($parsedAst, AST::fromArray($serializedAst));
     }
 }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -472,6 +472,9 @@ final class SchemaPrinterTest extends TestCase
         );
     }
 
+    // TODO it('Prints schema with description', () => {
+    // TODO it('Omits schema of common names', () => {
+
     public function testSplitsArgsWithDescriptionsAcrossMultipleLines(): void
     {
         $schema = $this->buildSingleFieldSchema([
@@ -933,6 +936,28 @@ final class SchemaPrinterTest extends TestCase
     }
 
     /**
+     * @see it('Prints a description with only whitespace', () => {
+     */
+    public function testPrintsADescriptionWithOnlyWhitespace(): void
+    {
+        $schema = $this->buildSingleFieldSchema([
+            'type' => Type::string(),
+            'description' => ' ',
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            type Query {
+              " "
+              singleField: String
+            }
+
+            GRAPHQL,
+            $schema
+        );
+    }
+
+    /**
      * @see it('One-line prints a short description')
      */
     public function testOneLinePrintsAShortDescription(): void
@@ -954,6 +979,25 @@ final class SchemaPrinterTest extends TestCase
         );
     }
 
+    public function testEscapesOneLineDescription(): void
+    {
+        $schema = $this->buildSingleFieldSchema([
+            'type' => Type::string(),
+            'description' => 'foo\bar',
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            type Query {
+              "foo\\bar"
+              singleField: String
+            }
+
+            GRAPHQL,
+            $schema
+        );
+    }
+
     /**
      * @see it('Print Introspection Schema')
      */
@@ -963,17 +1007,13 @@ final class SchemaPrinterTest extends TestCase
         $output = SchemaPrinter::printIntrospectionSchema($schema);
 
         $expected = <<<'GRAPHQL'
-      """
-      Directs the executor to include this field or fragment only when the `if` argument is true.
-      """
+      "Directs the executor to include this field or fragment only when the `if` argument is true."
       directive @include(
         "Included when true."
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-      """
-      Directs the executor to skip this field or fragment when the `if` argument is true.
-      """
+      "Directs the executor to skip this field or fragment when the `if` argument is true."
       directive @skip(
         "Skipped when true."
         if: Boolean!
@@ -981,15 +1021,11 @@ final class SchemaPrinterTest extends TestCase
 
       "Marks an element of a GraphQL schema as no longer supported."
       directive @deprecated(
-        """
-        Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).
-        """
+        "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https:\/\/commonmark.org\/)."
         reason: String = "No longer supported"
       ) on FIELD_DEFINITION | ENUM_VALUE
 
-      """
-      A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
-      """
+      "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
       type __Schema {
         "A list of all types supported by this server."
         types: [__Type!]!
@@ -997,14 +1033,10 @@ final class SchemaPrinterTest extends TestCase
         "The type that query operations will be rooted at."
         queryType: __Type!
 
-        """
-        If this server supports mutation, the type that mutation operations will be rooted at.
-        """
+        "If this server supports mutation, the type that mutation operations will be rooted at."
         mutationType: __Type
 
-        """
-        If this server support subscription, the type that subscription operations will be rooted at.
-        """
+        "If this server support subscription, the type that subscription operations will be rooted at."
         subscriptionType: __Type
 
         "A list of all directives supported by this server."
@@ -1033,14 +1065,10 @@ final class SchemaPrinterTest extends TestCase
         "Indicates this type is a scalar."
         SCALAR
 
-        """
-        Indicates this type is an object. `fields` and `interfaces` are valid fields.
-        """
+        "Indicates this type is an object. `fields` and `interfaces` are valid fields."
         OBJECT
 
-        """
-        Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.
-        """
+        "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields."
         INTERFACE
 
         "Indicates this type is a union. `possibleTypes` is a valid field."
@@ -1049,9 +1077,7 @@ final class SchemaPrinterTest extends TestCase
         "Indicates this type is an enum. `enumValues` is a valid field."
         ENUM
 
-        """
-        Indicates this type is an input object. `inputFields` is a valid field.
-        """
+        "Indicates this type is an input object. `inputFields` is a valid field."
         INPUT_OBJECT
 
         "Indicates this type is a list. `ofType` is a valid field."
@@ -1061,9 +1087,7 @@ final class SchemaPrinterTest extends TestCase
         NON_NULL
       }
 
-      """
-      Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.
-      """
+      "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."
       type __Field {
         name: String!
         description: String
@@ -1073,23 +1097,17 @@ final class SchemaPrinterTest extends TestCase
         deprecationReason: String
       }
 
-      """
-      Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.
-      """
+      "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
       type __InputValue {
         name: String!
         description: String
         type: __Type!
 
-        """
-        A GraphQL-formatted string representing the default value for this input value.
-        """
+        "A GraphQL-formatted string representing the default value for this input value."
         defaultValue: String
       }
 
-      """
-      One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.
-      """
+      "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."
       type __EnumValue {
         name: String!
         description: String
@@ -1110,9 +1128,7 @@ final class SchemaPrinterTest extends TestCase
         args: [__InputValue!]!
       }
 
-      """
-      A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.
-      """
+      "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."
       enum __DirectiveLocation {
         "Location adjacent to a query operation."
         QUERY


### PR DESCRIPTION
Escape sequences were broken, e.g. backslashes were not escaped.
This lead to parsers choking on descriptions that include backslashes,
followed by a non-escape sequence, e.g. "\M".