### PR TITLE
Introduce StandardTypeRegistry

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -172,6 +172,8 @@ Registry of standard GraphQL types and base class for all other types.
 
 ```php
 /**
+ * @deprecated use the `typeRegistry` on the `Schema` instead
+ *
  * @api
  *
  * @throws InvariantViolation
@@ -181,6 +183,8 @@ static function int(): GraphQL\Type\Definition\ScalarType
 
 ```php
 /**
+ * @deprecated use the `typeRegistry` on the `Schema` instead
+ *
  * @api
  *
  * @throws InvariantViolation
@@ -190,6 +194,8 @@ static function float(): GraphQL\Type\Definition\ScalarType
 
 ```php
 /**
+ * @deprecated use the `typeRegistry` on the `Schema` instead
+ *
  * @api
  *
  * @throws InvariantViolation
@@ -199,6 +205,8 @@ static function string(): GraphQL\Type\Definition\ScalarType
 
 ```php
 /**
+ * @deprecated use the `typeRegistry` on the `Schema` instead
+ *
  * @api
  *
  * @throws InvariantViolation
@@ -208,6 +216,8 @@ static function boolean(): GraphQL\Type\Definition\ScalarType
 
 ```php
 /**
+ * @deprecated use the `typeRegistry` on the `Schema` instead
+ *
  * @api
  *
  * @throws InvariantViolation
@@ -548,7 +558,7 @@ typeLoader?: TypeLoader|null,
 assumeValid?: bool|null,
 astNode?: SchemaDefinitionNode|null,
 extensionASTNodes?: array<SchemaExtensionNode>|null,
-typeRegistry?: StandardTypeRegistry|null,
+typeRegistry?: null|(StandardTypeRegistry&BuiltInDirectiveRegistry),
 }
 
 ### GraphQL\Type\SchemaConfig Methods
@@ -2419,6 +2429,7 @@ assumeValidSDL?: bool
  * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
  *
  * @param array<string, bool> $options
+ * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
  *
  * @phpstan-param BuildSchemaOptions $options
  *
@@ -2434,7 +2445,7 @@ static function build(
     $source,
     ?callable $typeConfigDecorator = null,
     array $options = [],
-    ?GraphQL\Type\Registry\StandardTypeRegistry $typeRegistry = null
+    $typeRegistry = null
 ): GraphQL\Type\Schema
 ```
 
@@ -2450,6 +2461,7 @@ static function build(
  * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
  *
  * @param array<string, bool> $options
+ * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
  *
  * @phpstan-param BuildSchemaOptions $options
  *
@@ -2464,7 +2476,7 @@ static function buildAST(
     GraphQL\Language\AST\DocumentNode $ast,
     ?callable $typeConfigDecorator = null,
     array $options = [],
-    ?GraphQL\Type\Registry\StandardTypeRegistry $typeRegistry = null
+    $typeRegistry = null
 ): GraphQL\Type\Schema
 ```
 

--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -548,6 +548,7 @@ typeLoader?: TypeLoader|null,
 assumeValid?: bool|null,
 astNode?: SchemaDefinitionNode|null,
 extensionASTNodes?: array<SchemaExtensionNode>|null,
+typeRegistry?: StandardTypeRegistry|null,
 }
 
 ### GraphQL\Type\SchemaConfig Methods
@@ -2429,7 +2430,12 @@ assumeValidSDL?: bool
  * @throws InvariantViolation
  * @throws SyntaxError
  */
-static function build($source, ?callable $typeConfigDecorator = null, array $options = []): GraphQL\Type\Schema
+static function build(
+    $source,
+    ?callable $typeConfigDecorator = null,
+    array $options = [],
+    ?GraphQL\Type\Registry\StandardTypeRegistry $typeRegistry = null
+): GraphQL\Type\Schema
 ```
 
 ```php
@@ -2457,7 +2463,8 @@ static function build($source, ?callable $typeConfigDecorator = null, array $opt
 static function buildAST(
     GraphQL\Language\AST\DocumentNode $ast,
     ?callable $typeConfigDecorator = null,
-    array $options = []
+    array $options = [],
+    ?GraphQL\Type\Registry\StandardTypeRegistry $typeRegistry = null
 ): GraphQL\Type\Schema
 ```
 

--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -2445,7 +2445,8 @@ static function build(
     $source,
     ?callable $typeConfigDecorator = null,
     array $options = [],
-    $typeRegistry = null
+    $typeRegistry = null,
+    ?GraphQL\Type\Introspection $introspection = null
 ): GraphQL\Type\Schema
 ```
 
@@ -2476,7 +2477,8 @@ static function buildAST(
     GraphQL\Language\AST\DocumentNode $ast,
     ?callable $typeConfigDecorator = null,
     array $options = [],
-    $typeRegistry = null
+    $typeRegistry = null,
+    ?GraphQL\Type\Introspection $introspection = null
 ): GraphQL\Type\Schema
 ```
 

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -17,7 +17,6 @@ use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionNode;
 use GraphQL\Language\AST\SelectionSetNode;
 use GraphQL\Type\Definition\AbstractType;
-use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\LeafType;
@@ -467,7 +466,7 @@ class ReferenceExecutor implements ExecutorImplementation
         $variableValues = $this->exeContext->variableValues;
 
         $skip = Values::getDirectiveValues(
-            Directive::skipDirective(),
+            $this->exeContext->schema->typeRegistry->skipDirective(),
             $node,
             $variableValues
         );
@@ -476,7 +475,7 @@ class ReferenceExecutor implements ExecutorImplementation
         }
 
         $include = Values::getDirectiveValues(
-            Directive::includeDirective(),
+            $this->exeContext->schema->typeRegistry->includeDirective(),
             $node,
             $variableValues
         );
@@ -661,23 +660,20 @@ class ReferenceExecutor implements ExecutorImplementation
      */
     protected function getFieldDef(Schema $schema, ObjectType $parentType, string $fieldName): ?FieldDefinition
     {
-        static $schemaMetaFieldDef, $typeMetaFieldDef, $typeNameMetaFieldDef;
-        $schemaMetaFieldDef ??= Introspection::schemaMetaFieldDef();
-        $typeMetaFieldDef ??= Introspection::typeMetaFieldDef();
-        $typeNameMetaFieldDef ??= Introspection::typeNameMetaFieldDef();
-
         $queryType = $schema->getQueryType();
-
-        if ($fieldName === $schemaMetaFieldDef->name && $queryType === $parentType) {
-            return $schemaMetaFieldDef;
+        $schemaMeta = $schema->typeRegistry->introspection()->schemaMetaFieldDef();
+        if ($fieldName === $schemaMeta->name && $queryType === $parentType) {
+            return $schemaMeta;
         }
 
-        if ($fieldName === $typeMetaFieldDef->name && $queryType === $parentType) {
-            return $typeMetaFieldDef;
+        $typeMeta = $schema->typeRegistry->introspection()->typeMetaFieldDef();
+        if ($fieldName === $typeMeta->name && $queryType === $parentType) {
+            return $typeMeta;
         }
 
-        if ($fieldName === $typeNameMetaFieldDef->name) {
-            return $typeNameMetaFieldDef;
+        $typeNameMeta = $schema->typeRegistry->introspection()->typeNameMetaFieldDef();
+        if ($fieldName === $typeNameMeta->name) {
+            return $typeNameMeta;
         }
 
         return $parentType->findField($fieldName);

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -661,17 +661,17 @@ class ReferenceExecutor implements ExecutorImplementation
     protected function getFieldDef(Schema $schema, ObjectType $parentType, string $fieldName): ?FieldDefinition
     {
         $queryType = $schema->getQueryType();
-        $schemaMeta = $schema->typeRegistry->introspection()->schemaMetaFieldDef();
+        $schemaMeta = $schema->introspection->schemaMetaFieldDef();
         if ($fieldName === $schemaMeta->name && $queryType === $parentType) {
             return $schemaMeta;
         }
 
-        $typeMeta = $schema->typeRegistry->introspection()->typeMetaFieldDef();
+        $typeMeta = $schema->introspection->typeMetaFieldDef();
         if ($fieldName === $typeMeta->name && $queryType === $parentType) {
             return $typeMeta;
         }
 
-        $typeNameMeta = $schema->typeRegistry->introspection()->typeNameMetaFieldDef();
+        $typeNameMeta = $schema->introspection->typeNameMetaFieldDef();
         if ($fieldName === $typeNameMeta->name) {
             return $typeNameMeta;
         }

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -32,6 +32,8 @@ abstract class Type implements \JsonSerializable
     ];
 
     /**
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @api
      *
      * @throws InvariantViolation
@@ -42,6 +44,8 @@ abstract class Type implements \JsonSerializable
     }
 
     /**
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @api
      *
      * @throws InvariantViolation
@@ -52,6 +56,8 @@ abstract class Type implements \JsonSerializable
     }
 
     /**
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @api
      *
      * @throws InvariantViolation
@@ -62,6 +68,8 @@ abstract class Type implements \JsonSerializable
     }
 
     /**
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @api
      *
      * @throws InvariantViolation
@@ -72,6 +80,8 @@ abstract class Type implements \JsonSerializable
     }
 
     /**
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @api
      *
      * @throws InvariantViolation
@@ -108,6 +118,8 @@ abstract class Type implements \JsonSerializable
     /**
      * Returns all builtin scalar types.
      *
+     * @deprecated use the `typeRegistry` on the `Schema` instead
+     *
      * @throws InvariantViolation
      *
      * @return array<string, ScalarType>
@@ -118,7 +130,7 @@ abstract class Type implements \JsonSerializable
     }
 
     /**
-     * @deprecated use a custom instance of `DefaultStandardTypeRegistry` on the `Schema` instead
+     * @deprecated use the `typeRegistry` on the `Schema` instead
      *
      * @param array<ScalarType> $types
      *

--- a/src/Type/Registry/BuiltInDirectiveRegistry.php
+++ b/src/Type/Registry/BuiltInDirectiveRegistry.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Type\Registry;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\Directive;
+
+interface BuiltInDirectiveRegistry
+{
+    /** @throws InvariantViolation */
+    public function deprecatedDirective(): Directive;
+
+    /** @throws InvariantViolation */
+    public function includeDirective(): Directive;
+
+    /** @throws InvariantViolation */
+    public function skipDirective(): Directive;
+
+    /**
+     * @throws InvariantViolation
+     *
+     * @return array<string, Directive>
+     */
+    public function internalDirectives(): array;
+}

--- a/src/Type/Registry/DefaultStandardTypeRegistry.php
+++ b/src/Type/Registry/DefaultStandardTypeRegistry.php
@@ -74,7 +74,7 @@ class DefaultStandardTypeRegistry implements StandardTypeRegistry
      *
      * @return T|callable():T
      */
-    private function objectOrLazyInitialize($objectOrClassName)
+    protected function objectOrLazyInitialize($objectOrClassName)
     {
         return is_object($objectOrClassName) ? $objectOrClassName : fn () => new $objectOrClassName();
     }

--- a/src/Type/Registry/DefaultStandardTypeRegistry.php
+++ b/src/Type/Registry/DefaultStandardTypeRegistry.php
@@ -12,7 +12,6 @@ use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Introspection;
 
 /**
  * A default implementation of the type registry.
@@ -40,8 +39,6 @@ class DefaultStandardTypeRegistry implements StandardTypeRegistry, BuiltInDirect
     /** @var array<string, Directive> */
     protected array $directives = [];
 
-    protected Introspection $introspection;
-
     /**
      * @param ScalarType|class-string<ScalarType> $intType
      * @param ScalarType|class-string<ScalarType> $floatType
@@ -63,8 +60,6 @@ class DefaultStandardTypeRegistry implements StandardTypeRegistry, BuiltInDirect
             Type::BOOLEAN => $this->objectOrLazyInitialize($booleanType),
             Type::ID => $this->objectOrLazyInitialize($idType),
         ];
-
-        $this->introspection = new Introspection($this);
     }
 
     /**
@@ -227,10 +222,5 @@ class DefaultStandardTypeRegistry implements StandardTypeRegistry, BuiltInDirect
                 ],
             ],
         ]);
-    }
-
-    public function introspection(): Introspection
-    {
-        return $this->introspection;
     }
 }

--- a/src/Type/Registry/DefaultStandardTypeRegistry.php
+++ b/src/Type/Registry/DefaultStandardTypeRegistry.php
@@ -22,7 +22,7 @@ use GraphQL\Type\Introspection;
  * When a type by class is requested, it will return a callable that will instantiate the type on first call.
  * On subsequent calls, it will return the same instance immediately.
  */
-class DefaultStandardTypeRegistry implements StandardTypeRegistry
+class DefaultStandardTypeRegistry implements StandardTypeRegistry, BuiltInDirectiveRegistry
 {
     private static self $instance;
 

--- a/src/Type/Registry/DefaultStandardTypeRegistry.php
+++ b/src/Type/Registry/DefaultStandardTypeRegistry.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Type\Registry;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\DirectiveLocation;
+use GraphQL\Type\Definition\BooleanType;
+use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Definition\FloatType;
+use GraphQL\Type\Definition\IDType;
+use GraphQL\Type\Definition\IntType;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\StringType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Introspection;
+
+/**
+ * A default implementation of the type registry.
+ *
+ * It will return the standard types by default, but can be initialized with custom types.
+ *
+ * When a type by class is requested, it will return a callable that will instantiate the type on first call.
+ * On subsequent calls, it will return the same instance immediately.
+ */
+class DefaultStandardTypeRegistry implements StandardTypeRegistry
+{
+    private static self $instance;
+
+    /**
+     * @var array{
+     *   Int: (ScalarType|callable(): ScalarType),
+     *   Float: (ScalarType|callable(): ScalarType),
+     *   String: (ScalarType|callable(): ScalarType),
+     *   Boolean: (ScalarType|callable(): ScalarType),
+     *   ID: (ScalarType|callable(): ScalarType),
+     * }
+     */
+    protected array $standardTypes;
+
+    /** @var array<string, Directive> */
+    protected array $directives = [];
+
+    protected Introspection $introspection;
+
+    /**
+     * @param ScalarType|class-string<ScalarType> $intType
+     * @param ScalarType|class-string<ScalarType> $floatType
+     * @param ScalarType|class-string<ScalarType> $stringType
+     * @param ScalarType|class-string<ScalarType> $booleanType
+     * @param ScalarType|class-string<ScalarType> $idType
+     */
+    public function __construct(
+        $intType = IntType::class,
+        $floatType = FloatType::class,
+        $stringType = StringType::class,
+        $booleanType = BooleanType::class,
+        $idType = IDType::class
+    ) {
+        $this->standardTypes = [
+            Type::INT => $this->objectOrLazyInitialize($intType),
+            Type::FLOAT => $this->objectOrLazyInitialize($floatType),
+            Type::STRING => $this->objectOrLazyInitialize($stringType),
+            Type::BOOLEAN => $this->objectOrLazyInitialize($booleanType),
+            Type::ID => $this->objectOrLazyInitialize($idType),
+        ];
+
+        $this->introspection = new Introspection($this);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param T|class-string<T> $objectOrClassName
+     *
+     * @return T|callable():T
+     */
+    private function objectOrLazyInitialize($objectOrClassName)
+    {
+        return is_object($objectOrClassName) ? $objectOrClassName : fn () => new $objectOrClassName();
+    }
+
+    /** Returns a singleton instance of itself. */
+    public static function instance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    /**
+     * Register a default instance of the type registry.
+     *
+     * When using multiple schemas, you should pass a type registry to the schema constructor instead.
+     */
+    public static function register(self $typeRegistry): void
+    {
+        self::$instance = $typeRegistry;
+    }
+
+    public function standardType(string $name): ScalarType
+    {
+        $type = $this->standardTypes[$name];
+        if (is_callable($type)) {
+            return $this->standardTypes[$name] = $type();
+        }
+
+        return $type;
+    }
+
+    /** @throws InvariantViolation */
+    public function int(): ScalarType
+    {
+        return $this->standardType(Type::INT);
+    }
+
+    /** @throws InvariantViolation */
+    public function float(): ScalarType
+    {
+        return $this->standardType(Type::FLOAT);
+    }
+
+    /** @throws InvariantViolation */
+    public function string(): ScalarType
+    {
+        return $this->standardType(Type::STRING);
+    }
+
+    /** @throws InvariantViolation */
+    public function boolean(): ScalarType
+    {
+        return $this->standardType(Type::BOOLEAN);
+    }
+
+    /** @throws InvariantViolation */
+    public function id(): ScalarType
+    {
+        return $this->standardType(Type::ID);
+    }
+
+    /**
+     * Returns all builtin scalar types.
+     *
+     * @throws InvariantViolation
+     *
+     * @return array<string, ScalarType>
+     */
+    public function standardTypes(): array
+    {
+        return [
+            Type::INT => $this->int(),
+            Type::FLOAT => $this->float(),
+            Type::STRING => $this->string(),
+            Type::BOOLEAN => $this->boolean(),
+            Type::ID => $this->id(),
+        ];
+    }
+
+    /**
+     * @throws InvariantViolation
+     *
+     * @return array<string, Directive>
+     */
+    public function internalDirectives(): array
+    {
+        return [
+            Directive::INCLUDE_NAME => $this->includeDirective(),
+            Directive::SKIP_NAME => $this->skipDirective(),
+            Directive::DEPRECATED_NAME => $this->deprecatedDirective(),
+        ];
+    }
+
+    /** @throws InvariantViolation */
+    public function includeDirective(): Directive
+    {
+        return $this->directives[Directive::INCLUDE_NAME] ??= new Directive([
+            'name' => Directive::INCLUDE_NAME,
+            'description' => 'Directs the executor to include this field or fragment only when the `if` argument is true.',
+            'locations' => [
+                DirectiveLocation::FIELD,
+                DirectiveLocation::FRAGMENT_SPREAD,
+                DirectiveLocation::INLINE_FRAGMENT,
+            ],
+            'args' => [
+                Directive::IF_ARGUMENT_NAME => [
+                    'type' => Type::nonNull($this->boolean()),
+                    'description' => 'Included when true.',
+                ],
+            ],
+        ]);
+    }
+
+    /** @throws InvariantViolation */
+    public function skipDirective(): Directive
+    {
+        return $this->directives[Directive::SKIP_NAME] ??= new Directive([
+            'name' => Directive::SKIP_NAME,
+            'description' => 'Directs the executor to skip this field or fragment when the `if` argument is true.',
+            'locations' => [
+                DirectiveLocation::FIELD,
+                DirectiveLocation::FRAGMENT_SPREAD,
+                DirectiveLocation::INLINE_FRAGMENT,
+            ],
+            'args' => [
+                Directive::IF_ARGUMENT_NAME => [
+                    'type' => Type::nonNull($this->boolean()),
+                    'description' => 'Skipped when true.',
+                ],
+            ],
+        ]);
+    }
+
+    /** @throws InvariantViolation */
+    public function deprecatedDirective(): Directive
+    {
+        return $this->directives[Directive::DEPRECATED_NAME] ??= new Directive([
+            'name' => Directive::DEPRECATED_NAME,
+            'description' => 'Marks an element of a GraphQL schema as no longer supported.',
+            'locations' => [
+                DirectiveLocation::FIELD_DEFINITION,
+                DirectiveLocation::ENUM_VALUE,
+                DirectiveLocation::ARGUMENT_DEFINITION,
+                DirectiveLocation::INPUT_FIELD_DEFINITION,
+            ],
+            'args' => [
+                Directive::REASON_ARGUMENT_NAME => [
+                    'type' => $this->string(),
+                    'description' => 'Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).',
+                    'defaultValue' => Directive::DEFAULT_DEPRECATION_REASON,
+                ],
+            ],
+        ]);
+    }
+
+    public function introspection(): Introspection
+    {
+        return $this->introspection;
+    }
+}

--- a/src/Type/Registry/StandardTypeRegistry.php
+++ b/src/Type/Registry/StandardTypeRegistry.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Type\Registry;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Introspection;
+
+/**
+ * A registry that returns standard types.
+ */
+interface StandardTypeRegistry
+{
+    /** @throws InvariantViolation */
+    public function int(): ScalarType;
+
+    /** @throws InvariantViolation */
+    public function float(): ScalarType;
+
+    /** @throws InvariantViolation */
+    public function id(): ScalarType;
+
+    /** @throws InvariantViolation */
+    public function string(): ScalarType;
+
+    /** @throws InvariantViolation */
+    public function boolean(): ScalarType;
+
+    /**
+     * @phpstan-param value-of<Type::STANDARD_TYPE_NAMES> $type
+     *
+     * @throws InvariantViolation
+     */
+    public function standardType(string $type): ScalarType;
+
+    /**
+     * Returns all builtin scalar types.
+     *
+     * @throws InvariantViolation
+     *
+     * @return array<string, ScalarType>
+     */
+    public function standardTypes(): array;
+
+    /** @throws InvariantViolation */
+    public function deprecatedDirective(): Directive;
+
+    /** @throws InvariantViolation */
+    public function includeDirective(): Directive;
+
+    /** @throws InvariantViolation */
+    public function skipDirective(): Directive;
+
+    /**
+     * @throws InvariantViolation
+     *
+     * @return array<string, Directive>
+     */
+    public function internalDirectives(): array;
+
+    public function introspection(): Introspection;
+}

--- a/src/Type/Registry/StandardTypeRegistry.php
+++ b/src/Type/Registry/StandardTypeRegistry.php
@@ -5,7 +5,6 @@ namespace GraphQL\Type\Registry;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Introspection;
 
 /**
  * A registry that returns standard types.
@@ -42,6 +41,4 @@ interface StandardTypeRegistry
      * @return array<string, ScalarType>
      */
     public function standardTypes(): array;
-
-    public function introspection(): Introspection;
 }

--- a/src/Type/Registry/StandardTypeRegistry.php
+++ b/src/Type/Registry/StandardTypeRegistry.php
@@ -3,7 +3,6 @@
 namespace GraphQL\Type\Registry;
 
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Introspection;
@@ -44,21 +43,6 @@ interface StandardTypeRegistry
      */
     public function standardTypes(): array;
 
-    /** @throws InvariantViolation */
-    public function deprecatedDirective(): Directive;
-
-    /** @throws InvariantViolation */
-    public function includeDirective(): Directive;
-
-    /** @throws InvariantViolation */
-    public function skipDirective(): Directive;
-
-    /**
-     * @throws InvariantViolation
-     *
-     * @return array<string, Directive>
-     */
-    public function internalDirectives(): array;
 
     public function introspection(): Introspection;
 }

--- a/src/Type/Registry/StandardTypeRegistry.php
+++ b/src/Type/Registry/StandardTypeRegistry.php
@@ -43,6 +43,5 @@ interface StandardTypeRegistry
      */
     public function standardTypes(): array;
 
-
     public function introspection(): Introspection;
 }

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -80,6 +80,8 @@ class Schema
     /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
     public $typeRegistry;
 
+    public Introspection $introspection;
+
     /**
      * @param SchemaConfig|array<string, mixed> $config
      *
@@ -107,6 +109,7 @@ class Schema
         $this->config = $config;
 
         $this->typeRegistry = $config->typeRegistry ?? DefaultStandardTypeRegistry::instance();
+        $this->introspection = $config->introspection ?? new Introspection($this->typeRegistry);
     }
 
     /**
@@ -169,7 +172,7 @@ class Schema
                     TypeInfo::extractTypesFromDirectives($directive, $allReferencedTypes);
                 }
             }
-            TypeInfo::extractTypes($this->typeRegistry->introspection()->_schema(), $allReferencedTypes);
+            TypeInfo::extractTypes($this->introspection->_schema(), $allReferencedTypes);
 
             $this->resolvedTypes = $allReferencedTypes;
             $this->fullyLoaded = true;
@@ -298,7 +301,7 @@ class Schema
             return $this->resolvedTypes[$name];
         }
 
-        $introspectionTypes = $this->typeRegistry->introspection()->getTypes();
+        $introspectionTypes = $this->introspection->getTypes();
         if (isset($introspectionTypes[$name])) {
             return $introspectionTypes[$name];
         }

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -16,6 +16,7 @@ use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
 use GraphQL\Utils\InterfaceImplementations;
@@ -76,7 +77,8 @@ class Schema
     /** @var array<int, SchemaExtensionNode> */
     public array $extensionASTNodes = [];
 
-    public StandardTypeRegistry $typeRegistry;
+    /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
+    public $typeRegistry;
 
     /**
      * @param SchemaConfig|array<string, mixed> $config

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
 
 /**
@@ -40,7 +41,7 @@ use GraphQL\Type\Registry\StandardTypeRegistry;
  *   assumeValid?: bool|null,
  *   astNode?: SchemaDefinitionNode|null,
  *   extensionASTNodes?: array<SchemaExtensionNode>|null,
- *   typeRegistry?: StandardTypeRegistry|null,
+ *   typeRegistry?: null|(StandardTypeRegistry&BuiltInDirectiveRegistry),
  * }
  */
 class SchemaConfig
@@ -78,7 +79,8 @@ class SchemaConfig
     /** @var array<SchemaExtensionNode> */
     public array $extensionASTNodes = [];
 
-    public ?StandardTypeRegistry $typeRegistry = null;
+    /** @var (StandardTypeRegistry&BuiltInDirectiveRegistry)|null */
+    public $typeRegistry;
 
     /**
      * Converts an array of options to instance of SchemaConfig
@@ -324,12 +326,18 @@ class SchemaConfig
         return $this;
     }
 
-    public function getTypeRegistry(): ?StandardTypeRegistry
+    /** @return (StandardTypeRegistry&BuiltInDirectiveRegistry)|null */
+    public function getTypeRegistry()
     {
         return $this->typeRegistry;
     }
 
-    public function setTypeRegistry(StandardTypeRegistry $typeRegistry): self
+    /**
+     * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
+     *
+     * @return $this
+     */
+    public function setTypeRegistry($typeRegistry): self
     {
         $this->typeRegistry = $typeRegistry;
 

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Registry\StandardTypeRegistry;
 
 /**
  * Configuration options for schema construction.
@@ -39,6 +40,7 @@ use GraphQL\Type\Definition\Type;
  *   assumeValid?: bool|null,
  *   astNode?: SchemaDefinitionNode|null,
  *   extensionASTNodes?: array<SchemaExtensionNode>|null,
+ *   typeRegistry?: StandardTypeRegistry|null,
  * }
  */
 class SchemaConfig
@@ -75,6 +77,8 @@ class SchemaConfig
 
     /** @var array<SchemaExtensionNode> */
     public array $extensionASTNodes = [];
+
+    public ?StandardTypeRegistry $typeRegistry = null;
 
     /**
      * Converts an array of options to instance of SchemaConfig
@@ -125,6 +129,10 @@ class SchemaConfig
 
             if (isset($options['extensionASTNodes'])) {
                 $config->setExtensionASTNodes($options['extensionASTNodes']);
+            }
+
+            if (isset($options['typeRegistry'])) {
+                $config->setTypeRegistry($options['typeRegistry']);
             }
         }
 
@@ -312,6 +320,18 @@ class SchemaConfig
     public function setExtensionASTNodes(array $extensionASTNodes): self
     {
         $this->extensionASTNodes = $extensionASTNodes;
+
+        return $this;
+    }
+
+    public function getTypeRegistry(): ?StandardTypeRegistry
+    {
+        return $this->typeRegistry;
+    }
+
+    public function setTypeRegistry(StandardTypeRegistry $typeRegistry): self
+    {
+        $this->typeRegistry = $typeRegistry;
 
         return $this;
     }

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -82,6 +82,8 @@ class SchemaConfig
     /** @var (StandardTypeRegistry&BuiltInDirectiveRegistry)|null */
     public $typeRegistry;
 
+    public ?Introspection $introspection = null;
+
     /**
      * Converts an array of options to instance of SchemaConfig
      * (or just returns empty config when array is not passed).
@@ -340,6 +342,19 @@ class SchemaConfig
     public function setTypeRegistry($typeRegistry): self
     {
         $this->typeRegistry = $typeRegistry;
+
+        return $this;
+    }
+
+    public function getIntrospection(): ?Introspection
+    {
+        return $this->introspection;
+    }
+
+    /** @return $this */
+    public function setIntrospection(?Introspection $introspection): self
+    {
+        $this->introspection = $introspection;
 
         return $this;
     }

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -42,6 +42,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
 
@@ -80,11 +81,13 @@ class ASTDefinitionBuilder
     /** @var array<string, array<int, Node&TypeExtensionNode>> */
     private array $typeExtensionsMap;
 
-    private StandardTypeRegistry $typeRegistry;
+    /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
+    private $typeRegistry;
 
     /**
      * @param array<string, Node&TypeDefinitionNode> $typeDefinitionsMap
      * @param array<string, array<int, Node&TypeExtensionNode>> $typeExtensionsMap
+     * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
      *
      * @phpstan-param ResolveType $resolveType
      * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
@@ -94,7 +97,7 @@ class ASTDefinitionBuilder
         array $typeExtensionsMap,
         callable $resolveType,
         callable $typeConfigDecorator = null,
-        StandardTypeRegistry $typeRegistry = null
+        $typeRegistry = null
     ) {
         $this->typeDefinitionsMap = $typeDefinitionsMap;
         $this->typeExtensionsMap = $typeExtensionsMap;

--- a/src/Utils/ASTDefinitionBuilder.php
+++ b/src/Utils/ASTDefinitionBuilder.php
@@ -42,6 +42,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Introspection;
 use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
@@ -84,6 +85,8 @@ class ASTDefinitionBuilder
     /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
     private $typeRegistry;
 
+    private Introspection $introspection;
+
     /**
      * @param array<string, Node&TypeDefinitionNode> $typeDefinitionsMap
      * @param array<string, array<int, Node&TypeExtensionNode>> $typeExtensionsMap
@@ -97,13 +100,15 @@ class ASTDefinitionBuilder
         array $typeExtensionsMap,
         callable $resolveType,
         callable $typeConfigDecorator = null,
-        $typeRegistry = null
+        $typeRegistry = null,
+        Introspection $introspection = null,
     ) {
         $this->typeDefinitionsMap = $typeDefinitionsMap;
         $this->typeExtensionsMap = $typeExtensionsMap;
         $this->resolveType = $resolveType;
         $this->typeConfigDecorator = $typeConfigDecorator;
         $this->typeRegistry = $typeRegistry ?? DefaultStandardTypeRegistry::instance();
+        $this->introspection = $introspection ?? new Introspection($this->typeRegistry);
     }
 
     /** @throws \Exception */
@@ -255,7 +260,7 @@ class ASTDefinitionBuilder
     private function internalBuildType(string $typeName, Node $typeNode = null): Type
     {
         $this->cache ??= \array_merge(
-            $this->typeRegistry->introspection()->getTypes(),
+            $this->introspection->getTypes(),
             $this->typeRegistry->standardTypes()
         );
 

--- a/src/Utils/BuildClientSchema.php
+++ b/src/Utils/BuildClientSchema.php
@@ -21,6 +21,7 @@ use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
 use GraphQL\Type\Schema;
@@ -33,7 +34,7 @@ use GraphQL\Type\TypeKind;
  *
  * @phpstan-type Options array{
  *   assumeValid?: bool,
- *   typeRegistry?: StandardTypeRegistry,
+ *   typeRegistry?: null|(StandardTypeRegistry&BuiltInDirectiveRegistry),
  * }
  *
  *    - assumeValid:
@@ -60,7 +61,8 @@ class BuildClientSchema
     /** @var array<string, NamedType&Type> */
     private array $typeMap = [];
 
-    private StandardTypeRegistry $typeRegistry;
+    /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
+    private $typeRegistry;
 
     /**
      * @param array<string, mixed> $introspectionQuery

--- a/src/Utils/BuildSchema.php
+++ b/src/Utils/BuildSchema.php
@@ -14,6 +14,7 @@ use GraphQL\Language\AST\TypeExtensionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Language\Source;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Registry\BuiltInDirectiveRegistry;
 use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Registry\StandardTypeRegistry;
 use GraphQL\Type\Schema;
@@ -64,10 +65,12 @@ class BuildSchema
      */
     private array $options;
 
-    private StandardTypeRegistry $typeRegistry;
+    /** @var StandardTypeRegistry&BuiltInDirectiveRegistry */
+    private $typeRegistry;
 
     /**
      * @param array<string, bool> $options
+     * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
      *
      * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
      * @phpstan-param BuildSchemaOptions $options
@@ -76,7 +79,7 @@ class BuildSchema
         DocumentNode $ast,
         callable $typeConfigDecorator = null,
         array $options = [],
-        StandardTypeRegistry $typeRegistry = null
+        $typeRegistry = null
     ) {
         $this->ast = $ast;
         $this->typeConfigDecorator = $typeConfigDecorator;
@@ -94,6 +97,7 @@ class BuildSchema
      * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
      *
      * @param array<string, bool> $options
+     * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
      *
      * @phpstan-param BuildSchemaOptions $options
      *
@@ -109,7 +113,7 @@ class BuildSchema
         $source,
         callable $typeConfigDecorator = null,
         array $options = [],
-        StandardTypeRegistry $typeRegistry = null
+        $typeRegistry = null
     ): Schema {
         $doc = $source instanceof DocumentNode
             ? $source
@@ -129,6 +133,7 @@ class BuildSchema
      * @phpstan-param TypeConfigDecorator|null $typeConfigDecorator
      *
      * @param array<string, bool> $options
+     * @param (StandardTypeRegistry&BuiltInDirectiveRegistry)|null $typeRegistry
      *
      * @phpstan-param BuildSchemaOptions $options
      *
@@ -143,7 +148,7 @@ class BuildSchema
         DocumentNode $ast,
         callable $typeConfigDecorator = null,
         array $options = [],
-        StandardTypeRegistry $typeRegistry = null
+        $typeRegistry = null
     ): Schema {
         return (new self($ast, $typeConfigDecorator, $options, $typeRegistry))->buildSchema();
     }

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -557,14 +557,7 @@ class SchemaExtender
 
     protected function isSpecifiedScalarType(Type $type): bool
     {
-        return $type instanceof NamedType
-            && (
-                $type->name === Type::STRING
-                || $type->name === Type::INT
-                || $type->name === Type::FLOAT
-                || $type->name === Type::BOOLEAN
-                || $type->name === Type::ID
-            );
+        return $type instanceof NamedType && in_array($type->name, Type::STANDARD_TYPE_NAMES, true);
     }
 
     /**

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -557,7 +557,8 @@ class SchemaExtender
 
     protected function isSpecifiedScalarType(Type $type): bool
     {
-        return $type instanceof NamedType && in_array($type->name, Type::STANDARD_TYPE_NAMES, true);
+        return $type instanceof NamedType
+            && in_array($type->name, Type::STANDARD_TYPE_NAMES, true);
     }
 
     /**

--- a/src/Utils/SchemaExtender.php
+++ b/src/Utils/SchemaExtender.php
@@ -146,7 +146,9 @@ class SchemaExtender
 
                 return $this->extendNamedType($existingType);
             },
-            $typeConfigDecorator
+            $typeConfigDecorator,
+            $schema->typeRegistry,
+            $schema->introspection
         );
 
         $this->extendTypeCache = [];
@@ -196,6 +198,8 @@ class SchemaExtender
             ->setDirectives($this->getMergedDirectives($schema, $directiveDefinitions))
             ->setAstNode($schema->astNode ?? $schemaDef)
             ->setExtensionASTNodes($schemaExtensionASTNodes)
+            ->setTypeRegistry($schema->typeRegistry)
+            ->setIntrospection($schema->introspection)
         );
     }
 

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -20,6 +20,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Introspection;
@@ -443,7 +444,7 @@ class SchemaPrinter
             return ' @deprecated';
         }
 
-        $reasonAST = AST::astFromValue($reason, Type::string());
+        $reasonAST = AST::astFromValue($reason, new StringType());
         assert($reasonAST instanceof StringValueNode);
 
         $reasonASTString = Printer::doPrint($reasonAST);

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -328,17 +328,17 @@ class TypeInfo
     private static function getFieldDefinition(Schema $schema, Type $parentType, FieldNode $fieldNode): ?FieldDefinition
     {
         $name = $fieldNode->name->value;
-        $schemaMeta = $schema->typeRegistry->introspection()->schemaMetaFieldDef();
+        $schemaMeta = $schema->introspection->schemaMetaFieldDef();
         if ($name === $schemaMeta->name && $schema->getQueryType() === $parentType) {
             return $schemaMeta;
         }
 
-        $typeMeta = $schema->typeRegistry->introspection()->typeMetaFieldDef();
+        $typeMeta = $schema->introspection->typeMetaFieldDef();
         if ($name === $typeMeta->name && $schema->getQueryType() === $parentType) {
             return $typeMeta;
         }
 
-        $typeNameMeta = $schema->typeRegistry->introspection()->typeNameMetaFieldDef();
+        $typeNameMeta = $schema->introspection->typeNameMetaFieldDef();
         if ($name === $typeNameMeta->name && $parentType instanceof CompositeType) {
             return $typeNameMeta;
         }

--- a/src/Utils/TypeInfo.php
+++ b/src/Utils/TypeInfo.php
@@ -32,7 +32,6 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
 use GraphQL\Type\Definition\WrappingType;
-use GraphQL\Type\Introspection;
 use GraphQL\Type\Schema;
 
 class TypeInfo
@@ -329,17 +328,17 @@ class TypeInfo
     private static function getFieldDefinition(Schema $schema, Type $parentType, FieldNode $fieldNode): ?FieldDefinition
     {
         $name = $fieldNode->name->value;
-        $schemaMeta = Introspection::schemaMetaFieldDef();
+        $schemaMeta = $schema->typeRegistry->introspection()->schemaMetaFieldDef();
         if ($name === $schemaMeta->name && $schema->getQueryType() === $parentType) {
             return $schemaMeta;
         }
 
-        $typeMeta = Introspection::typeMetaFieldDef();
+        $typeMeta = $schema->typeRegistry->introspection()->typeMetaFieldDef();
         if ($name === $typeMeta->name && $schema->getQueryType() === $parentType) {
             return $typeMeta;
         }
 
-        $typeNameMeta = Introspection::typeNameMetaFieldDef();
+        $typeNameMeta = $schema->typeRegistry->introspection()->typeNameMetaFieldDef();
         if ($name === $typeNameMeta->name && $parentType instanceof CompositeType) {
             return $typeNameMeta;
         }

--- a/src/Validator/Rules/KnownArgumentNamesOnDirectives.php
+++ b/src/Validator/Rules/KnownArgumentNamesOnDirectives.php
@@ -10,7 +10,7 @@ use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\Visitor;
 use GraphQL\Language\VisitorOperation;
 use GraphQL\Type\Definition\Argument;
-use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Utils\Utils;
 use GraphQL\Validator\QueryValidationContext;
 use GraphQL\Validator\SDLValidationContext;
@@ -62,7 +62,7 @@ class KnownArgumentNamesOnDirectives extends ValidationRule
         $schema = $context->getSchema();
         $definedDirectives = $schema !== null
             ? $schema->getDirectives()
-            : Directive::getInternalDirectives();
+            : DefaultStandardTypeRegistry::instance()->internalDirectives();
 
         foreach ($definedDirectives as $directive) {
             $directiveArgs[$directive->name] = \array_map(

--- a/src/Validator/Rules/KnownDirectives.php
+++ b/src/Validator/Rules/KnownDirectives.php
@@ -34,7 +34,7 @@ use GraphQL\Language\AST\UnionTypeExtensionNode;
 use GraphQL\Language\AST\VariableDefinitionNode;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Language\Visitor;
-use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Validator\QueryValidationContext;
 use GraphQL\Validator\SDLValidationContext;
 use GraphQL\Validator\ValidationContext;
@@ -66,7 +66,7 @@ class KnownDirectives extends ValidationRule
         $locationsMap = [];
         $schema = $context->getSchema();
         $definedDirectives = $schema === null
-            ? Directive::getInternalDirectives()
+            ? DefaultStandardTypeRegistry::instance()->internalDirectives()
             : $schema->getDirectives();
 
         foreach ($definedDirectives as $directive) {

--- a/src/Validator/Rules/ProvidedRequiredArgumentsOnDirectives.php
+++ b/src/Validator/Rules/ProvidedRequiredArgumentsOnDirectives.php
@@ -11,7 +11,7 @@ use GraphQL\Language\AST\NonNullTypeNode;
 use GraphQL\Language\Printer;
 use GraphQL\Language\Visitor;
 use GraphQL\Type\Definition\Argument;
-use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Validator\QueryValidationContext;
 use GraphQL\Validator\SDLValidationContext;
 use GraphQL\Validator\ValidationContext;
@@ -57,7 +57,7 @@ class ProvidedRequiredArgumentsOnDirectives extends ValidationRule
         $requiredArgsMap = [];
         $schema = $context->getSchema();
         $definedDirectives = $schema === null
-            ? Directive::getInternalDirectives()
+            ? DefaultStandardTypeRegistry::instance()->internalDirectives()
             : $schema->getDirectives();
 
         foreach ($definedDirectives as $directive) {

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -181,7 +181,7 @@ class QueryComplexity extends QuerySecurityRule
 
             if ($directiveNode->name->value === Directive::INCLUDE_NAME) {
                 $includeArguments = Values::getArgumentValues(
-                    Directive::includeDirective(),
+                    $this->context->getSchema()->typeRegistry->includeDirective(),
                     $directiveNode,
                     $variableValues
                 );
@@ -192,7 +192,7 @@ class QueryComplexity extends QuerySecurityRule
 
             if ($directiveNode->name->value === Directive::SKIP_NAME) {
                 $skipArguments = Values::getArgumentValues(
-                    Directive::skipDirective(),
+                    $this->context->getSchema()->typeRegistry->skipDirective(),
                     $directiveNode,
                     $variableValues
                 );

--- a/src/Validator/Rules/QuerySecurityRule.php
+++ b/src/Validator/Rules/QuerySecurityRule.php
@@ -115,7 +115,7 @@ abstract class QuerySecurityRule extends ValidationRule
 
                     $fieldDef = null;
                     if ($parentType instanceof HasFieldsType) {
-                        $introspection = $context->getSchema()->typeRegistry->introspection();
+                        $introspection = $context->getSchema()->introspection;
                         $schemaMetaFieldDef = $introspection->schemaMetaFieldDef();
                         $typeMetaFieldDef = $introspection->typeMetaFieldDef();
                         $typeNameMetaFieldDef = $introspection->typeNameMetaFieldDef();

--- a/src/Validator/Rules/QuerySecurityRule.php
+++ b/src/Validator/Rules/QuerySecurityRule.php
@@ -12,7 +12,6 @@ use GraphQL\Language\Visitor;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\HasFieldsType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Introspection;
 use GraphQL\Utils\AST;
 use GraphQL\Validator\QueryValidationContext;
 
@@ -116,9 +115,9 @@ abstract class QuerySecurityRule extends ValidationRule
 
                     $fieldDef = null;
                     if ($parentType instanceof HasFieldsType) {
-                        $schemaMetaFieldDef = Introspection::schemaMetaFieldDef();
-                        $typeMetaFieldDef = Introspection::typeMetaFieldDef();
-                        $typeNameMetaFieldDef = Introspection::typeNameMetaFieldDef();
+                        $schemaMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->schemaMetaFieldDef();
+                        $typeMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->typeMetaFieldDef();
+                        $typeNameMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->typeNameMetaFieldDef();
 
                         $queryType = $context->getSchema()->getQueryType();
 

--- a/src/Validator/Rules/QuerySecurityRule.php
+++ b/src/Validator/Rules/QuerySecurityRule.php
@@ -115,9 +115,10 @@ abstract class QuerySecurityRule extends ValidationRule
 
                     $fieldDef = null;
                     if ($parentType instanceof HasFieldsType) {
-                        $schemaMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->schemaMetaFieldDef();
-                        $typeMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->typeMetaFieldDef();
-                        $typeNameMetaFieldDef = $context->getSchema()->typeRegistry->introspection()->typeNameMetaFieldDef();
+                        $introspection = $context->getSchema()->typeRegistry->introspection();
+                        $schemaMetaFieldDef = $introspection->schemaMetaFieldDef();
+                        $typeMetaFieldDef = $introspection->typeMetaFieldDef();
+                        $typeNameMetaFieldDef = $introspection->typeNameMetaFieldDef();
 
                         $queryType = $context->getSchema()->getQueryType();
 

--- a/src/Validator/Rules/UniqueDirectivesPerLocation.php
+++ b/src/Validator/Rules/UniqueDirectivesPerLocation.php
@@ -7,7 +7,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\DirectiveDefinitionNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\Visitor;
-use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Validator\QueryValidationContext;
 use GraphQL\Validator\SDLValidationContext;
 use GraphQL\Validator\ValidationContext;
@@ -47,7 +47,7 @@ class UniqueDirectivesPerLocation extends ValidationRule
         $schema = $context->getSchema();
         $definedDirectives = $schema !== null
             ? $schema->getDirectives()
-            : Directive::getInternalDirectives();
+            : DefaultStandardTypeRegistry::instance()->internalDirectives();
         foreach ($definedDirectives as $directive) {
             if (! $directive->isRepeatable) {
                 $uniqueDirectiveMap[$directive->name] = true;

--- a/tests/CustomIntType.php
+++ b/tests/CustomIntType.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests;
+
+use GraphQL\Type\Definition\IntType;
+
+class CustomIntType extends IntType {}

--- a/tests/DefaultStandardTypeRegistryTest.php
+++ b/tests/DefaultStandardTypeRegistryTest.php
@@ -21,7 +21,6 @@ final class DefaultStandardTypeRegistryTest extends TestCase
         $this->registry = new DefaultStandardTypeRegistry();
     }
 
-    /** @throws InvariantViolation */
     public function testInitializeWithStandardTypes(): void
     {
         self::assertInstanceOf(IntType::class, $this->registry->int());
@@ -31,7 +30,6 @@ final class DefaultStandardTypeRegistryTest extends TestCase
         self::assertInstanceOf(IDType::class, $this->registry->id());
     }
 
-    /** @throws InvariantViolation */
     public function testReturnSameStandardTypeInstance(): void
     {
         self::assertSame($this->registry->int(), $this->registry->int());
@@ -41,7 +39,6 @@ final class DefaultStandardTypeRegistryTest extends TestCase
         self::assertSame($this->registry->id(), $this->registry->id());
     }
 
-    /** @throws InvariantViolation */
     public function testAllowOverridingStandardType(): void
     {
         $this->registry = new DefaultStandardTypeRegistry(CustomIntType::class);

--- a/tests/DefaultStandardTypeRegistryTest.php
+++ b/tests/DefaultStandardTypeRegistryTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\BooleanType;
+use GraphQL\Type\Definition\FloatType;
+use GraphQL\Type\Definition\IDType;
+use GraphQL\Type\Definition\IntType;
+use GraphQL\Type\Definition\StringType;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultStandardTypeRegistryTest extends TestCase
+{
+    private DefaultStandardTypeRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->registry = new DefaultStandardTypeRegistry();
+    }
+
+    /** @throws InvariantViolation */
+    public function testInitializeWithStandardTypes(): void
+    {
+        self::assertInstanceOf(IntType::class, $this->registry->int());
+        self::assertInstanceOf(FloatType::class, $this->registry->float());
+        self::assertInstanceOf(BooleanType::class, $this->registry->boolean());
+        self::assertInstanceOf(StringType::class, $this->registry->string());
+        self::assertInstanceOf(IDType::class, $this->registry->id());
+    }
+
+    /** @throws InvariantViolation */
+    public function testReturnSameStandardTypeInstance(): void
+    {
+        self::assertSame($this->registry->int(), $this->registry->int());
+        self::assertSame($this->registry->float(), $this->registry->float());
+        self::assertSame($this->registry->boolean(), $this->registry->boolean());
+        self::assertSame($this->registry->string(), $this->registry->string());
+        self::assertSame($this->registry->id(), $this->registry->id());
+    }
+
+    /** @throws InvariantViolation */
+    public function testAllowOverridingStandardType(): void
+    {
+        $this->registry = new DefaultStandardTypeRegistry(CustomIntType::class);
+
+        self::assertInstanceOf(CustomIntType::class, $this->registry->int());
+        self::assertInstanceOf(FloatType::class, $this->registry->float());
+        self::assertInstanceOf(BooleanType::class, $this->registry->boolean());
+        self::assertInstanceOf(StringType::class, $this->registry->string());
+        self::assertInstanceOf(IDType::class, $this->registry->id());
+    }
+}

--- a/tests/DefaultStandardTypeRegistryTest.php
+++ b/tests/DefaultStandardTypeRegistryTest.php
@@ -2,7 +2,6 @@
 
 namespace GraphQL\Tests;
 
-use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\BooleanType;
 use GraphQL\Type\Definition\FloatType;
 use GraphQL\Type\Definition\IDType;

--- a/tests/MultipleSchemaTest.php
+++ b/tests/MultipleSchemaTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests;
+
+use GraphQL\Error\InvariantViolation;
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
+use GraphQL\Type\Schema;
+use GraphQL\Type\SchemaConfig;
+use PHPUnit\Framework\TestCase;
+
+final class MultipleSchemaTest extends TestCase
+{
+    public function testMultipleSchemasWithCustomIntType(): void
+    {
+        $schema1 = $this->createSchema();
+        $result1 = GraphQL::executeQuery($schema1, '{ count }');
+        self::assertSame(['data' => ['count' => 1]], $result1->toArray());
+
+        $schema2 = $this->createSchema();
+        $result2 = GraphQL::executeQuery($schema2, '{ count }');
+        self::assertSame(['data' => ['count' => 1]], $result2->toArray());
+
+        self::assertNotSame($schema1->getType('Int'), $schema2->getType('Int'));
+    }
+
+    /** @throws InvariantViolation */
+    private function createSchema(): Schema
+    {
+        $typeRegistry = new DefaultStandardTypeRegistry(
+            CustomIntType::class
+        );
+
+        $query = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'count' => [
+                    'type' => Type::nonNull($typeRegistry->int()),
+                    'resolve' => fn () => 1,
+                ],
+            ],
+        ]);
+
+        $config = SchemaConfig::create([
+            'typeRegistry' => $typeRegistry,
+            'query' => $query,
+        ]);
+
+        return new Schema($config);
+    }
+}

--- a/tests/Type/StandardTypesTest.php
+++ b/tests/Type/StandardTypesTest.php
@@ -5,31 +5,24 @@ namespace GraphQL\Tests\Type;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\CustomScalarType;
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use PHPUnit\Framework\TestCase;
 
 final class StandardTypesTest extends TestCase
 {
-    /** @var array<string, ScalarType> */
-    private static array $originalStandardTypes;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$originalStandardTypes = Type::getStandardTypes();
-    }
-
     public function tearDown(): void
     {
         parent::tearDown();
-        Type::overrideStandardTypes(self::$originalStandardTypes);
+
+        // Create a new instance of DefaultStandardTypeRegistry to reset the standard types
+        DefaultStandardTypeRegistry::register(new DefaultStandardTypeRegistry());
     }
 
     public function testAllowsOverridingStandardTypes(): void
     {
         $originalTypes = Type::getStandardTypes();
         self::assertCount(5, $originalTypes);
-        self::assertSame(self::$originalStandardTypes, $originalTypes);
 
         $newBooleanType = self::createCustomScalarType(Type::BOOLEAN);
         $newFloatType = self::createCustomScalarType(Type::FLOAT);
@@ -65,7 +58,6 @@ final class StandardTypesTest extends TestCase
     {
         $originalTypes = Type::getStandardTypes();
         self::assertCount(5, $originalTypes);
-        self::assertSame(self::$originalStandardTypes, $originalTypes);
 
         $newIDType = self::createCustomScalarType(Type::ID);
         $newStringType = self::createCustomScalarType(Type::STRING);

--- a/tests/Utils/BreakingChangesFinderTest.php
+++ b/tests/Utils/BreakingChangesFinderTest.php
@@ -10,6 +10,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BreakingChangesFinder;
 use PHPUnit\Framework\TestCase;
@@ -1161,7 +1162,7 @@ final class BreakingChangesFinderTest extends TestCase
             ],
         ]);
 
-        $directiveThatIsRemoved = Directive::skipDirective();
+        $directiveThatIsRemoved = DefaultStandardTypeRegistry::instance()->skipDirective();
         $directiveThatRemovesArgOld = new Directive([
             'name' => 'DirectiveThatRemovesArg',
             'locations' => [DirectiveLocation::FIELD_DEFINITION],
@@ -1303,14 +1304,14 @@ final class BreakingChangesFinderTest extends TestCase
     public function testShouldDetectIfADirectiveWasExplicitlyRemoved(): void
     {
         $oldSchema = new Schema([
-            'directives' => [Directive::skipDirective(), Directive::includeDirective()],
+            'directives' => [DefaultStandardTypeRegistry::instance()->skipDirective(), DefaultStandardTypeRegistry::instance()->includeDirective()],
         ]);
 
         $newSchema = new Schema([
-            'directives' => [Directive::skipDirective()],
+            'directives' => [DefaultStandardTypeRegistry::instance()->skipDirective()],
         ]);
 
-        $includeDirective = Directive::includeDirective();
+        $includeDirective = DefaultStandardTypeRegistry::instance()->includeDirective();
 
         self::assertEquals(
             [
@@ -1329,10 +1330,10 @@ final class BreakingChangesFinderTest extends TestCase
         $oldSchema = new Schema([]);
 
         $newSchema = new Schema([
-            'directives' => [Directive::skipDirective(), Directive::includeDirective()],
+            'directives' => [DefaultStandardTypeRegistry::instance()->skipDirective(), DefaultStandardTypeRegistry::instance()->includeDirective()],
         ]);
 
-        $deprecatedDirective = Directive::deprecatedDirective();
+        $deprecatedDirective = DefaultStandardTypeRegistry::instance()->deprecatedDirective();
 
         self::assertEquals(
             [

--- a/tests/Utils/BuildClientSchemaTest.php
+++ b/tests/Utils/BuildClientSchemaTest.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\EnumValueDefinition;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Introspection;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildClientSchema;
 use GraphQL\Utils\BuildSchema;
@@ -28,10 +29,13 @@ final class BuildClientSchemaTest extends TestCase
     {
         $options = ['directiveIsRepeatable' => true];
 
-        $serverSchema = BuildSchema::build($sdl);
+        $typeRegistry = new DefaultStandardTypeRegistry();
+        $introspection = new Introspection($typeRegistry);
+
+        $serverSchema = BuildSchema::build($sdl, null, [], $typeRegistry, $introspection);
         $initialIntrospection = Introspection::fromSchema($serverSchema, $options);
 
-        $clientSchema = BuildClientSchema::build($initialIntrospection);
+        $clientSchema = BuildClientSchema::build($initialIntrospection, ['typeRegistry' => $typeRegistry, 'introspection' => $introspection]);
         $secondIntrospection = Introspection::fromSchema($clientSchema, $options);
 
         self::assertSame($initialIntrospection, $secondIntrospection);

--- a/tests/Utils/BuildSchemaTest.php
+++ b/tests/Utils/BuildSchemaTest.php
@@ -142,7 +142,11 @@ final class BuildSchemaTest extends TestCaseBase
     {
         $schema = new Schema([]);
         $sdlSchema = BuildSchema::buildAST(
-            new DocumentNode(['definitions' => new NodeList([])])
+            new DocumentNode(['definitions' => new NodeList([])]),
+            null,
+            [],
+            $schema->typeRegistry,
+            $schema->introspection
         );
 
         self::assertEquals(array_values($schema->getDirectives()), $sdlSchema->getDirectives());
@@ -1221,7 +1225,7 @@ final class BuildSchemaTest extends TestCaseBase
         ');
 
         self::assertSame(Type::id(), $schema->getType('ID'));
-        self::assertSame(DefaultStandardTypeRegistry::instance()->introspection()->_schema(), $schema->getType('__Schema'));
+        self::assertSame($schema->introspection->_schema(), $schema->getType('__Schema'));
     }
 
     /** @see it('Allows to reference introspection types') */
@@ -1238,7 +1242,7 @@ final class BuildSchemaTest extends TestCaseBase
         $type = $queryType->getField('introspectionField')->getType();
         self::assertInstanceOf(ObjectType::class, $type);
         self::assertSame('__EnumValue', $type->name);
-        self::assertSame(DefaultStandardTypeRegistry::instance()->introspection()->_enumValue(), $schema->getType('__EnumValue'));
+        self::assertSame($schema->introspection->_enumValue(), $schema->getType('__EnumValue'));
     }
 
     /** @see it('Rejects invalid SDL') */

--- a/tests/Validator/ValidatorTestCase.php
+++ b/tests/Validator/ValidatorTestCase.php
@@ -18,6 +18,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Type\Registry\DefaultStandardTypeRegistry;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\ValidationRule;
@@ -57,6 +58,8 @@ abstract class ValidatorTestCase extends TestCase
     /** @throws InvariantViolation */
     public static function getTestSchema(): Schema
     {
+        $typeRegistry = DefaultStandardTypeRegistry::instance();
+
         $Being = new InterfaceType([
             'name' => 'Being',
             'fields' => [
@@ -364,9 +367,9 @@ abstract class ValidatorTestCase extends TestCase
             'query' => $queryRoot,
             'subscription' => $subscriptionRoot,
             'directives' => [
-                Directive::includeDirective(),
-                Directive::skipDirective(),
-                Directive::deprecatedDirective(),
+                $typeRegistry->includeDirective(),
+                $typeRegistry->skipDirective(),
+                $typeRegistry->deprecatedDirective(),
                 new Directive([
                     'name' => 'directive',
                     'locations' => [DirectiveLocation::FIELD, DirectiveLocation::FRAGMENT_DEFINITION],


### PR DESCRIPTION
Currently, types are referenced and cached statically. This is problematic when using multiple schema's that have different standard types that share the same memory. For example, when running them in un-isolated unit tests or when there is a long running PHP process that serves GraphQL requests.

To solve this problem, we introduce a `StandardTypeRegistry` interface with a `DefaultTypeRegistry` implementation. People are allowed to create their own registries by implementing the interface. Every Schema should be constructed with a `typeRegistry` that is an instance of `StandardTypeRegistry`. From there on, all types are queried from the registry. The registry will be responsible for caching the types to make sure subsequent calls to the same type will return the same instance.

Internally, all static calls to the standard types (Type::string(), Type::int(), Type::float(), Type::boolean(), Type::id()) have been replaced with dynamic calls on the type registry. Also calls to the introspection objects and internal directives are using the type registry now.

As most people probably have only one schema, we keep the static methods on the Type call. These now forward to `DefaultTypeRegistry::getInstance()`. This way, we don't break existing installations.

The reason for creating a `StandardTypeRegistry` interface as opposed to just a non-final implementation is that it allows people to use composition instead of inheritance to extend the functionality of the registry. For example, in my project I'd like to have a registry that holds all types and that allows me to query any type by their name (instead of FQCN). I can then delegate the interface methods to the decorated `StandardTypeRegistry`.

Resolves #1424