### PR TITLE
Allow callable in `args`

### DIFF
--- a/src/Type/Definition/Argument.php
+++ b/src/Type/Definition/Argument.php
@@ -60,13 +60,17 @@ class Argument
     }
 
     /**
-     * @phpstan-param ArgumentListConfig $config
+     * @phpstan-param ArgumentListConfig|callable(): ArgumentListConfig $config
      *
      * @return array<int, self>
      */
-    public static function listFromConfig(iterable $config): array
+    public static function listFromConfig($config): array
     {
         $list = [];
+
+        if (\is_callable($config)) {
+            $config = $config();
+        }
 
         foreach ($config as $name => $argConfig) {
             if (! \is_array($argConfig)) {

--- a/src/Type/Definition/FieldDefinition.php
+++ b/src/Type/Definition/FieldDefinition.php
@@ -21,7 +21,7 @@ use GraphQL\Utils\Utils;
  *     name: string,
  *     type: FieldType,
  *     resolve?: FieldResolver|null,
- *     args?: ArgumentListConfig|null,
+ *     args?: ArgumentListConfig|callable(): ArgumentListConfig|null,
  *     description?: string|null,
  *     visible?: VisibilityFn|bool,
  *     deprecationReason?: string|null,
@@ -31,7 +31,7 @@ use GraphQL\Utils\Utils;
  * @phpstan-type UnnamedFieldDefinitionConfig array{
  *     type: FieldType,
  *     resolve?: FieldResolver|null,
- *     args?: ArgumentListConfig|null,
+ *     args?: ArgumentListConfig|callable(): ArgumentListConfig|null,
  *     description?: string|null,
  *     visible?: VisibilityFn|bool,
  *     deprecationReason?: string|null,

--- a/tests/Type/LazyDefinitionTest.php
+++ b/tests/Type/LazyDefinitionTest.php
@@ -221,4 +221,24 @@ final class LazyDefinitionTest extends TestCaseBase
         self::assertNull($schema->getMutationType());
         self::assertNull($schema->getSubscriptionType());
     }
+
+    public function testLazyArgs(): void
+    {
+        $objType = new ObjectType([
+            'name' => 'SomeObject',
+            'fields' => [
+                'f' => [
+                    'type' => Type::string(),
+                    'args' => static fn (): array => [
+                        'id' => ['type' => Type::int()],
+                    ],
+                ],
+            ],
+        ]);
+
+        $objType->assertValid();
+
+        self::assertNotNull($objType->getField('f')->getArg('id'));
+        self::assertSame(Type::int(), $objType->getField('f')->getArg('id')->getType());
+    }
 }


### PR DESCRIPTION
This makes it possible to dynamically alter the `args` via a callable.