### PR TITLE
Remove `ArrayAccess` from `NodeList` and enforce contiguous `int` keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Make `NodeList` an actual list
+
 ## v15.1.0
 
 ### Added

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -224,7 +224,7 @@ class Visitor
                                 throw new \Exception("Can only add Node to NodeList, got: {$notNode}.");
                             }
 
-                            $node[$editKey] = $editValue;
+                            $node->set($editKey, $editValue);
                         } else {
                             $node->{$editKey} = $editValue;
                         }
@@ -246,7 +246,7 @@ class Visitor
                         ? $index
                         : $keys[$index];
                     $node = $parent instanceof NodeList
-                        ? $parent[$key]
+                        ? $parent->get($key)
                         : $parent->{$key};
                 }
                 if ($node === null) {

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -61,7 +61,7 @@ class QueryComplexity extends QuerySecurityRule
                     );
                 },
                 NodeKind::VARIABLE_DEFINITION => function ($def): VisitorOperation {
-                    $this->variableDefs[] = $def;
+                    $this->variableDefs->add($def);
 
                     return Visitor::skipNode();
                 },

--- a/tests/Error/ErrorTest.php
+++ b/tests/Error/ErrorTest.php
@@ -34,8 +34,8 @@ final class ErrorTest extends TestCase
     }');
         $ast = Parser::parse($source);
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $ast->definitions[0];
-        $fieldNode = $operationDefinition->selectionSet->selections[0];
+        $operationDefinition = $ast->definitions->get(0);
+        $fieldNode = $operationDefinition->selectionSet->selections->get(0);
         $e = new Error('msg', [$fieldNode]);
 
         self::assertEquals([$fieldNode], $e->getNodes());
@@ -54,8 +54,8 @@ final class ErrorTest extends TestCase
     }');
         $ast = Parser::parse($source);
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $ast->definitions[0];
-        $fieldNode = $operationDefinition->selectionSet->selections[0];
+        $operationDefinition = $ast->definitions->get(0);
+        $fieldNode = $operationDefinition->selectionSet->selections->get(0);
         $e = new Error('msg', $fieldNode); // Non-array value.
 
         self::assertEquals([$fieldNode], $e->getNodes());
@@ -73,7 +73,7 @@ final class ErrorTest extends TestCase
       field
     }');
         $ast = Parser::parse($source);
-        $operationNode = $ast->definitions[0];
+        $operationNode = $ast->definitions->get(0);
         $e = new Error('msg', [$operationNode]);
 
         self::assertEquals([$operationNode], $e->getNodes());

--- a/tests/Error/ErrorTest.php
+++ b/tests/Error/ErrorTest.php
@@ -114,8 +114,8 @@ final class ErrorTest extends TestCase
     {
         $ast = Parser::parse('{ field }');
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $ast->definitions[0];
-        $node = $operationDefinition->selectionSet->selections[0];
+        $operationDefinition = $ast->definitions->get(0);
+        $node = $operationDefinition->selectionSet->selections->get(0);
         $e = new Error('msg', [$node]);
 
         self::assertEquals(

--- a/tests/Error/PrintErrorTest.php
+++ b/tests/Error/PrintErrorTest.php
@@ -63,8 +63,8 @@ Test (9:1)
         ));
 
         /** @var ObjectTypeDefinitionNode $objectDefinitionA */
-        $objectDefinitionA = $sourceA->definitions[0];
-        $fieldTypeA = $objectDefinitionA->fields[0]->type;
+        $objectDefinitionA = $sourceA->definitions->get(0);
+        $fieldTypeA = $objectDefinitionA->fields->get(0)->type;
 
         $sourceB = Parser::parse(new Source(
             'type Foo {
@@ -74,8 +74,8 @@ Test (9:1)
         ));
 
         /** @var ObjectTypeDefinitionNode $objectDefinitionB */
-        $objectDefinitionB = $sourceB->definitions[0];
-        $fieldTypeB = $objectDefinitionB->fields[0]->type;
+        $objectDefinitionB = $sourceB->definitions->get(0);
+        $fieldTypeB = $objectDefinitionB->fields->get(0)->type;
 
         $error = new Error(
             'Example error with two nodes',

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -257,11 +257,11 @@ final class ExecutorTest extends TestCase
         Executor::execute($schema, $ast, $rootValue, null, ['var' => '123']);
 
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $ast->definitions[0];
+        $operationDefinition = $ast->definitions->get(0);
 
         self::assertEquals('test', $info->fieldName);
         self::assertCount(1, $info->fieldNodes);
-        self::assertSame($operationDefinition->selectionSet->selections[0], $info->fieldNodes[0]);
+        self::assertSame($operationDefinition->selectionSet->selections->get(0), $info->fieldNodes[0]);
         self::assertSame(Type::string(), $info->returnType);
         self::assertSame($schema->getQueryType(), $info->parentType);
         self::assertEquals(['result'], $info->path);

--- a/tests/Language/AST/NodeTest.php
+++ b/tests/Language/AST/NodeTest.php
@@ -30,16 +30,16 @@ final class NodeTest extends TestCase
         $cloneFields = $clone->fields;
         self::assertNotSameButEquals($nodeFields, $cloneFields);
 
-        $nodeId = $nodeFields[0];
-        $cloneId = $cloneFields[0];
+        $nodeId = $nodeFields->get(0);
+        $cloneId = $cloneFields->get(0);
         self::assertNotSameButEquals($nodeId, $cloneId);
 
         $nodeIdArgs = $nodeId->arguments;
         $cloneIdArgs = $cloneId->arguments;
         self::assertNotSameButEquals($nodeIdArgs, $cloneIdArgs);
 
-        $nodeArg = $nodeIdArgs[0];
-        $cloneArg = $cloneIdArgs[0];
+        $nodeArg = $nodeIdArgs->get(0);
+        $cloneArg = $cloneIdArgs->get(0);
         self::assertNotSameButEquals($nodeArg, $cloneArg);
 
         self::assertSame($node->loc, $clone->loc);

--- a/tests/Language/ParserTest.php
+++ b/tests/Language/ParserTest.php
@@ -220,7 +220,7 @@ HEREDOC;
         ]);
 
         /** @var OperationDefinitionNode $operationDefinition */
-        $operationDefinition = $result->definitions[0];
+        $operationDefinition = $result->definitions->get(0);
         self::assertEquals($expected, $operationDefinition->selectionSet);
     }
 

--- a/tests/Language/SerializationTest.php
+++ b/tests/Language/SerializationTest.php
@@ -58,8 +58,8 @@ final class SerializationTest extends TestCase
 
                 foreach ($expectedValue as $index => $listNode) {
                     $tmpPath2 = $tmpPath;
-                    $tmpPath2[] = $index;
-                    self::assertNodesAreEqual($listNode, $actualValue[$index], $tmpPath2);
+                    $tmpPath2[] = (string) $index;
+                    self::assertNodesAreEqual($listNode, $actualValue->get($index), $tmpPath2);
                 }
             } elseif ($expectedValue instanceof Location) {
                 self::assertInstanceOf(Location::class, $actualValue, $err);

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -49,7 +49,7 @@ final class VisitorTest extends ValidatorTestCase
 
         if ($parent instanceof NodeList) {
             self::assertIsInt($key);
-            self::assertTrue(isset($parent[$key]));
+            self::assertTrue($parent->has($key));
         } else {
             self::assertIsString($key);
             self::assertTrue(property_exists($parent, $key));
@@ -66,7 +66,8 @@ final class VisitorTest extends ValidatorTestCase
         }
 
         if ($parent instanceof NodeList) {
-            self::assertEquals($node, $parent[$key]);
+            self::assertIsInt($key);
+            self::assertEquals($node, $parent->get($key));
         } else {
             /** @phpstan-ignore-next-line */
             self::assertEquals($node, $parent->{$key});
@@ -91,7 +92,8 @@ final class VisitorTest extends ValidatorTestCase
 
         foreach ($path as $key) {
             if ($result instanceof NodeList) {
-                $result = $result[$key];
+                self::assertIsInt($key);
+                $result = $result->get($key);
             } else {
                 /** @phpstan-ignore-next-line */
                 $result = $result->{$key};
@@ -221,7 +223,7 @@ final class VisitorTest extends ValidatorTestCase
         self::assertNotEquals($ast, $editedAst);
 
         $expected = $ast->cloneDeep();
-        $operationNode = $expected->definitions[0];
+        $operationNode = $expected->definitions->get(0);
         assert($operationNode instanceof OperationDefinitionNode);
         $operationNode->directives = new NodeList([$directive1, $directive2]);
 

--- a/tests/Utils/AstGetOperationAstTest.php
+++ b/tests/Utils/AstGetOperationAstTest.php
@@ -18,7 +18,7 @@ final class AstGetOperationAstTest extends TestCase
         $doc = Parser::parse('{ field }');
         self::assertEquals(
             AST::getOperationAST($doc),
-            $doc->definitions->offsetGet(0)
+            $doc->definitions->get(0)
         );
     }
 
@@ -28,7 +28,7 @@ final class AstGetOperationAstTest extends TestCase
     public function testGetsAnOperationFromADcoumentWithNamedOpMutation(): void
     {
         $doc = Parser::parse('mutation Test { field }');
-        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->get(0));
     }
 
     /**
@@ -37,7 +37,7 @@ final class AstGetOperationAstTest extends TestCase
     public function testGetsAnOperationFromADcoumentWithNamedOpSubscription(): void
     {
         $doc = Parser::parse('subscription Test { field }');
-        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->offsetGet(0));
+        self::assertEquals(AST::getOperationAST($doc), $doc->definitions->get(0));
     }
 
     /**
@@ -99,8 +99,8 @@ final class AstGetOperationAstTest extends TestCase
           mutation TestM { field }
           subscription TestS { field }
         ');
-        self::assertEquals(AST::getOperationAST($doc, 'TestQ'), $doc->definitions->offsetGet(0));
-        self::assertEquals(AST::getOperationAST($doc, 'TestM'), $doc->definitions->offsetGet(1));
-        self::assertEquals(AST::getOperationAST($doc, 'TestS'), $doc->definitions->offsetGet(2));
+        self::assertEquals(AST::getOperationAST($doc, 'TestQ'), $doc->definitions->get(0));
+        self::assertEquals(AST::getOperationAST($doc, 'TestM'), $doc->definitions->get(1));
+        self::assertEquals(AST::getOperationAST($doc, 'TestS'), $doc->definitions->get(2));
     }
 }

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -429,7 +429,7 @@ final class BuildSchemaTest extends TestCaseBase
             
             GRAPHQL;
 
-        $definition = Parser::parse($sdl)->definitions[0];
+        $definition = Parser::parse($sdl)->definitions->get(0);
         self::assertInstanceOf(InterfaceTypeDefinitionNode::class, $definition);
         self::assertCount(0, $definition->interfaces, 'The interfaces property must be an empty list.');
 


### PR DESCRIPTION
Reintroduces https://github.com/webonyx/graphql-php/pull/1315 and https://github.com/webonyx/graphql-php/pull/1321.

I found that AST manipulation is common enough that we should not break it in a minor release.