### PR TITLE
Don't try parse value as string if it's already enum unit. PhpEnumType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix PhpEnumType parse value if it's already enum value https://github.com/webonyx/graphql-php/pull/1481
+
 ## v15.8.0
 
 ### Added

--- a/src/Type/Definition/PhpEnumType.php
+++ b/src/Type/Definition/PhpEnumType.php
@@ -45,6 +45,15 @@ class PhpEnumType extends EnumType
         ]);
     }
 
+    public function parseValue($value)
+    {
+        if ($value instanceof \UnitEnum) {
+            return $value;
+        }
+
+        return parent::parseValue($value);
+    }
+
     public function serialize($value): string
     {
         if (! is_a($value, $this->enumClass)) {

--- a/tests/Type/EnumTypeTest.php
+++ b/tests/Type/EnumTypeTest.php
@@ -580,11 +580,10 @@ final class EnumTypeTest extends TestCase
                 'data' => ['first' => 'ONE', 'second' => 'TWO', 'third' => null],
                 'errors' => [
                     [
-                        'locations' => [['line' => 4, 'column' => 13]],
                         'extensions' => [
                             'debugMessage' => 'Expected a value of type SimpleEnum but received: "WRONG". Cannot serialize value as enum: "WRONG"',
                             'trace' => [
-                                ['call' => 'GraphQL\Type\Definition\EnumType::serialize()'],
+                                ['call' => 'GraphQL\Type\Definition\EnumType::serialize(\'WRONG\')'],
                             ],
                         ],
                     ],

--- a/tests/Type/PhpEnumType/StringPhpEnum.php
+++ b/tests/Type/PhpEnumType/StringPhpEnum.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Type\PhpEnumType;
+
+enum StringPhpEnum: string
+{
+    case A = "a_string";
+    case B = "b_string";
+}


### PR DESCRIPTION
Fixes a bug in subscriptions when an enum object is received instead of a string

I added a couple of tests to check how the value is parsed.

In addition, I fix a test that fails depending on the PHP version (`tests/Type/EnumTypeTest.php@testAllowsSimpleArrayAsValues`). It might be worth using a check that does not include things that may change depending on the php version.

All test passed. Tested with PHP 8.2.10 (cli) (built: Aug 31 2023 18:52:55) (NTS)

<img width="589" alt="изображение" src="https://github.com/webonyx/graphql-php/assets/1656453/0fa7ef62-3152-4c4c-be5a-8ff7276b0172">

If we talk about the backward compatibility of these changes, then nothing should break.



