### PR TITLE
Avoid deprecated interpolation syntax

### DIFF
--- a/src/Validator/Rules/ValuesOfCorrectType.php
+++ b/src/Validator/Rules/ValuesOfCorrectType.php
@@ -179,7 +179,7 @@ class ValuesOfCorrectType extends ValidationRule
     public static function badValueMessage($typeName, $valueName, $message = null)
     {
         return sprintf('Expected type %s, found %s', $typeName, $valueName) .
-            ($message ? "; ${message}" : '.');
+            ($message ? "; $message" : '.');
     }
 
     /**


### PR DESCRIPTION
This prevents a deprecation message in PHP 8.2.