### PR TITLE
QueryComplexity - Add success & failing test in combination with fragments #785

### DIFF
--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -59,6 +59,23 @@ final class QueryComplexityTest extends QuerySecurityTestCase
         $this->assertDocumentValidators($query, 2, 3);
     }
 
+    /**
+     * @dataProvider fragmentQueriesOnRootProvider
+     */
+    public function testFragmentQueriesOnRoot(string $query): void
+    {
+        $this->assertDocumentValidators($query, 12, 13);
+    }
+
+    /** @return array<int, array<string>> */
+    public function fragmentQueriesOnRootProvider(): array
+    {
+        return [
+            ['fragment humanFragment on QueryRoot { human { dogs { name } } } query { ...humanFragment }'], // success example
+            ['query { ...humanFragment } fragment humanFragment on QueryRoot { human { dogs { name } } }'], // failing example, changed order see https://github.com/webonyx/graphql-php/issues/785
+        ];
+    }
+
     public function testAliasesQueries(): void
     {
         $query = 'query MyQuery { thomas: human(name: "Thomas") { firstName } jeremy: human(name: "Jeremy") { firstName } }';


### PR DESCRIPTION
Adding a working & failing test case as suggested by @spawnia in https://github.com/webonyx/graphql-php/issues/785
First query works, the second changes the order and fails.