### PR TITLE
Before fetching a type, first check if it exists

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -186,19 +186,9 @@ class SchemaPrinter
      */
     protected static function hasDefaultRootOperationTypes(Schema $schema): bool
     {
-        if ($schema->hasType('Query') && $schema->getQueryType() === $schema->getType('Query')) {
-            return true;
-        }
-
-        if ($schema->hasType('Mutation') && $schema->getMutationType() === $schema->getType('Mutation')) {
-            return true;
-        }
-
-        if ($schema->hasType('Subscription') && $schema->getSubscriptionType() === $schema->getType('Subscription')) {
-            return true;
-        }
-
-        return false;
+        return ($schema->getQueryType() !== null && $schema->getQueryType() === $schema->getType('Query'))
+            && ($schema->getMutationType() !== null && $schema->getMutationType() === $schema->getType('Mutation'))
+            && ($schema->getSubscriptionType() !== null && $schema->getSubscriptionType() === $schema->getType('Subscription'));
     }
 
     /**


### PR DESCRIPTION
When upgrading from 15.1.0 to 15.2.1 I noticed the following error in our setup:

```
  Type "Subscription" not found in name to fully qualified mapping
```

We have a very strict service locator. Any type that is retrieved should exist, or fail.

This works fine, and allows us to quickly spot invalid referenced types.

But this broke in f82c04f191906150bfb0ca3458f238d24312d839

I think it's better to first check if a type exists, before comparing it.