### PR TITLE
Allow enum instances in `PhpEnumType::parseValue()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Allow enum instances in `PhpEnumType::parseValue()`
+- Allow enum instances in `PhpEnumType::parseValue()` https://github.com/webonyx/graphql-php/pull/1519
 
 ## v15.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v15.9.1
+
+### Fixed
+
+- Allow enum instances in `PhpEnumType::parseValue()`
+
 ## v15.9.0
 
 ### Added

--- a/src/Type/Definition/PhpEnumType.php
+++ b/src/Type/Definition/PhpEnumType.php
@@ -47,12 +47,22 @@ class PhpEnumType extends EnumType
 
     public function serialize($value): string
     {
-        if (! is_a($value, $this->enumClass)) {
+        if (! ($value instanceof $this->enumClass)) {
             $notEnum = Utils::printSafe($value);
             throw new SerializationError("Cannot serialize value as enum: {$notEnum}, expected instance of {$this->enumClass}.");
         }
 
         return $value->name;
+    }
+
+    public function parseValue($value)
+    {
+        // Can happen when variable values undergo a serialization cycle before execution
+        if ($value instanceof $this->enumClass) {
+            return $value;
+        }
+
+        return parent::parseValue($value);
     }
 
     /** @param class-string $class */

--- a/tests/Type/PhpEnumTypeTest.php
+++ b/tests/Type/PhpEnumTypeTest.php
@@ -183,7 +183,7 @@ GRAPHQL, SchemaPrinter::printType($enumType));
             'query ($bar: PhpEnum!) { foo(bar: $bar) }',
             true,
             null,
-            ['bar' => PhpEnum::A->name]
+            ['bar' => 'A']
         );
         self::assertSame([
             'data' => [


### PR DESCRIPTION
Resolves https://github.com/webonyx/graphql-php/pull/1481