### PR TITLE
fix: build client schema have custom scalar value mixed type

### DIFF
--- a/src/Utils/BuildClientSchema.php
+++ b/src/Utils/BuildClientSchema.php
@@ -314,7 +314,7 @@ class BuildClientSchema
         return new CustomScalarType([
             'name' => $scalar['name'],
             'description' => $scalar['description'],
-            'serialize' => static fn ($value): string => (string) $value,
+            'serialize' => static fn ($value) => $value,
         ]);
     }
 

--- a/tests/Utils/BuildClientSchemaTest.php
+++ b/tests/Utils/BuildClientSchemaTest.php
@@ -1013,4 +1013,28 @@ SDL;
         $this->expectExceptionMessage('Expected Foo to be a GraphQL Object type.');
         $clientSchema->assertValid();
     }
+
+    public function testCustomScalarValueMixedExecution(): void
+    {
+        $schema = BuildSchema::build('
+        scalar CustomScalar
+    
+        type Query {
+          foo(bar: CustomScalar): CustomScalar
+        }
+        ');
+
+        $introspection = Introspection::fromSchema($schema);
+        $clientSchema = BuildClientSchema::build($introspection);
+
+        $result = GraphQL::executeQuery(
+            $clientSchema,
+            'query CustomScalarObject($v: CustomScalar) { foo(bar: $v) }',
+            ['foo' => ['baz' => 'value']],
+            null,
+            ['v' => 100]
+        );
+
+        self::assertSame(['foo' => ['baz' => 'value']], $result->data);
+    }
 }


### PR DESCRIPTION
Currently, the serialize function of scalar type made by `GraphQL\Utils\BuildClientSchema` class will cast value to string but it should return raw value instead for consistent with `GraphQL\Utils\BuildSchema` and in GraphQL spec not have any notes said value of scalar types must be string https://graphql.org/learn/schema/#scalar-types

This PR to solve the problem above