### PR TITLE
Use GITHUB_TOKEN if GA_PAT secret is not set

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GA_PAT }}
+          token: ${{ secrets.GA_PAT == '' && secrets.GA_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GA_PAT }}
+          token: ${{ secrets.GA_PAT == '' && secrets.GA_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Useful in forks for example where the secret is usually not set.