### PR TITLE
Replace self:: with static:: in schema printer

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -174,7 +174,7 @@ class SchemaPrinter
         // TODO add condition for schema.description
         // Only print a schema definition if there is a description or if it should
         // not be omitted because of having default type names.
-        if (! self::hasDefaultRootOperationTypes($schema)) {
+        if (! static::hasDefaultRootOperationTypes($schema)) {
             return "schema {\n"
                 . ($queryType !== null ? "  query: {$queryType->name}\n" : '')
                 . ($mutationType !== null ? "  mutation: {$mutationType->name}\n" : '')
@@ -378,7 +378,7 @@ class SchemaPrinter
     {
         return static::printDescription($options, $type)
             . "type {$type->name}"
-            . self::printImplementedInterfaces($type)
+            . static::printImplementedInterfaces($type)
             . static::printFields($options, $type);
     }
 
@@ -420,7 +420,7 @@ class SchemaPrinter
             $previousHasDescription = $hasDescription;
         }
 
-        return self::printBlock($fields);
+        return static::printBlock($fields);
     }
 
     /**
@@ -477,7 +477,7 @@ class SchemaPrinter
     {
         return static::printDescription($options, $type)
             . "interface {$type->name}"
-            . self::printImplementedInterfaces($type)
+            . static::printImplementedInterfaces($type)
             . static::printFields($options, $type);
     }
 


### PR DESCRIPTION
The `SchemaPrinter` class uses static methods.

Those methods can be overloaded in a child class (they are protected). However, if we want the base `SchemaPrinter` static function to be able to call the overloaded functions in the child class, the call to these functions must be done using the `static::` keyword (Late static binding).

This is done properly almost everywhere in the code, but in some places there remains calls done using `self::`.

This commit turns the remaining `self::` into `static::` to make Late Static Binding possible.