### PR TITLE
Do not set raw vars on query complexity rule if no validation rules are used

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -136,7 +136,7 @@ class GraphQL
                 ? $source
                 : Parser::parse(new Source($source, 'GraphQL'));
 
-            if ($validationRules === null || $validationRules === []) {
+            if ($validationRules === null) {
                 $queryComplexity = DocumentValidator::getRule(QueryComplexity::class);
                 assert($queryComplexity instanceof QueryComplexity, 'should not register a different rule for QueryComplexity');
 


### PR DESCRIPTION
If an empty array of validation rules is passed, no validations will be performed. It seems unnecessary to set the raw variable values on the query complexity rule in such a case.

In these situations, this change saves the unnecessary overhead from DocumentValidator::getRule(), which internally instantiates all rules through DocumentValidator::allRules().