### PR TITLE
feat: add missing @throws to Type constructors

### DIFF
--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -63,6 +63,8 @@ class EnumType extends Type implements InputType, OutputType, LeafType, Nullable
     private array $nameLookup;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param EnumTypeConfig $config
      */
     public function __construct(array $config)

--- a/src/Type/Definition/InputObjectType.php
+++ b/src/Type/Definition/InputObjectType.php
@@ -42,6 +42,8 @@ class InputObjectType extends Type implements InputType, NullableType, NamedType
     private array $fields;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param InputObjectConfig $config
      */
     public function __construct(array $config)

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -37,6 +37,8 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
     public array $config;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param InterfaceConfig $config
      */
     public function __construct(array $config)

--- a/src/Type/Definition/NamedTypeImplementation.php
+++ b/src/Type/Definition/NamedTypeImplementation.php
@@ -18,6 +18,9 @@ trait NamedTypeImplementation
         return $this->name;
     }
 
+    /**
+     * @throws InvariantViolation
+     */
     protected function inferName(): string
     {
         if (isset($this->name)) {

--- a/src/Type/Definition/ObjectType.php
+++ b/src/Type/Definition/ObjectType.php
@@ -84,6 +84,8 @@ class ObjectType extends Type implements OutputType, CompositeType, NullableType
     public array $config;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param ObjectConfig $config
      */
     public function __construct(array $config)

--- a/src/Type/Definition/ScalarType.php
+++ b/src/Type/Definition/ScalarType.php
@@ -2,6 +2,7 @@
 
 namespace GraphQL\Type\Definition;
 
+use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\ScalarTypeDefinitionNode;
 use GraphQL\Language\AST\ScalarTypeExtensionNode;
 use GraphQL\Utils\Utils;
@@ -44,6 +45,8 @@ abstract class ScalarType extends Type implements OutputType, InputType, LeafTyp
     public array $config;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param ScalarConfig $config
      */
     public function __construct(array $config = [])

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -48,6 +48,8 @@ class UnionType extends Type implements AbstractType, OutputType, CompositeType,
     private array $possibleTypeNames;
 
     /**
+     * @throws InvariantViolation
+     *
      * @phpstan-param UnionConfig $config
      */
     public function __construct(array $config)


### PR DESCRIPTION
I started using this https://phpstan.org/blog/bring-your-exceptions-under-control and having `@throws` in the library is better for users since they can infer it and don't have to explicitly specify in their codebases.