### PR TITLE
test(phpunit): fix suffix deprecation

### DIFF
--- a/tests/Type/EagerTypeLoaderTest.php
+++ b/tests/Type/EagerTypeLoaderTest.php
@@ -12,7 +12,7 @@ use GraphQL\Type\Schema;
 /**
  * @see LazyTypeLoaderTest
  */
-final class EagerTypeLoaderTest extends TypeLoaderTest
+final class EagerTypeLoaderTest extends TypeLoaderTestCaseBase
 {
     private InterfaceType $node;
 

--- a/tests/Type/LazyTypeLoaderTest.php
+++ b/tests/Type/LazyTypeLoaderTest.php
@@ -9,10 +9,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 
-/**
- * @see TypeLoaderTest
- */
-final class LazyTypeLoaderTest extends TypeLoaderTest
+final class LazyTypeLoaderTest extends TypeLoaderTestCaseBase
 {
     /** @var callable(): InterfaceType */
     private $node;

--- a/tests/Type/TypeLoaderTestCaseBase.php
+++ b/tests/Type/TypeLoaderTestCaseBase.php
@@ -10,7 +10,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 
-abstract class TypeLoaderTest extends TestCaseBase
+abstract class TypeLoaderTestCaseBase extends TestCaseBase
 {
     use ArraySubsetAsserts;
 


### PR DESCRIPTION
> Abstract test case classes with "Test" suffix are deprecated (GraphQL\Tests\Type\TypeLoaderTest)