### PR TITLE
Fixes a documentation error

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -84,7 +84,7 @@ use GraphQL\GraphQL;
 use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\DocumentValidator;
 
-DocumentValidator::addRule(new DisableIntrospection());
+DocumentValidator::addRule(new DisableIntrospection(true));
 
 GraphQL::executeQuery(/*...*/);
 ```


### PR DESCRIPTION
If not used with a boolean, an exception is thrown.

`ArgumentCountError: Too few arguments to function GraphQL\Validator\Rules\DisableIntrospection::__construct(), 0 passed in /var/www/html/app/Http/Controllers/GraphQLRequest.php on line 35 and exactly 1 expected in file /var/www/html/vendor/webonyx/graphql-php/src/Validator/Rules/DisableIntrospection.php on line 16`