### PR TITLE
Initialize OperationDefinitionNode.variableDefinitions

### DIFF
--- a/src/Language/AST/OperationDefinitionNode.php
+++ b/src/Language/AST/OperationDefinitionNode.php
@@ -28,6 +28,7 @@ class OperationDefinitionNode extends Node implements ExecutableDefinitionNode, 
     {
         parent::__construct($vars);
         $this->directives ??= new NodeList([]);
+        $this->variableDefinitions ??= new NodeList([]);
     }
 
     public function getSelectionSet(): SelectionSetNode

--- a/tests/Utils/AstFromArrayTest.php
+++ b/tests/Utils/AstFromArrayTest.php
@@ -29,6 +29,7 @@ final class AstFromArrayTest extends TestCase
         ]);
         assert($res instanceof OperationDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
+        self::assertEquals($res->variableDefinitions, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'Field',
@@ -74,6 +75,7 @@ final class AstFromArrayTest extends TestCase
         ]);
         assert($res instanceof OperationDefinitionNode);
         self::assertEquals($res->directives, new NodeList([]));
+        self::assertEquals($res->variableDefinitions, new NodeList([]));
 
         $res = AST::fromArray([
             'kind' => 'Field',


### PR DESCRIPTION
Fixing one more case of uninitialized node list in OperationDefinitionNode.