### PR TITLE
Correctly print deprecated argument with default value

### DIFF
--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -338,7 +338,7 @@ class SchemaPrinter
      */
     protected static function printInputValue($arg): string
     {
-        $argDecl = "{$arg->name}: {$arg->getType()->toString()}" . static::printDeprecated($arg);
+        $argDecl = "{$arg->name}: {$arg->getType()->toString()}";
 
         if ($arg->defaultValueExists()) {
             $defaultValueAST = AST::astFromValue($arg->defaultValue, $arg->getType());
@@ -350,6 +350,8 @@ class SchemaPrinter
 
             $argDecl .= ' = ' . Printer::doPrint($defaultValueAST);
         }
+
+        $argDecl .= static::printDeprecated($arg);
 
         return $argDecl;
     }

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1369,4 +1369,27 @@ final class SchemaPrinterTest extends TestCase
             ['sortArguments' => true]
         );
     }
+
+    public function testPrintDeprecatedFieldArg(): void
+    {
+        $schema = $this->buildSingleFieldSchema([
+            'type' => Type::int(),
+            'args' => [
+                'id' => [
+                    'type' => Type::id(),
+                    'defaultValue' => '123',
+                    'deprecationReason' => 'this is deprecated',
+                ],
+            ],
+        ]);
+        self::assertPrintedSchemaEquals(
+            <<<GRAPHQL
+            type Query {
+              singleField(id: ID = 123 @deprecated(reason: "this is deprecated")): Int
+            }
+
+            GRAPHQL,
+            $schema
+        );
+    }
 }


### PR DESCRIPTION
Today I deprecated an argument with a default value and noticed that the schema was printed wrong:

```graphql
type Query {
  singleField(id: ID @deprecated(reason: "this is deprecated") = 123): Int
}
```

The `@deprecated` directive should be put after the `= 123` default value.