### PR TITLE
Initialize `directives` and `arguments` in `Node` with empty `NodeList`

### DIFF
--- a/src/Language/AST/DirectiveDefinitionNode.php
+++ b/src/Language/AST/DirectiveDefinitionNode.php
@@ -17,4 +17,10 @@ class DirectiveDefinitionNode extends Node implements TypeSystemDefinitionNode
 
     /** @var NodeList<NameNode> */
     public NodeList $locations;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->arguments = $this->arguments ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/DirectiveDefinitionNode.php
+++ b/src/Language/AST/DirectiveDefinitionNode.php
@@ -21,6 +21,6 @@ class DirectiveDefinitionNode extends Node implements TypeSystemDefinitionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->arguments = $this->arguments ?? new NodeList([]);
+        $this->arguments ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/DirectiveNode.php
+++ b/src/Language/AST/DirectiveNode.php
@@ -14,6 +14,6 @@ class DirectiveNode extends Node
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->arguments = $this->arguments ?? new NodeList([]);
+        $this->arguments ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/DirectiveNode.php
+++ b/src/Language/AST/DirectiveNode.php
@@ -10,4 +10,10 @@ class DirectiveNode extends Node
 
     /** @var NodeList<ArgumentNode> */
     public NodeList $arguments;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->arguments = $this->arguments ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/EnumTypeDefinitionNode.php
+++ b/src/Language/AST/EnumTypeDefinitionNode.php
@@ -24,6 +24,6 @@ class EnumTypeDefinitionNode extends Node implements TypeDefinitionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/EnumTypeDefinitionNode.php
+++ b/src/Language/AST/EnumTypeDefinitionNode.php
@@ -20,4 +20,10 @@ class EnumTypeDefinitionNode extends Node implements TypeDefinitionNode
     {
         return $this->name;
     }
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/EnumTypeExtensionNode.php
+++ b/src/Language/AST/EnumTypeExtensionNode.php
@@ -17,7 +17,7 @@ class EnumTypeExtensionNode extends Node implements TypeExtensionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 
     public function getName(): NameNode

--- a/src/Language/AST/EnumTypeExtensionNode.php
+++ b/src/Language/AST/EnumTypeExtensionNode.php
@@ -14,6 +14,12 @@ class EnumTypeExtensionNode extends Node implements TypeExtensionNode
     /** @var NodeList<EnumValueDefinitionNode> */
     public NodeList $values;
 
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
+
     public function getName(): NameNode
     {
         return $this->name;

--- a/src/Language/AST/FieldNode.php
+++ b/src/Language/AST/FieldNode.php
@@ -21,7 +21,7 @@ class FieldNode extends Node implements SelectionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
-        $this->arguments = $this->arguments ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
+        $this->arguments ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/FieldNode.php
+++ b/src/Language/AST/FieldNode.php
@@ -17,4 +17,11 @@ class FieldNode extends Node implements SelectionNode
     public NodeList $directives;
 
     public ?SelectionSetNode $selectionSet = null;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+		$this->arguments = $this->arguments ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/FragmentDefinitionNode.php
+++ b/src/Language/AST/FragmentDefinitionNode.php
@@ -28,7 +28,7 @@ class FragmentDefinitionNode extends Node implements ExecutableDefinitionNode, H
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 
     public function getSelectionSet(): SelectionSetNode

--- a/src/Language/AST/FragmentDefinitionNode.php
+++ b/src/Language/AST/FragmentDefinitionNode.php
@@ -25,6 +25,12 @@ class FragmentDefinitionNode extends Node implements ExecutableDefinitionNode, H
 
     public SelectionSetNode $selectionSet;
 
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
+
     public function getSelectionSet(): SelectionSetNode
     {
         return $this->selectionSet;

--- a/src/Language/AST/FragmentSpreadNode.php
+++ b/src/Language/AST/FragmentSpreadNode.php
@@ -10,4 +10,10 @@ class FragmentSpreadNode extends Node implements SelectionNode
 
     /** @var NodeList<DirectiveNode> */
     public NodeList $directives;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/FragmentSpreadNode.php
+++ b/src/Language/AST/FragmentSpreadNode.php
@@ -14,6 +14,6 @@ class FragmentSpreadNode extends Node implements SelectionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/InlineFragmentNode.php
+++ b/src/Language/AST/InlineFragmentNode.php
@@ -16,6 +16,6 @@ class InlineFragmentNode extends Node implements SelectionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/InlineFragmentNode.php
+++ b/src/Language/AST/InlineFragmentNode.php
@@ -12,4 +12,10 @@ class InlineFragmentNode extends Node implements SelectionNode
     public NodeList $directives;
 
     public SelectionSetNode $selectionSet;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/InputObjectTypeDefinitionNode.php
+++ b/src/Language/AST/InputObjectTypeDefinitionNode.php
@@ -20,4 +20,10 @@ class InputObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     {
         return $this->name;
     }
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
 }

--- a/src/Language/AST/InputObjectTypeDefinitionNode.php
+++ b/src/Language/AST/InputObjectTypeDefinitionNode.php
@@ -24,6 +24,6 @@ class InputObjectTypeDefinitionNode extends Node implements TypeDefinitionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -24,6 +24,12 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
 
     public SelectionSetNode $selectionSet;
 
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
+
     public function getSelectionSet(): SelectionSetNode
     {
         return $this->selectionSet;

--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -27,7 +27,7 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 
     public function getSelectionSet(): SelectionSetNode

--- a/src/Language/AST/VariableDefinitionNode.php
+++ b/src/Language/AST/VariableDefinitionNode.php
@@ -20,6 +20,6 @@ class VariableDefinitionNode extends Node implements DefinitionNode
     public function __construct(array $vars)
     {
         parent::__construct($vars);
-        $this->directives = $this->directives ?? new NodeList([]);
+        $this->directives ??= new NodeList([]);
     }
 }

--- a/src/Language/AST/VariableDefinitionNode.php
+++ b/src/Language/AST/VariableDefinitionNode.php
@@ -4,7 +4,7 @@ namespace GraphQL\Language\AST;
 
 class VariableDefinitionNode extends Node implements DefinitionNode
 {
-    public string $kind = NodeKind::VARIABLE_DEFINITION;
+	public string $kind = NodeKind::VARIABLE_DEFINITION;
 
     public VariableNode $variable;
 
@@ -16,4 +16,10 @@ class VariableDefinitionNode extends Node implements DefinitionNode
 
     /** @var NodeList<DirectiveNode> */
     public NodeList $directives;
+
+	public function __construct(array $vars)
+	{
+		parent::__construct($vars);
+		$this->directives = $this->directives ?? new NodeList([]);
+	}
 }

--- a/tests/Utils/AstFromArrayTest.php
+++ b/tests/Utils/AstFromArrayTest.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Utils;
+
+use GraphQL\Error\SerializationError;
+use GraphQL\Language\AST\BooleanValueNode;
+use GraphQL\Language\AST\EnumValueNode;
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\AST\FloatValueNode;
+use GraphQL\Language\AST\FragmentDefinitionNode;
+use GraphQL\Language\AST\FragmentSpreadNode;
+use GraphQL\Language\AST\InlineFragmentNode;
+use GraphQL\Language\AST\IntValueNode;
+use GraphQL\Language\AST\ListValueNode;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\NullValueNode;
+use GraphQL\Language\AST\ObjectFieldNode;
+use GraphQL\Language\AST\ObjectValueNode;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Language\AST\VariableDefinitionNode;
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Utils\AST;
+use PHPUnit\Framework\TestCase;
+
+final class AstFromArrayTest extends TestCase
+{
+    public function testVariableDefinitionArrayFromArray(): void
+    {
+		/**
+		 * @var VariableDefinitionNode
+		 */
+		$res = AST::fromArray([
+				"kind"=>"VariableDefinition",
+				"directives"=>[]
+		]);
+        self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var OperationDefinitionNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"OperationDefinition",
+			"directives"=>[]
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var FieldNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"Field",
+			"directives"=>[],
+			"arguments"=>[]
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+		self::assertEquals($res->arguments, new NodeList([]) );
+
+		/**
+		 * @var FragmentSpreadNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"FragmentSpread",
+			"directives"=>[],
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var FragmentDefinitionNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"FragmentDefinition",
+			"directives"=>[],
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var InlineFragmentNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"InlineFragment",
+			"directives"=>[],
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+	}
+
+	public function testVariableDefinitionArrayFromSparseArray(): void
+	{
+		/**
+		 * @var VariableDefinitionNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"VariableDefinition"
+		]);
+
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var OperationDefinitionNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"OperationDefinition"
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var FieldNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"Field",
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+		self::assertEquals($res->arguments, new NodeList([]) );
+
+		/**
+		 * @var FragmentSpreadNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"FragmentSpread",
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var FragmentDefinitionNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"FragmentDefinition",
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+
+		/**
+		 * @var InlineFragmentNode
+		 */
+		$res = AST::fromArray([
+			"kind"=>"InlineFragment",
+		]);
+		self::assertEquals($res->directives, new NodeList([]) );
+	}
+}

--- a/tests/Utils/AstFromArrayTest.php
+++ b/tests/Utils/AstFromArrayTest.php
@@ -20,45 +20,45 @@ final class AstFromArrayTest extends TestCase
             'kind' => 'VariableDefinition',
             'directives' => [],
         ]);
-		assert($res instanceof  VariableDefinitionNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof VariableDefinitionNode);
+        self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'OperationDefinition',
             'directives' => [],
         ]);
-		assert($res instanceof  OperationDefinitionNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof OperationDefinitionNode);
+        self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'Field',
             'directives' => [],
             'arguments' => [],
         ]);
-		assert($res instanceof  FieldNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof FieldNode);
+        self::assertEquals($res->directives, new NodeList([]));
         self::assertEquals($res->arguments, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'FragmentSpread',
             'directives' => [],
         ]);
-		assert($res instanceof  FragmentSpreadNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof FragmentSpreadNode);
+        self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'FragmentDefinition',
             'directives' => [],
         ]);
-		assert($res instanceof  FragmentDefinitionNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof FragmentDefinitionNode);
+        self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'InlineFragment',
             'directives' => [],
         ]);
-		assert($res instanceof  InlineFragmentNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof InlineFragmentNode);
+        self::assertEquals($res->directives, new NodeList([]));
     }
 
     public function testVariableDefinitionArrayFromSparseArray(): void
@@ -66,38 +66,38 @@ final class AstFromArrayTest extends TestCase
         $res = AST::fromArray([
             'kind' => 'VariableDefinition',
         ]);
-		assert($res instanceof  VariableDefinitionNode);
+        assert($res instanceof VariableDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'OperationDefinition',
         ]);
-		assert($res instanceof  OperationDefinitionNode);
+        assert($res instanceof OperationDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
-		$res = AST::fromArray([
-			'kind' => 'Field',
-		]);
-		assert($res instanceof  FieldNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        $res = AST::fromArray([
+            'kind' => 'Field',
+        ]);
+        assert($res instanceof FieldNode);
+        self::assertEquals($res->directives, new NodeList([]));
         self::assertEquals($res->arguments, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'FragmentSpread',
         ]);
-		assert($res instanceof  FragmentSpreadNode);
+        assert($res instanceof FragmentSpreadNode);
         self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'FragmentDefinition',
         ]);
-		assert($res instanceof  FragmentDefinitionNode);
+        assert($res instanceof FragmentDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'InlineFragment',
         ]);
-		assert($res instanceof  InlineFragmentNode);
-		self::assertEquals($res->directives, new NodeList([]));
+        assert($res instanceof InlineFragmentNode);
+        self::assertEquals($res->directives, new NodeList([]));
     }
 }

--- a/tests/Utils/AstFromArrayTest.php
+++ b/tests/Utils/AstFromArrayTest.php
@@ -16,113 +16,88 @@ final class AstFromArrayTest extends TestCase
 {
     public function testVariableDefinitionArrayFromArray(): void
     {
-        /**
-         * @var VariableDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'VariableDefinition',
             'directives' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  VariableDefinitionNode);
+		self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var OperationDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'OperationDefinition',
             'directives' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  OperationDefinitionNode);
+		self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var FieldNode
-         */
         $res = AST::fromArray([
             'kind' => 'Field',
             'directives' => [],
             'arguments' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  FieldNode);
+		self::assertEquals($res->directives, new NodeList([]));
         self::assertEquals($res->arguments, new NodeList([]));
 
-        /**
-         * @var FragmentSpreadNode
-         */
         $res = AST::fromArray([
             'kind' => 'FragmentSpread',
             'directives' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  FragmentSpreadNode);
+		self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var FragmentDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'FragmentDefinition',
             'directives' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  FragmentDefinitionNode);
+		self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var InlineFragmentNode
-         */
         $res = AST::fromArray([
             'kind' => 'InlineFragment',
             'directives' => [],
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  InlineFragmentNode);
+		self::assertEquals($res->directives, new NodeList([]));
     }
 
     public function testVariableDefinitionArrayFromSparseArray(): void
     {
-        /**
-         * @var VariableDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'VariableDefinition',
         ]);
-
+		assert($res instanceof  VariableDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var OperationDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'OperationDefinition',
         ]);
+		assert($res instanceof  OperationDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var FieldNode
-         */
-        $res = AST::fromArray([
-            'kind' => 'Field',
-        ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		$res = AST::fromArray([
+			'kind' => 'Field',
+		]);
+		assert($res instanceof  FieldNode);
+		self::assertEquals($res->directives, new NodeList([]));
         self::assertEquals($res->arguments, new NodeList([]));
 
-        /**
-         * @var FragmentSpreadNode
-         */
         $res = AST::fromArray([
             'kind' => 'FragmentSpread',
         ]);
+		assert($res instanceof  FragmentSpreadNode);
         self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var FragmentDefinitionNode
-         */
         $res = AST::fromArray([
             'kind' => 'FragmentDefinition',
         ]);
+		assert($res instanceof  FragmentDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
 
-        /**
-         * @var InlineFragmentNode
-         */
         $res = AST::fromArray([
             'kind' => 'InlineFragment',
         ]);
-        self::assertEquals($res->directives, new NodeList([]));
+		assert($res instanceof  InlineFragmentNode);
+		self::assertEquals($res->directives, new NodeList([]));
     }
 }

--- a/tests/Utils/AstFromArrayTest.php
+++ b/tests/Utils/AstFromArrayTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AstFromArrayTest extends TestCase
 {
-    public function testVariableDefinitionArrayFromArray(): void
+    public function testFromArray(): void
     {
         $res = AST::fromArray([
             'kind' => 'VariableDefinition',
@@ -61,7 +61,7 @@ final class AstFromArrayTest extends TestCase
         self::assertEquals($res->directives, new NodeList([]));
     }
 
-    public function testVariableDefinitionArrayFromSparseArray(): void
+    public function testFromOptimizedArray(): void
     {
         $res = AST::fromArray([
             'kind' => 'VariableDefinition',


### PR DESCRIPTION
Hey folks, I finally got around to updating to 15.0 today, and a few things exploded. Similar to the [issue I reported a while ago](https://github.com/webonyx/graphql-php/pull/1272), I run into issues when calling `AST::fromArray` on AST arrays that are generated without empty placeholder arrays for things like `directives` and `arguments`. 

My previous approach was to coalesce those fields to empty array in the consuming code, but this time there were a lot more of those access points to guard against, so I thought I'd try just initializing `directives` and `arguments` in the constructors.

There are, of course, several other ways we could approach this:
* make these fields private and make getters that coalesce to empty lists
* put `isset` and coalesce checks everywhere where these things are accessed

We could also discuss modifying our AST generation so that it doesn't add empty placeholders (~thus mirroring the JavaScript version of GraphQL~ edit: actually done by a [3rd-party optimization tool](https://www.npmjs.com/package/@graphql-tools/optimize)), which would make it harder for this kind of problem to slip past us.

I'm open to anything. Please let me know what you think.