### PR TITLE
feat: use concrete exceptions instead of RequestError

### DIFF
--- a/src/Server/Exception/BatchedQueriesAreNotSupported.php
+++ b/src/Server/Exception/BatchedQueriesAreNotSupported.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class BatchedQueriesAreNotSupported extends RequestError {}

--- a/src/Server/Exception/CannotParseJsonBody.php
+++ b/src/Server/Exception/CannotParseJsonBody.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class CannotParseJsonBody extends RequestError {}

--- a/src/Server/Exception/CannotParseVariables.php
+++ b/src/Server/Exception/CannotParseVariables.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class CannotParseVariables extends RequestError {}

--- a/src/Server/Exception/CannotReadBody.php
+++ b/src/Server/Exception/CannotReadBody.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class CannotReadBody extends RequestError {}

--- a/src/Server/Exception/FailedToDetermineOperationType.php
+++ b/src/Server/Exception/FailedToDetermineOperationType.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class FailedToDetermineOperationType extends RequestError {}

--- a/src/Server/Exception/GetMethodSupportsOnlyQueryOperation.php
+++ b/src/Server/Exception/GetMethodSupportsOnlyQueryOperation.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class GetMethodSupportsOnlyQueryOperation extends RequestError {}

--- a/src/Server/Exception/HttpMethodNotSupported.php
+++ b/src/Server/Exception/HttpMethodNotSupported.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class HttpMethodNotSupported extends RequestError {}

--- a/src/Server/Exception/InvalidOperationParameter.php
+++ b/src/Server/Exception/InvalidOperationParameter.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class InvalidOperationParameter extends RequestError {}

--- a/src/Server/Exception/InvalidQueryIdParameter.php
+++ b/src/Server/Exception/InvalidQueryIdParameter.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class InvalidQueryIdParameter extends RequestError {}

--- a/src/Server/Exception/InvalidQueryParameter.php
+++ b/src/Server/Exception/InvalidQueryParameter.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class InvalidQueryParameter extends RequestError {}

--- a/src/Server/Exception/MissingContentTypeHeader.php
+++ b/src/Server/Exception/MissingContentTypeHeader.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class MissingContentTypeHeader extends RequestError {}

--- a/src/Server/Exception/MissingQueryOrQueryIdParameter.php
+++ b/src/Server/Exception/MissingQueryOrQueryIdParameter.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class MissingQueryOrQueryIdParameter extends RequestError {}

--- a/src/Server/Exception/PersistedQueriesAreNotSupported.php
+++ b/src/Server/Exception/PersistedQueriesAreNotSupported.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class PersistedQueriesAreNotSupported extends RequestError {}

--- a/src/Server/Exception/UnexpectedContentType.php
+++ b/src/Server/Exception/UnexpectedContentType.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Server\Exception;
+
+use GraphQL\Server\RequestError;
+
+class UnexpectedContentType extends RequestError {}

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -13,6 +13,20 @@ use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\GraphQL;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\Parser;
+use GraphQL\Server\Exception\BatchedQueriesAreNotSupported;
+use GraphQL\Server\Exception\CannotParseJsonBody;
+use GraphQL\Server\Exception\CannotParseVariables;
+use GraphQL\Server\Exception\CannotReadBody;
+use GraphQL\Server\Exception\FailedToDetermineOperationType;
+use GraphQL\Server\Exception\GetMethodSupportsOnlyQueryOperation;
+use GraphQL\Server\Exception\HttpMethodNotSupported;
+use GraphQL\Server\Exception\InvalidOperationParameter;
+use GraphQL\Server\Exception\InvalidQueryIdParameter;
+use GraphQL\Server\Exception\InvalidQueryParameter;
+use GraphQL\Server\Exception\MissingContentTypeHeader;
+use GraphQL\Server\Exception\MissingQueryOrQueryIdParameter;
+use GraphQL\Server\Exception\PersistedQueriesAreNotSupported;
+use GraphQL\Server\Exception\UnexpectedContentType;
 use GraphQL\Utils\AST;
 use GraphQL\Utils\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -58,7 +72,7 @@ class Helper
             $contentType = $_SERVER['CONTENT_TYPE'] ?? null;
 
             if ($contentType === null) {
-                throw new RequestError('Missing "Content-Type" header');
+                throw new MissingContentTypeHeader('Missing "Content-Type" header');
             }
 
             if (\stripos($contentType, 'application/graphql') !== false) {
@@ -78,7 +92,7 @@ class Helper
             } elseif (\stripos($contentType, 'multipart/form-data') !== false) {
                 $bodyParams = $_POST;
             } else {
-                throw new RequestError('Unexpected content type: ' . Utils::printSafeJson($contentType));
+                throw new UnexpectedContentType('Unexpected content type: ' . Utils::printSafeJson($contentType));
             }
         }
 
@@ -119,7 +133,7 @@ class Helper
             return OperationParams::create($bodyParams);
         }
 
-        throw new RequestError("HTTP Method \"{$method}\" is not supported");
+        throw new HttpMethodNotSupported("HTTP Method \"{$method}\" is not supported");
     }
 
     /**
@@ -136,32 +150,32 @@ class Helper
         $query = $params->query ?? '';
         $queryId = $params->queryId ?? '';
         if ($query === '' && $queryId === '') {
-            $errors[] = new RequestError('GraphQL Request must include at least one of those two parameters: "query" or "queryId"');
+            $errors[] = new MissingQueryOrQueryIdParameter('GraphQL Request must include at least one of those two parameters: "query" or "queryId"');
         }
 
         if (! \is_string($query)) {
-            $errors[] = new RequestError(
+            $errors[] = new InvalidQueryParameter(
                 'GraphQL Request parameter "query" must be string, but got '
                 . Utils::printSafeJson($params->query)
             );
         }
 
         if (! \is_string($queryId)) {
-            $errors[] = new RequestError(
+            $errors[] = new InvalidQueryIdParameter(
                 'GraphQL Request parameter "queryId" must be string, but got '
                 . Utils::printSafeJson($params->queryId)
             );
         }
 
         if ($params->operation !== null && ! \is_string($params->operation)) {
-            $errors[] = new RequestError(
+            $errors[] = new InvalidOperationParameter(
                 'GraphQL Request parameter "operation" must be string, but got '
                 . Utils::printSafeJson($params->operation)
             );
         }
 
         if ($params->variables !== null && (! \is_array($params->variables) || isset($params->variables[0]))) {
-            $errors[] = new RequestError(
+            $errors[] = new CannotParseVariables(
                 'GraphQL Request parameter "variables" must be object or JSON string parsed to object, but got '
                 . Utils::printSafeJson($params->originalInput['variables'])
             );
@@ -241,7 +255,7 @@ class Helper
             }
 
             if ($isBatch && ! $config->getQueryBatching()) {
-                throw new RequestError('Batched queries are not supported by this server');
+                throw new BatchedQueriesAreNotSupported('Batched queries are not supported by this server');
             }
 
             $errors = $this->validateOperationParams($op);
@@ -268,12 +282,12 @@ class Helper
             $operationAST = AST::getOperationAST($doc, $op->operation);
 
             if ($operationAST === null) {
-                throw new RequestError('Failed to determine operation type');
+                throw new FailedToDetermineOperationType('Failed to determine operation type');
             }
 
             $operationType = $operationAST->operation;
             if ($operationType !== 'query' && $op->readOnly) {
-                throw new RequestError('GET supports only query operation');
+                throw new GetMethodSupportsOnlyQueryOperation('GET supports only query operation');
             }
 
             $result = GraphQL::promiseToExecute(
@@ -323,7 +337,7 @@ class Helper
         $loader = $config->getPersistedQueryLoader();
 
         if ($loader === null) {
-            throw new RequestError('Persisted queries are not supported by this server');
+            throw new PersistedQueriesAreNotSupported('Persisted queries are not supported by this server');
         }
 
         $source = $loader($operationParams->queryId, $operationParams);
@@ -428,7 +442,7 @@ class Helper
     {
         $body = \file_get_contents('php://input');
         if ($body === false) {
-            throw new RequestError('Could not read body.');
+            throw new CannotReadBody('Cannot not read body.');
         }
 
         return $body;
@@ -451,7 +465,7 @@ class Helper
             $contentType = $request->getHeader('content-type');
 
             if (! isset($contentType[0])) {
-                throw new RequestError('Missing "Content-Type" header');
+                throw new MissingContentTypeHeader('Missing "Content-Type" header');
             }
 
             if (\stripos($contentType[0], 'application/graphql') !== false) {
@@ -490,7 +504,7 @@ class Helper
         $bodyParams = \json_decode($rawBody, true);
 
         if (\json_last_error() !== \JSON_ERROR_NONE) {
-            throw new RequestError('Expected JSON object or array for "application/json" request, but failed to parse because: ' . \json_last_error_msg());
+            throw new CannotParseJsonBody('Expected JSON object or array for "application/json" request, but failed to parse because: ' . \json_last_error_msg());
         }
 
         return $bodyParams;
@@ -513,7 +527,7 @@ class Helper
     {
         if (! \is_array($bodyParams)) {
             $notArray = Utils::printSafeJson($bodyParams);
-            throw new RequestError("Expected JSON object or array for \"application/json\" request, got: {$notArray}");
+            throw new CannotParseJsonBody("Expected JSON object or array for \"application/json\" request, got: {$notArray}");
         }
     }
 

--- a/tests/Server/QueryExecutionTest.php
+++ b/tests/Server/QueryExecutionTest.php
@@ -9,9 +9,9 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\Parser;
+use GraphQL\Server\Exception\MissingQueryOrQueryIdParameter;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
-use GraphQL\Server\RequestError;
 use GraphQL\Server\ServerConfig;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\CustomValidationRule;
@@ -602,7 +602,7 @@ final class QueryExecutionTest extends ServerTestCase
         );
 
         self::assertInstanceOf(
-            RequestError::class,
+            MissingQueryOrQueryIdParameter::class,
             $result->errors[0]->getPrevious()
         );
     }

--- a/tests/Server/RequestParsingTest.php
+++ b/tests/Server/RequestParsingTest.php
@@ -3,6 +3,10 @@
 namespace GraphQL\Tests\Server;
 
 use GraphQL\Error\InvariantViolation;
+use GraphQL\Server\Exception\CannotParseJsonBody;
+use GraphQL\Server\Exception\HttpMethodNotSupported;
+use GraphQL\Server\Exception\MissingContentTypeHeader;
+use GraphQL\Server\Exception\UnexpectedContentType;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
@@ -445,7 +449,7 @@ final class RequestParsingTest extends TestCase
     {
         $body = 'not really{} a json';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parseRawRequest('application/json', $body);
     }
@@ -454,21 +458,21 @@ final class RequestParsingTest extends TestCase
     {
         $body = 'not really{} a json';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parsePsrRequest('application/json', $body);
     }
 
     public function testFailsParsingNonPreParsedPsrRequest(): void
     {
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: null');
         $this->parsePsrRequest('application/json', json_encode(null, JSON_THROW_ON_ERROR));
     }
 
     public function testFailsParsingInvalidEmptyJsonRequestPsr(): void
     {
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, but failed to parse because: Syntax error');
         $this->parsePsrRequest('application/json', '');
     }
@@ -477,7 +481,7 @@ final class RequestParsingTest extends TestCase
     {
         $body = '"str"';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: "str"');
         $this->parseRawRequest('application/json', $body);
     }
@@ -486,7 +490,7 @@ final class RequestParsingTest extends TestCase
     {
         $body = '"str"';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(CannotParseJsonBody::class);
         $this->expectExceptionMessage('Expected JSON object or array for "application/json" request, got: "str"');
         $this->parsePsrRequest('application/json', $body);
     }
@@ -496,7 +500,7 @@ final class RequestParsingTest extends TestCase
         $contentType = 'not-supported-content-type';
         $body = 'test';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(UnexpectedContentType::class);
         $this->expectExceptionMessage('Unexpected content type: "not-supported-content-type"');
         $this->parseRawRequest($contentType, $body);
     }
@@ -506,14 +510,14 @@ final class RequestParsingTest extends TestCase
         $contentType = 'not-supported-content-type';
         $body = 'test';
 
-        $this->expectException(RequestError::class);
+        $this->expectException(UnexpectedContentType::class);
         $this->expectExceptionMessage('Unexpected content type: "not-supported-content-type"');
         $this->parseRawRequest($contentType, $body);
     }
 
     public function testFailsWithMissingContentTypeRaw(): void
     {
-        $this->expectException(RequestError::class);
+        $this->expectException(MissingContentTypeHeader::class);
         $this->expectExceptionMessage('Missing "Content-Type" header');
         $this->parseRawRequest(null, 'test');
     }
@@ -526,14 +530,14 @@ final class RequestParsingTest extends TestCase
 
     public function testFailsOnMethodsOtherThanPostOrGetRaw(): void
     {
-        $this->expectException(RequestError::class);
+        $this->expectException(HttpMethodNotSupported::class);
         $this->expectExceptionMessage('HTTP Method "PUT" is not supported');
         $this->parseRawRequest('application/json', json_encode([], JSON_THROW_ON_ERROR), 'PUT');
     }
 
     public function testFailsOnMethodsOtherThanPostOrGetPsr(): void
     {
-        $this->expectException(RequestError::class);
+        $this->expectException(HttpMethodNotSupported::class);
         $this->expectExceptionMessage('HTTP Method "PUT" is not supported');
         $this->parsePsrRequest('application/json', json_encode([], JSON_THROW_ON_ERROR), 'PUT');
     }


### PR DESCRIPTION
I propose implementing more detailed errors instead of generic RequestError. It allows consumers to better react to specific error cases.