### PR TITLE
fix: do not add `false` to NodeList

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,6 +39,9 @@ parameters:
         - message: "#^Property GraphQL\\\\Tests\\\\Type\\\\SchemaTest\\:\\:\\$implementingType is never read, only written\\.$#"
           path: tests
 
+        # Cannot satisfy input covariance
+        - '~(expects|should return) array<string, array<string, callable\(GraphQL\\Language\\AST\\Node\): GraphQL\\Language\\VisitorOperation\|void\|false\|null>\|\(callable\(GraphQL\\Language\\AST\\Node\): GraphQL\\Language\\VisitorOperation\|void\|false\|null\)>(,| but returns)?~'
+
 includes:
     - phpstan-baseline.neon
     - phpstan/include-by-php-version.php

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -6,6 +6,7 @@ use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\NodeList;
 use GraphQL\Utils\TypeInfo;
+use GraphQL\Utils\Utils;
 
 /**
  * Utility for efficient AST traversal and modification.
@@ -26,7 +27,7 @@ use GraphQL\Utils\TypeInfo;
  *     $editedAST = Visitor::visit($ast, [
  *       'enter' => function ($node, $key, $parent, $path, $ancestors) {
  *         // return
- *         //   null: no action
+ *         //   null: remove this node
  *         //   Visitor::skipNode(): skip visiting this node
  *         //   Visitor::stop(): stop visiting altogether
  *         //   Visitor::removeNode(): delete this node
@@ -225,9 +226,12 @@ class Visitor
                             ++$editOffset;
                         } else {
                             if ($node instanceof NodeList || \is_array($node)) {
-                                if ($editValue !== false) {
-                                    $node[$editKey] = $editValue;
+                                if (! $editValue instanceof Node) {
+                                    $notNode = Utils::printSafe($editValue);
+                                    throw new \Exception("Can only add Node to NodeList, got: {$notNode}.");
                                 }
+
+                                $node[$editKey] = $editValue;
                             } else {
                                 $node->{$editKey} = $editValue;
                             }

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -274,25 +274,22 @@ class Visitor
 
                 if ($visitFn !== null) {
                     $result = $visitFn($node, $key, $parent, $path, $ancestors);
-                    $editValue = null;
 
                     if ($result !== null) {
-                        if ($result instanceof VisitorOperation) {
-                            if ($result instanceof VisitorStop) {
-                                break;
-                            }
-
-                            if (! $isLeaving && $result instanceof VisitorSkipNode) {
-                                \array_pop($path);
-                                continue;
-                            }
-
-                            if ($result instanceof VisitorRemoveNode) {
-                                $editValue = null;
-                            }
-                        } else {
-                            $editValue = $result;
+                        if ($result instanceof VisitorStop) {
+                            break;
                         }
+
+                        if ($result instanceof VisitorSkipNode) {
+                            if (! $isLeaving) {
+                                \array_pop($path);
+                            }
+                            continue;
+                        }
+
+                        $editValue = $result instanceof VisitorRemoveNode
+                            ? null
+                            : $result;
 
                         $edits[] = [$key, $editValue];
                         if (! $isLeaving) {

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -94,7 +94,8 @@ use GraphQL\Utils\TypeInfo;
  *       ]
  *     ]);
  *
- * @phpstan-type VisitorArray array<string, callable(Node): VisitorOperation|mixed|null>|array<string, array<string, callable(Node): VisitorOperation|mixed|null>>
+ * @phpstan-type NodeVisitor callable(Node): (VisitorOperation|null|false|void)
+ * @phpstan-type VisitorArray array<string, NodeVisitor>|array<string, array<string, NodeVisitor>>
  */
 class Visitor
 {
@@ -224,7 +225,9 @@ class Visitor
                             ++$editOffset;
                         } else {
                             if ($node instanceof NodeList || \is_array($node)) {
-                                $node[$editKey] = $editValue;
+                                if ($editValue !== false) {
+                                    $node[$editKey] = $editValue;
+                                }
                             } else {
                                 $node->{$editKey} = $editValue;
                             }

--- a/src/Validator/QueryValidationContext.php
+++ b/src/Validator/QueryValidationContext.php
@@ -129,11 +129,8 @@ class QueryValidationContext implements ValidationContext
                 Visitor::visitWithTypeInfo(
                     $typeInfo,
                     [
-                        NodeKind::VARIABLE_DEFINITION => static fn (): bool => false,
-                        NodeKind::VARIABLE => static function (VariableNode $variable) use (
-                            &$usages,
-                            $typeInfo
-                        ): void {
+                        NodeKind::VARIABLE_DEFINITION => static fn () => Visitor::skipNode(),
+                        NodeKind::VARIABLE => static function (VariableNode $variable) use (&$usages, $typeInfo): void {
                             $usages[] = [
                                 'node' => $variable,
                                 'type' => $typeInfo->getInputType(),

--- a/src/Validator/Rules/SingleFieldSubscription.php
+++ b/src/Validator/Rules/SingleFieldSubscription.php
@@ -11,9 +11,6 @@ use GraphQL\Validator\QueryValidationContext;
 
 class SingleFieldSubscription extends ValidationRule
 {
-    /**
-     * @return array<string, callable>
-     */
     public function getVisitor(QueryValidationContext $context): array
     {
         return [


### PR DESCRIPTION
Visitor like this one https://github.com/webonyx/graphql-php/blob/76e165607d1a0f5eb47e8dbd8d653fa9661d0281/src/Validator/QueryValidationContext.php#L132 may return `false` or `void` https://github.com/webonyx/graphql-php/blob/76e165607d1a0f5eb47e8dbd8d653fa9661d0281/src/Language/Visitor.php#L275 which is interpreted as `false` as well.

However, we were pushing the false into a `NodeList` which is wrong I believe since it should contain nodes only.

And also based on tests I came to a conclusion that `false` is valid return value from NodeVisitor so I handled it only for `NodeList`.