### PR TITLE
Don't unnecessarily invoke type loader when printing schema

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -186,9 +186,12 @@ class SchemaPrinter
      */
     protected static function hasDefaultRootOperationTypes(Schema $schema): bool
     {
+        $mutationType = $schema->getMutationType();
+        $subscriptionType = $schema->getSubscriptionType();
+
         return $schema->getQueryType() === $schema->getType('Query')
-            && $schema->getMutationType() === $schema->getType('Mutation')
-            && $schema->getSubscriptionType() === $schema->getType('Subscription');
+            && ($mutationType !== null && $mutationType === $schema->getType('Mutation'))
+            && ($subscriptionType !== null && $subscriptionType === $schema->getType('Subscription'));
     }
 
     /**

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -66,6 +66,28 @@ final class SchemaPrinterTest extends TestCase
         );
     }
 
+    public function testPrintSchemaShouldNotInvokeTypeLoader(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'fields' => [
+                    'examplesCustom' => [
+                        'name' => 'examplesCustom',
+                        'type' => Type::boolean(),
+                    ],
+                ],
+                'name' => 'Query',
+            ]),
+            'typeLoader' => function ($name) {
+                throw new \RuntimeException("Not expected to resolve '{$name}'");
+            },
+        ]);
+
+        SchemaPrinter::doPrint($schema);
+    }
+
     /**
      * @see it('Prints [String] Field')
      */


### PR DESCRIPTION
## Summary
Before https://github.com/webonyx/graphql-php/pull/1303 , the type loader was not invoked when printing the schema and not mutation or subscription is defined.

This brings back the previous behaviour in this regard.

I'm not sure what is really wanted here, it was discovered as feedback in the preparation for graphql-laravel for the graphql-php v15 upgrade in https://github.com/rebing/graphql-laravel/pull/953#issuecomment-1449855145 and we added a test case which did not trigger the typeloader in v14 ( https://github.com/rebing/graphql-laravel/pull/995 , though at that point it wasn't yet clear what's going on).

It's not a big issue, but I figured I open the PR as discussion, if we really need to invoke the type loader if we already see that there's not such top level type defined.

The test is just quickly put together: if you change back to the code in master, the test throws an exception.

Let me know what you think, cheers.