### PR TITLE
Also set queryId from sha256 hash if query is provided

### DIFF
--- a/src/Server/OperationParams.php
+++ b/src/Server/OperationParams.php
@@ -117,7 +117,6 @@ class OperationParams
         // Apollo server/client compatibility
         if (
             isset($instance->extensions['persistedQuery']['sha256Hash'])
-            && $instance->query === null
             && $instance->queryId === null
         ) {
             $instance->queryId = $instance->extensions['persistedQuery']['sha256Hash'];

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -374,6 +374,31 @@ final class RequestParsingTest extends TestCase
         }
     }
 
+    public function testParsesApolloPersistedQueryJSONRequestIncludingQuery(): void
+    {
+        $query = '{my query}';
+        $queryId = 'my-query-id';
+        $extensions = ['persistedQuery' => ['sha256Hash' => $queryId]];
+        $variables = ['test' => 1, 'test2' => 2];
+        $operation = 'op';
+
+        $body = [
+            'query' => '{my query}',
+            'extensions' => $extensions,
+            'variables' => $variables,
+            'operationName' => $operation,
+        ];
+        $parsed = [
+            'raw' => $this->parseRawRequest('application/json', json_encode($body, JSON_THROW_ON_ERROR)),
+            'psr' => $this->parsePsrRequest('application/json', json_encode($body, JSON_THROW_ON_ERROR)),
+        ];
+        foreach ($parsed as $method => $parsedBody) {
+            self::assertInstanceOf(OperationParams::class, $parsedBody);
+            self::assertValidOperationParams($parsedBody, $query, $queryId, $variables, $operation, $extensions, $method);
+            self::assertFalse($parsedBody->readOnly, $method);
+        }
+    }
+
     public function testParsesBatchJSONRequest(): void
     {
         $body = [


### PR DESCRIPTION
This is necessary to support automatic persisted queries (https://www.apollographql.com/docs/apollo-server/performance/apq/) in the way outlined by #1372. Without this fix, the Apollo-style automatic query hash is not converted to a query id when a query is also present. This means the persistedQueryLoader is still not called to allow saving the query, even after the fix from #1372.