### PR TITLE
Allow lazy types in SchemaConfig

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -537,7 +537,7 @@ Usage example:
 
 @phpstan-type MaybeLazyObjectType ObjectType|(callable(): (ObjectType|null))|null
 @phpstan-type TypeLoader callable(string $typeName): ((Type&NamedType)|null)
-@phpstan-type Types iterable<Type&NamedType>|(callable(): iterable<Type&NamedType>)
+@phpstan-type Types iterable<Type&NamedType>|(callable(): iterable<Type&NamedType>)|iterable<(callable(): Type&NamedType)>|(callable(): iterable<(callable(): Type&NamedType)>)
 @phpstan-type SchemaConfigOptions array{
 query?: MaybeLazyObjectType,
 mutation?: MaybeLazyObjectType,

--- a/src/Type/SchemaConfig.php
+++ b/src/Type/SchemaConfig.php
@@ -28,7 +28,7 @@ use GraphQL\Type\Definition\Type;
  *
  * @phpstan-type MaybeLazyObjectType ObjectType|(callable(): (ObjectType|null))|null
  * @phpstan-type TypeLoader callable(string $typeName): ((Type&NamedType)|null)
- * @phpstan-type Types iterable<Type&NamedType>|(callable(): iterable<Type&NamedType>)
+ * @phpstan-type Types iterable<Type&NamedType>|(callable(): iterable<Type&NamedType>)|iterable<(callable(): Type&NamedType)>|(callable(): iterable<(callable(): Type&NamedType)>)
  * @phpstan-type SchemaConfigOptions array{
  *   query?: MaybeLazyObjectType,
  *   mutation?: MaybeLazyObjectType,


### PR DESCRIPTION
This is already supported, but not allowed by PHPStan.