### PR TITLE
ci: ensure GA run is triggered on fixers' push

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -47,10 +47,7 @@ jobs:
       - uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write --tab-width=2 *.md **/*.md
-          branch: ${{ github.head_ref }}
           commit_message: Prettify docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -2,8 +2,6 @@ name: Autoformat
 
 on:
   push:
-    branches:
-      - '*'
 
 jobs:
   composer-normalize:
@@ -33,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GA_PAT }}
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -51,10 +50,16 @@ jobs:
 
   php-cs-fixer:
     runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GA_PAT }}
 
       - uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
- We have to use PAT since events triggered by the GITHUB_TOKEN will not create a new workflow run
 
 https://github.com/stefanzweifel/git-auto-commit-action/blob/12f68633e45c72459cd040c868605f2471c7f63b/README.md#commits-made-by-this-action-do-not-trigger-new-workflow-runs  
 https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow