### PR TITLE
Allow sorting more items in SchemaPrinter

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -2521,7 +2521,15 @@ static function concatAST(array $documents): GraphQL\Language\AST\DocumentNode
 
 Prints the contents of a Schema in schema definition language.
 
-@phpstan-type Options array{sortTypes?: bool}
+All sorting options sort alphabetically. If not given or `false`, the original schema definition order will be used.
+
+@phpstan-type Options array{
+sortArguments?: bool,
+sortEnumValues?: bool,
+sortFields?: bool,
+sortInputFields?: bool,
+sortTypes?: bool,
+}
 
 ### GraphQL\Utils\SchemaPrinter Methods
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -27,7 +27,15 @@ use GraphQL\Type\Schema;
 /**
  * Prints the contents of a Schema in schema definition language.
  *
- * @phpstan-type Options array{sortTypes?: bool}
+ * All sorting options sort alphabetically. If not given or `false`, the original schema definition order will be used.
+ *
+ * @phpstan-type Options array{
+ *   sortArguments?: bool,
+ *   sortEnumValues?: bool,
+ *   sortFields?: bool,
+ *   sortInputFields?: bool,
+ *   sortTypes?: bool,
+ * }
  */
 class SchemaPrinter
 {
@@ -239,6 +247,10 @@ class SchemaPrinter
             return '';
         }
 
+        if (isset($options['sortArguments']) && $options['sortArguments'] === true) {
+            usort($args, static fn (Argument $left, Argument $right): int => $left->name <=> $right->name);
+        }
+
         $allArgsWithoutDescription = true;
         foreach ($args as $arg) {
             $description = $arg->description;
@@ -340,7 +352,13 @@ class SchemaPrinter
         $fields = [];
         $firstInBlock = true;
         $previousHasDescription = false;
-        foreach ($type->getFields() as $f) {
+        $fieldDefinitions = $type->getFields();
+
+        if (isset($options['sortFields']) && $options['sortFields'] === true) {
+            ksort($fieldDefinitions);
+        }
+
+        foreach ($fieldDefinitions as $f) {
             $hasDescription = $f->description !== null;
             if ($previousHasDescription && ! $hasDescription) {
                 $fields[] = '';
@@ -434,7 +452,13 @@ class SchemaPrinter
     {
         $values = [];
         $firstInBlock = true;
-        foreach ($type->getValues() as $value) {
+        $valueDefinitions = $type->getValues();
+
+        if (isset($options['sortEnumValues']) && $options['sortEnumValues'] === true) {
+            usort($valueDefinitions, static fn (EnumValueDefinition $left, EnumValueDefinition $right): int => $left->name <=> $right->name);
+        }
+
+        foreach ($valueDefinitions as $value) {
             $values[] = static::printDescription($options, $value, '  ', $firstInBlock)
                 . '  '
                 . $value->name
@@ -456,8 +480,13 @@ class SchemaPrinter
     {
         $fields = [];
         $firstInBlock = true;
+        $fieldDefinitions = $type->getFields();
 
-        foreach ($type->getFields() as $field) {
+        if (isset($options['sortInputFields']) && $options['sortInputFields'] === true) {
+            ksort($fieldDefinitions);
+        }
+
+        foreach ($fieldDefinitions as $field) {
             $fields[] = static::printDescription($options, $field, '  ', $firstInBlock)
                 . '  '
                 . static::printInputValue($field);

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1224,4 +1224,170 @@ final class SchemaPrinterTest extends TestCase
             ['sortTypes' => true]
         );
     }
+
+    /**
+     * Additional functionality not present in the reference implementation.
+     */
+    public function testPrintSchemaWithSortedFields(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new InputObjectType(['name' => 'InputObject', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+                new InterfaceType(['name' => 'FooInterface', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+                new ObjectType(['name' => 'Abc', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+            ],
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            input InputObject {
+              foo: String
+              bar: String
+            }
+            
+            interface FooInterface {
+              bar: String
+              foo: String
+            }
+            
+            type Abc {
+              bar: String
+              foo: String
+            }
+
+            GRAPHQL,
+            $schema,
+            ['sortFields' => true]
+        );
+    }
+
+    /**
+     * Additional functionality not present in the reference implementation.
+     */
+    public function testPrintSchemaWithSortedInputFields(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new InputObjectType(['name' => 'InputObject', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+                new InterfaceType(['name' => 'FooInterface', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+                new ObjectType(['name' => 'Abc', 'fields' => [
+                    'foo' => ['type' => Type::string()],
+                    'bar' => ['type' => Type::string()],
+                ]]),
+            ],
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            input InputObject {
+              bar: String
+              foo: String
+            }
+            
+            interface FooInterface {
+              foo: String
+              bar: String
+            }
+            
+            type Abc {
+              foo: String
+              bar: String
+            }
+
+            GRAPHQL,
+            $schema,
+            ['sortInputFields' => true]
+        );
+    }
+
+    /**
+     * Additional functionality not present in the reference implementation.
+     */
+    public function testPrintSchemaWithSortedEnumValues(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new EnumType([
+                    'name' => 'RGB',
+                    'values' => [
+                        'RED' => [],
+                        'GREEN' => [],
+                        'BLUE' => [],
+                    ],
+                ]),
+            ],
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            enum RGB {
+              BLUE
+              GREEN
+              RED
+            }
+
+            GRAPHQL,
+            $schema,
+            ['sortEnumValues' => true]
+        );
+    }
+
+    /**
+     * Additional functionality not present in the reference implementation.
+     */
+    public function testPrintSchemaWithSortedArguments(): void
+    {
+        $schema = new Schema([
+            'types' => [
+                new InterfaceType(['name' => 'FooInterface', 'fields' => [
+                    'myField' => [
+                        'type' => Type::string(),
+                        'args' => [
+                            'foo' => ['type' => Type::int()],
+                            'bar' => ['type' => Type::int()],
+                        ],
+                    ],
+                ]]),
+                new ObjectType(['name' => 'Abc', 'fields' => [
+                    'myField' => [
+                        'type' => Type::string(),
+                        'args' => [
+                            'foo' => ['type' => Type::int()],
+                            'bar' => ['type' => Type::int()],
+                        ],
+                    ],
+                ]]),
+            ],
+        ]);
+
+        self::assertPrintedSchemaEquals(
+            <<<'GRAPHQL'
+            interface FooInterface {
+              myField(bar: Int, foo: Int): String
+            }
+            
+            type Abc {
+              myField(bar: Int, foo: Int): String
+            }
+
+            GRAPHQL,
+            $schema,
+            ['sortArguments' => true]
+        );
+    }
 }


### PR DESCRIPTION
This change allows you to configure the SchemaPrinter and define what should be sorted and what not.

`sortArguments` allows to sort arguments used in fields on objects and interfaces.

`sortFields` allows to sort fields inside objects and interfaces.

`sortInputFields` allows to sort fields inside input objects.

`sortEnumValues` allows to sort enum values.

It's important to know that changing the order of fields inside input objects can have severe consequences for clients that have generated code based on that order. For example, Apollo for Kotlin and Swift takes the ordering from the input object to create the input objects.

When the order in the schema changes, so does the order of the constructor arguments for those objects. When the calling code doesn't use named arguments, they can pass wrong values.

That's why I made sorting of input object fields a separate option.