### PR TITLE
Allow context to be scoped

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1515,6 +1515,13 @@ function createRejected(Throwable $reason): GraphQL\Executor\Promise\Promise
 function all(iterable $promisesOrValues): GraphQL\Executor\Promise\Promise
 ```
 
+## GraphQL\Executor\ScopedContext
+
+Can be used to make control how cloning of context is performed.
+
+This allows for making sure the changes to the context are only passed to subfields
+and not visible to parent fields.
+
 ## GraphQL\Validator\DocumentValidator
 
 Implements the "Validation" section of the spec.

--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -9,67 +9,6 @@ See [related documentation](executing-queries.md).
 
 ```php
 /**
- * Executes graphql query.
- *
- * More sophisticated GraphQL servers, such as those which persist queries,
- * may wish to separate the validation and execution phases to a static time
- * tooling step, and a server runtime step.
- *
- * Available options:
- *
- * schema:
- *    The GraphQL type system to use when validating and executing a query.
- * source:
- *    A GraphQL language formatted string representing the requested operation.
- * rootValue:
- *    The value provided as the first argument to resolver functions on the top
- *    level type (e.g. the query object type).
- * contextValue:
- *    The context value is provided as an argument to resolver functions after
- *    field arguments. It is used to pass shared information useful at any point
- *    during executing this query, for example the currently logged in user and
- *    connections to databases or other services.
- * variableValues:
- *    A mapping of variable name to runtime value to use for all variables
- *    defined in the requestString.
- * operationName:
- *    The name of the operation to use if requestString contains multiple
- *    possible operations. Can be omitted if requestString contains only
- *    one operation.
- * fieldResolver:
- *    A resolver function to use when one is not provided by the schema.
- *    If not provided, the default field resolver is used (which looks for a
- *    value on the source value with the field's name).
- * validationRules:
- *    A set of rules for query validation step. Default value is all available rules.
- *    Empty array would allow to skip query validation (may be convenient for persisted
- *    queries which are validated before persisting and assumed valid during execution)
- *
- * @param string|DocumentNode        $source
- * @param mixed                      $rootValue
- * @param mixed                      $contextValue
- * @param array<string, mixed>|null  $variableValues
- * @param array<ValidationRule>|null $validationRules
- *
- * @api
- *
- * @throws \Exception
- * @throws InvariantViolation
- */
-static function executeQuery(
-    GraphQL\Type\Schema $schema,
-    $source,
-    $rootValue = null,
-    $contextValue = null,
-    ?array $variableValues = null,
-    ?string $operationName = null,
-    ?callable $fieldResolver = null,
-    ?array $validationRules = null
-): GraphQL\Executor\ExecutionResult
-```
-
-```php
-/**
  * Same as executeQuery(), but requires PromiseAdapter and always returns a Promise.
  * Useful for Async PHP platforms.
  *
@@ -1514,13 +1453,6 @@ function createRejected(Throwable $reason): GraphQL\Executor\Promise\Promise
  */
 function all(iterable $promisesOrValues): GraphQL\Executor\Promise\Promise
 ```
-
-## GraphQL\Executor\ScopedContext
-
-Can be used to make control how cloning of context is performed.
-
-This allows for making sure the changes to the context are only passed to subfields
-and not visible to parent fields.
 
 ## GraphQL\Validator\DocumentValidator
 

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -294,8 +294,8 @@ class ReferenceExecutor implements ExecutorImplementation
         // Similar to completeValueCatchingError.
         try {
             $result = $operation->operation === 'mutation'
-                ? $this->executeFieldsSerially($type, $rootValue, $path, $fields)
-                : $this->executeFields($type, $rootValue, $path, $fields);
+                ? $this->executeFieldsSerially($type, $rootValue, $path, $fields, $this->exeContext->contextValue)
+                : $this->executeFields($type, $rootValue, $path, $fields, $this->exeContext->contextValue);
 
             $promise = $this->getPromise($result);
             if ($promise !== null) {
@@ -522,22 +522,23 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param mixed             $rootValue
      * @param array<string|int> $path
+     * @param mixed             $contextValue
      *
      * @phpstan-param Fields $fields
      *
      * @return array<mixed>|Promise|\stdClass
      */
-    protected function executeFieldsSerially(ObjectType $parentType, $rootValue, array $path, \ArrayObject $fields)
+    protected function executeFieldsSerially(ObjectType $parentType, $rootValue, array $path, \ArrayObject $fields, $contextValue)
     {
         $result = $this->promiseReduce(
             \array_keys($fields->getArrayCopy()),
-            function ($results, $responseName) use ($path, $parentType, $rootValue, $fields) {
+            function ($results, $responseName) use ($contextValue, $path, $parentType, $rootValue, $fields) {
                 $fieldNodes = $fields[$responseName];
                 assert($fieldNodes instanceof \ArrayObject, 'The keys of $fields populate $responseName');
 
                 $fieldPath = $path;
                 $fieldPath[] = $responseName;
-                $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath);
+                $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath, $contextValue);
                 if ($result === static::$UNDEFINED) {
                     return $results;
                 }
@@ -577,6 +578,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param mixed                       $rootValue
      * @param array<int, string|int>      $path
+     * @param mixed                       $contextValue
      *
      * @phpstan-param Path                $path
      *
@@ -587,7 +589,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @return array<mixed>|\Throwable|mixed|null
      */
-    protected function resolveField(ObjectType $parentType, $rootValue, \ArrayObject $fieldNodes, array $path)
+    protected function resolveField(ObjectType $parentType, $rootValue, \ArrayObject $fieldNodes, array $path, $contextValue)
     {
         $exeContext = $this->exeContext;
         $fieldNode = $fieldNodes[0];
@@ -631,7 +633,8 @@ class ReferenceExecutor implements ExecutorImplementation
             $fieldNode,
             $resolveFn,
             $rootValue,
-            $info
+            $info,
+            $contextValue
         );
 
         return $this->completeValueCatchingError(
@@ -639,7 +642,8 @@ class ReferenceExecutor implements ExecutorImplementation
             $fieldNodes,
             $info,
             $path,
-            $result
+            $result,
+            $contextValue
         );
     }
 
@@ -684,6 +688,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * Returns the result of resolveFn or the abrupt-return Error object.
      *
      * @param mixed $rootValue
+     * @param mixed $contextValue
      *
      * @phpstan-param FieldResolver $resolveFn
      *
@@ -694,7 +699,8 @@ class ReferenceExecutor implements ExecutorImplementation
         FieldNode $fieldNode,
         callable $resolveFn,
         $rootValue,
-        ResolveInfo $info
+        ResolveInfo $info,
+        $contextValue
     ) {
         try {
             // Build a map of arguments from the field.arguments AST, using the
@@ -704,7 +710,6 @@ class ReferenceExecutor implements ExecutorImplementation
                 $fieldNode,
                 $this->exeContext->variableValues
             );
-            $contextValue = $this->exeContext->contextValue;
 
             return $resolveFn($rootValue, $args, $contextValue, $info);
         } catch (\Throwable $error) {
@@ -718,6 +723,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
+     * @param mixed                       $contextValue
      *
      * @phpstan-param Path                $path
      *
@@ -732,18 +738,19 @@ class ReferenceExecutor implements ExecutorImplementation
         \ArrayObject $fieldNodes,
         ResolveInfo $info,
         array $path,
-        $result
+        $result,
+        $contextValue
     ) {
         // Otherwise, error protection is applied, logging the error and resolving
         // a null value for this field if one is encountered.
         try {
             $promise = $this->getPromise($result);
             if ($promise !== null) {
-                $completed = $promise->then(function (&$resolved) use ($returnType, $fieldNodes, $info, $path) {
-                    return $this->completeValue($returnType, $fieldNodes, $info, $path, $resolved);
+                $completed = $promise->then(function (&$resolved) use ($contextValue, $returnType, $fieldNodes, $info, $path) {
+                    return $this->completeValue($returnType, $fieldNodes, $info, $path, $resolved, $contextValue);
                 });
             } else {
-                $completed = $this->completeValue($returnType, $fieldNodes, $info, $path, $result);
+                $completed = $this->completeValue($returnType, $fieldNodes, $info, $path, $result, $contextValue);
             }
 
             $promise = $this->getPromise($completed);
@@ -811,6 +818,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
      * @param mixed                       $result
+     * @param mixed                       $contextValue
      *
      * @throws \Throwable
      * @throws Error
@@ -822,7 +830,8 @@ class ReferenceExecutor implements ExecutorImplementation
         \ArrayObject $fieldNodes,
         ResolveInfo $info,
         array $path,
-        &$result
+        &$result,
+        $contextValue
     ) {
         // If result is an Error, throw a located error.
         if ($result instanceof \Throwable) {
@@ -837,7 +846,8 @@ class ReferenceExecutor implements ExecutorImplementation
                 $fieldNodes,
                 $info,
                 $path,
-                $result
+                $result,
+                $contextValue
             );
             if ($completed === null) {
                 throw new InvariantViolation("Cannot return null for non-nullable field \"{$info->parentType}.{$info->fieldName}\".");
@@ -858,7 +868,7 @@ class ReferenceExecutor implements ExecutorImplementation
                 throw new InvariantViolation("Expected field {$info->parentType}.{$info->fieldName} to return iterable, but got: {$resultType}.");
             }
 
-            return $this->completeListValue($returnType, $fieldNodes, $info, $path, $result);
+            return $this->completeListValue($returnType, $fieldNodes, $info, $path, $result, $contextValue);
         }
 
         assert($returnType instanceof NamedType, 'Wrapping types should return early');
@@ -875,12 +885,12 @@ class ReferenceExecutor implements ExecutorImplementation
         }
 
         if ($returnType instanceof AbstractType) {
-            return $this->completeAbstractValue($returnType, $fieldNodes, $info, $path, $result);
+            return $this->completeAbstractValue($returnType, $fieldNodes, $info, $path, $result, $contextValue);
         }
 
         // Field type must be and Object, Interface or Union and expect sub-selections.
         if ($returnType instanceof ObjectType) {
-            return $this->completeObjectValue($returnType, $fieldNodes, $info, $path, $result);
+            return $this->completeObjectValue($returnType, $fieldNodes, $info, $path, $result, $contextValue);
         }
 
         $safeReturnType = Utils::printSafe($returnType);
@@ -949,6 +959,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param list<string|int> $path
      * @param iterable<mixed> $results
+     * @param mixed           $contextValue
      *
      * @throws Error
      *
@@ -959,7 +970,8 @@ class ReferenceExecutor implements ExecutorImplementation
         \ArrayObject $fieldNodes,
         ResolveInfo $info,
         array $path,
-        iterable &$results
+        iterable &$results,
+        $contextValue
     ) {
         $itemType = $returnType->getWrappedType();
 
@@ -970,7 +982,7 @@ class ReferenceExecutor implements ExecutorImplementation
             $fieldPath = [...$path, $i++];
             $info->path = $fieldPath;
 
-            $completedItem = $this->completeValueCatchingError($itemType, $fieldNodes, $info, $fieldPath, $item);
+            $completedItem = $this->completeValueCatchingError($itemType, $fieldNodes, $info, $fieldPath, $item, $contextValue);
 
             if (! $containsPromise && $this->getPromise($completedItem) !== null) {
                 $containsPromise = true;
@@ -1016,6 +1028,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int> $path
      * @param array<mixed> $result
+     * @param mixed $contextValue
      *
      * @throws \Exception
      * @throws Error
@@ -1028,13 +1041,14 @@ class ReferenceExecutor implements ExecutorImplementation
         \ArrayObject $fieldNodes,
         ResolveInfo $info,
         array $path,
-        &$result
+        &$result,
+        $contextValue
     ) {
         $exeContext = $this->exeContext;
-        $typeCandidate = $returnType->resolveType($result, $exeContext->contextValue, $info);
+        $typeCandidate = $returnType->resolveType($result, $contextValue, $info);
 
         if ($typeCandidate === null) {
-            $runtimeType = static::defaultTypeResolver($result, $exeContext->contextValue, $info, $returnType);
+            $runtimeType = static::defaultTypeResolver($result, $contextValue, $info, $returnType);
         } elseif (! \is_string($typeCandidate) && \is_callable($typeCandidate)) {
             $runtimeType = $typeCandidate();
         } else {
@@ -1053,7 +1067,8 @@ class ReferenceExecutor implements ExecutorImplementation
                 $fieldNodes,
                 $info,
                 $path,
-                $result
+                $result,
+                $contextValue
             ));
         }
 
@@ -1067,7 +1082,8 @@ class ReferenceExecutor implements ExecutorImplementation
             $fieldNodes,
             $info,
             $path,
-            $result
+            $result,
+            $contextValue
         );
     }
 
@@ -1143,6 +1159,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
      * @param mixed                       $result
+     * @param mixed                       $contextValue
      *
      * @throws \Exception
      * @throws Error
@@ -1154,16 +1171,18 @@ class ReferenceExecutor implements ExecutorImplementation
         \ArrayObject $fieldNodes,
         ResolveInfo $info,
         array $path,
-        &$result
+        &$result,
+        $contextValue
     ) {
         // If there is an isTypeOf predicate function, call it with the
         // current result. If isTypeOf returns false, then raise an error rather
         // than continuing execution.
-        $isTypeOf = $returnType->isTypeOf($result, $this->exeContext->contextValue, $info);
+        $isTypeOf = $returnType->isTypeOf($result, $contextValue, $info);
         if ($isTypeOf !== null) {
             $promise = $this->getPromise($isTypeOf);
             if ($promise !== null) {
                 return $promise->then(function ($isTypeOfResult) use (
+                    $contextValue,
                     $returnType,
                     $fieldNodes,
                     $path,
@@ -1177,7 +1196,8 @@ class ReferenceExecutor implements ExecutorImplementation
                         $returnType,
                         $fieldNodes,
                         $path,
-                        $result
+                        $result,
+                        $contextValue
                     );
                 });
             }
@@ -1192,7 +1212,8 @@ class ReferenceExecutor implements ExecutorImplementation
             $returnType,
             $fieldNodes,
             $path,
-            $result
+            $result,
+            $contextValue
         );
     }
 
@@ -1217,6 +1238,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param array<string|int>           $path
      * @param mixed                       $result
+     * @param mixed                       $contextValue
      *
      * @throws \Exception
      * @throws Error
@@ -1227,11 +1249,12 @@ class ReferenceExecutor implements ExecutorImplementation
         ObjectType $returnType,
         \ArrayObject $fieldNodes,
         array $path,
-        &$result
+        &$result,
+        $contextValue
     ) {
         $subFieldNodes = $this->collectSubFields($returnType, $fieldNodes);
 
-        return $this->executeFields($returnType, $result, $path, $subFieldNodes);
+        return $this->executeFields($returnType, $result, $path, $subFieldNodes, $contextValue);
     }
 
     /**
@@ -1276,6 +1299,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param mixed             $rootValue
      * @param array<string|int> $path
+     * @param mixed             $contextValue
      *
      * @phpstan-param Fields $fields
      *
@@ -1284,14 +1308,14 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @return Promise|\stdClass|array<mixed>
      */
-    protected function executeFields(ObjectType $parentType, $rootValue, array $path, \ArrayObject $fields)
+    protected function executeFields(ObjectType $parentType, $rootValue, array $path, \ArrayObject $fields, $contextValue)
     {
         $containsPromise = false;
         $results = [];
         foreach ($fields as $responseName => $fieldNodes) {
             $fieldPath = $path;
             $fieldPath[] = $responseName;
-            $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath);
+            $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath, $this->maybeScopeContext($contextValue));
             if ($result === static::$UNDEFINED) {
                 continue;
             }
@@ -1392,5 +1416,19 @@ class ReferenceExecutor implements ExecutorImplementation
         );
 
         return $runtimeType;
+    }
+
+    /**
+     * @param mixed $contextValue
+     *
+     * @return mixed
+     */
+    private function maybeScopeContext($contextValue)
+    {
+        if ($contextValue instanceof ScopedContext) {
+            return $contextValue->clone();
+        }
+
+        return $contextValue;
     }
 }

--- a/src/Executor/ScopedContext.php
+++ b/src/Executor/ScopedContext.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Executor;
+
+/**
+ * When the context implements `ScopedContext` the `clone()` method will be
+ * called before passing the context to the subfields. This allows passing
+ * information to subfields without affecting the parent fields.
+ */
+interface ScopedContext
+{
+    public function clone(): self;
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -49,6 +49,9 @@ class GraphQL
      *    field arguments. It is used to pass shared information useful at any point
      *    during executing this query, for example the currently logged in user and
      *    connections to databases or other services.
+     *    You can implement the `ScopedContext` interface on your custom context
+     *    object to make sure modifications of the context object are only available
+     *    to subfields without affecting the parent fields.
      * variableValues:
      *    A mapping of variable name to runtime value to use for all variables
      *    defined in the requestString.
@@ -71,10 +74,10 @@ class GraphQL
      * @param array<string, mixed>|null  $variableValues
      * @param array<ValidationRule>|null $validationRules
      *
-     * @api
-     *
      * @throws \Exception
      * @throws InvariantViolation
+     *@api
+     *
      */
     public static function executeQuery(
         SchemaType $schema,

--- a/tests/Executor/ScopedContextTest.php
+++ b/tests/Executor/ScopedContextTest.php
@@ -1,0 +1,290 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Executor;
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use GraphQL\Executor\Executor;
+use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
+use GraphQL\Language\Parser;
+use GraphQL\Tests\Executor\TestClasses\MyScopedContext;
+use GraphQL\Tests\Executor\TestClasses\MySharedContext;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use PHPUnit\Framework\TestCase;
+
+final class ScopedContextTest extends TestCase
+{
+    use ArraySubsetAsserts;
+
+    private Schema $schema;
+
+    private SyncPromiseAdapter $promiseAdapter;
+
+    /** @var array<string, MyScopedContext|MySharedContext> */
+    private array $contexts = [];
+
+    public function setUp(): void
+    {
+        $this->contexts = [];
+
+        $b = new ObjectType([
+            'name' => 'b',
+            'fields' => [
+                'c' => [
+                    'type' => Type::string(),
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'c';
+                        $this->contexts['c'] = $context;
+
+                        return implode('.', $context->path);
+                    },
+                ],
+            ],
+        ]);
+
+        $e = new ObjectType([
+            'name' => 'e',
+            'fields' => [
+                'f' => [
+                    'type' => Type::string(),
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'f';
+                        $this->contexts['f'] = $context;
+
+                        return implode('.', $context->path);
+                    },
+                ],
+            ],
+        ]);
+
+        $d = new ObjectType([
+            'name' => 'd',
+            'fields' => [
+                'e' => [
+                    'type' => $e,
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'e';
+                        $this->contexts['e'] = $context;
+
+                        return $rootValue;
+                    },
+                ],
+            ],
+        ]);
+
+        $a = new ObjectType([
+            'name' => 'a',
+            'fields' => [
+                'b' => [
+                    'type' => $b,
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'b';
+                        $this->contexts['b'] = $context;
+
+                        return $rootValue;
+                    },
+                ],
+                'd' => [
+                    'type' => $d,
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'd';
+                        $this->contexts['d'] = $context;
+
+                        return $rootValue;
+                    },
+                ],
+            ],
+        ]);
+
+        $h = new ObjectType([
+            'name' => 'h',
+            'fields' => [
+                'i' => [
+                    'type' => Type::string(),
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'i';
+                        $this->contexts['i'] = $context;
+
+                        return implode('.', $context->path);
+                    },
+                ],
+            ],
+        ]);
+
+        $g = new ObjectType([
+            'name' => 'g',
+            'fields' => [
+                'h' => [
+                    'type' => $h,
+                    'resolve' => function ($rootValue, $args, $context) {
+                        $context->path[] = 'h';
+                        $this->contexts['h'] = $context;
+
+                        return $rootValue;
+                    },
+                ],
+            ],
+        ]);
+
+        $this->schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'a' => [
+                        'type' => $a,
+                        'resolve' => function ($rootValue, $args, $context) {
+                            $context->path[] = 'a';
+                            $this->contexts['a'] = $context;
+
+                            return $rootValue;
+                        },
+                    ],
+                    'g' => [
+                        'type' => $g,
+                        'resolve' => function ($rootValue, $args, $context) {
+                            $context->path[] = 'g';
+                            $this->contexts['g'] = $context;
+
+                            return $rootValue;
+                        },
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->promiseAdapter = new SyncPromiseAdapter();
+    }
+
+    public function testContextShouldBeScopedBeforePassingToChildren(): void
+    {
+        $context = new MyScopedContext();
+
+        $doc = <<<'GRAPHQL'
+            query { 
+              a {
+                b {
+                  c
+                }
+                d {
+                  e {
+                    f
+                  }
+                }
+              }
+              g {
+                h {
+                  i
+                }
+              }
+            }
+            GRAPHQL;
+
+        $result = Executor::promiseToExecute(
+            $this->promiseAdapter,
+            $this->schema,
+            Parser::parse($doc),
+            'rootValue',
+            $context,
+            [],
+            null,
+            null
+        );
+
+        $result = $this->promiseAdapter->wait($result);
+
+        self::assertSame([], $context->path);
+        self::assertSame(['a'], $this->contexts['a']->path);
+        self::assertSame(['a', 'b'], $this->contexts['b']->path);
+        self::assertSame(['a', 'b', 'c'], $this->contexts['c']->path);
+        self::assertSame(['a', 'd'], $this->contexts['d']->path);
+        self::assertSame(['a', 'd', 'e'], $this->contexts['e']->path);
+        self::assertSame(['a', 'd', 'e', 'f'], $this->contexts['f']->path);
+        self::assertSame(['g'], $this->contexts['g']->path);
+        self::assertSame(['g', 'h'], $this->contexts['h']->path);
+        self::assertSame(['g', 'h', 'i'], $this->contexts['i']->path);
+        self::assertSame([
+            'a' => [
+                'b' => [
+                    'c' => 'a.b.c',
+                ],
+                'd' => [
+                    'e' => [
+                        'f' => 'a.d.e.f',
+                    ],
+                ],
+            ],
+            'g' => [
+                'h' => [
+                    'i' => 'g.h.i',
+                ],
+            ],
+        ], $result->data);
+    }
+
+    public function testContextShouldNotBeScoped(): void
+    {
+        $context = new MySharedContext();
+
+        $doc = <<<'GRAPHQL'
+            query { 
+              a {
+                b {
+                  c
+                }
+                d {
+                  e {
+                    f
+                  }
+                }
+              }
+              g {
+                h {
+                  i
+                }
+              }
+            }
+            GRAPHQL;
+
+        $result = Executor::promiseToExecute(
+            $this->promiseAdapter,
+            $this->schema,
+            Parser::parse($doc),
+            'rootValue',
+            $context,
+            [],
+            null,
+            null
+        );
+
+        $result = $this->promiseAdapter->wait($result);
+
+        self::assertSame(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], $context->path);
+        self::assertSame($context, $this->contexts['a']);
+        self::assertSame($context, $this->contexts['b']);
+        self::assertSame($context, $this->contexts['c']);
+        self::assertSame($context, $this->contexts['d']);
+        self::assertSame($context, $this->contexts['e']);
+        self::assertSame($context, $this->contexts['f']);
+        self::assertSame($context, $this->contexts['g']);
+        self::assertSame($context, $this->contexts['h']);
+        self::assertSame($context, $this->contexts['i']);
+        self::assertSame([
+            'a' => [
+                'b' => [
+                    'c' => 'a.b.c',
+                ],
+                'd' => [
+                    'e' => [
+                        'f' => 'a.b.c.d.e.f',
+                    ],
+                ],
+            ],
+            'g' => [
+                'h' => [
+                    'i' => 'a.b.c.d.e.f.g.h.i',
+                ],
+            ],
+        ], $result->data);
+    }
+}

--- a/tests/Executor/TestClasses/MyScopedContext.php
+++ b/tests/Executor/TestClasses/MyScopedContext.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Executor\TestClasses;
+
+use GraphQL\Executor\ScopedContext;
+
+final class MyScopedContext implements ScopedContext
+{
+    /** @var list<string> */
+    public array $path = [];
+
+    public function clone(): ScopedContext
+    {
+        return clone $this;
+    }
+}

--- a/tests/Executor/TestClasses/MySharedContext.php
+++ b/tests/Executor/TestClasses/MySharedContext.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Executor\TestClasses;
+
+final class MySharedContext
+{
+    /** @var list<string> */
+    public array $path = [];
+}


### PR DESCRIPTION
By implementing the `ScopedContext` interface on your context object, you can ensure that
scope is only passed downwards and not shared with other fields.

Example:
```graphql
query {
  a {
    b {
      c
    }
    d {
      e {
        f
      }
    }
  }
  g {
    h {
      i
    }
  }
}
```

In the above situation, the following will happen:
* `a` receives the cloned context from the executor
* `b` receives the cloned context from `a`
* `c` receives the cloned context from `b`
* `d` receives the cloned context from `a`
* `e` receives the cloned context from `d`
* `f` receives the cloned context from `e`
* `g` receives the cloned context from the executor
* `h` receives the cloned context from `g`
* `i` receives the cloned context from `h`

References:
- https://github.com/graphql/graphql-js/issues/2692
- https://github.com/rmosolgo/graphql-ruby/pull/2634