### PR TITLE
Allow access to calculated query complexity

### DIFF
--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -75,6 +75,10 @@ class QueryComplexity extends QuerySecurityRule
                             return;
                         }
 
+                        if ($this->maxQueryComplexity === self::DISABLED) {
+                            return;
+                        }
+
                         $complexity = $this->fieldComplexity($operationDefinition->selectionSet);
 
                         if ($complexity <= $this->maxQueryComplexity) {

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -27,6 +27,8 @@ class QueryComplexity extends QuerySecurityRule
 {
     protected int $maxQueryComplexity;
 
+    protected int $queryComplexity;
+
     /** @var array<string, mixed> */
     protected array $rawVariableValues = [];
 
@@ -46,6 +48,7 @@ class QueryComplexity extends QuerySecurityRule
 
     public function getVisitor(QueryValidationContext $context): array
     {
+        $this->queryComplexity = 0;
         $this->context = $context;
         $this->variableDefs = new NodeList([]);
         $this->fieldNodeAndDefs = new \ArrayObject();
@@ -79,16 +82,16 @@ class QueryComplexity extends QuerySecurityRule
                             return;
                         }
 
-                        $complexity = $this->fieldComplexity($operationDefinition->selectionSet);
+                        $this->queryComplexity = $this->fieldComplexity($operationDefinition->selectionSet);
 
-                        if ($complexity <= $this->maxQueryComplexity) {
+                        if ($this->queryComplexity <= $this->maxQueryComplexity) {
                             return;
                         }
 
                         $context->reportError(
                             new Error(static::maxQueryComplexityErrorMessage(
                                 $this->maxQueryComplexity,
-                                $complexity
+                                $this->queryComplexity
                             ))
                         );
                     },
@@ -261,6 +264,11 @@ class QueryComplexity extends QuerySecurityRule
     public function getMaxQueryComplexity(): int
     {
         return $this->maxQueryComplexity;
+    }
+
+    public function getQueryComplexity(): int
+    {
+        return $this->queryComplexity;
     }
 
     /**


### PR DESCRIPTION
**Early return when complexity is disabled**
This allows other validation rules to depend on the `QueryComplexity` rule, and disable the query complexity completely on some condition.

```php
$rules[QueryComplexity::class] = $queryComplexity = new QueryComplexity($this->maxQueryComplexity);

// Always enable the query complexity rule, but ignore for introspection queries
$rules[WhenIntrospection::class] = new WhenIntrospection(function () use ($queryComplexity) : void {
    $queryComplexity->setMaxQueryComplexity(QueryComplexity::DISABLED);
});
```

**Allow access to calculated query complexity**
This allows you to read the calculated query complexity. A use case could be: add a rule that logs when queries are detected with a complexity higher than X.

This helps with #1204

```php
$rules[QueryComplexity::class] = $queryComplexity = new QueryComplexity($this->maxQueryComplexity);

$rules[WhenLeaveOperation::class] = new WhenLeaveOperation(function () use ($queryComplexity) : void {
    if ($queryComplexity->getQueryComplexity() >= 400) {
        $this->logger->info('Found a query with high complexity');
    }
});
```