### PR TITLE
Allow disabling short form query in Printer

### DIFF
--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -62,6 +62,8 @@ use GraphQL\Language\AST\VariableNode;
  */
 class Printer
 {
+    private bool $useShortFormQueryWhenPossible;
+
     /**
      * Converts the AST of a GraphQL node to a string.
      *
@@ -72,12 +74,15 @@ class Printer
     public static function doPrint(Node $ast): string
     {
         static $instance;
-        $instance ??= new static();
+        $instance ??= new static(true);
 
         return $instance->printAST($ast);
     }
 
-    protected function __construct() {}
+    public function __construct(bool $useShortFormQueryWhenPossible)
+    {
+        $this->useShortFormQueryWhenPossible = $useShortFormQueryWhenPossible;
+    }
 
     /**
      * Recursively traverse an AST depth-first and produce a pretty string.
@@ -368,7 +373,7 @@ class Printer
 
                 // Anonymous queries with no directives or variable definitions can use
                 // the query short form.
-                return $name === '' && $directives === '' && $varDefs === '' && $op === 'query'
+                return $this->useShortFormQueryWhenPossible && $name === '' && $directives === '' && $varDefs === '' && $op === 'query'
                     ? $selectionSet
                     : $this->join([$op, $this->join([$name, $varDefs]), $directives, $selectionSet], ' ');
 

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -292,7 +292,7 @@ GRAPHQL, Printer::doPrint($ast));
         self::assertASTMatches('3.14', AST::astFromValue(3.14, Type::float()));
     }
 
-    public function testPrintwithoutShortFormQuery() : void
+    public function testPrintwithoutShortFormQuery(): void
     {
         $printer = new Printer(false);
         $queryAstShorthanded = Parser::parse('query { id, name }');
@@ -307,6 +307,5 @@ GRAPHQL, Printer::doPrint($ast));
       GRAPHQL,
             $printer->printAST($queryAstShorthanded)
         );
-
     }
 }

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -291,4 +291,22 @@ GRAPHQL, Printer::doPrint($ast));
         self::assertASTMatches('3', AST::astFromValue(3, Type::int()));
         self::assertASTMatches('3.14', AST::astFromValue(3.14, Type::float()));
     }
+
+    public function testPrintwithoutShortFormQuery() : void
+    {
+        $printer = new Printer(false);
+        $queryAstShorthanded = Parser::parse('query { id, name }');
+
+        self::assertSame(
+            <<<'GRAPHQL'
+      query {
+        id
+        name
+      }
+
+      GRAPHQL,
+            $printer->printAST($queryAstShorthanded)
+        );
+
+    }
 }


### PR DESCRIPTION
When using the Printer to tidy/reformat GraphQL operations, I noticed that it would always choose the short form. In our company, we'd like to be explicit, and always define the type of the operation.

Therefore I want to be able to turn this off.
