### PR TITLE
ensure new lines are counted in multi line comments, fixes #1177

### DIFF
--- a/src/Language/Lexer.php
+++ b/src/Language/Lexer.php
@@ -598,7 +598,14 @@ class Lexer
                 $value .= $chunk . '"""';
                 $chunk = '';
             } else {
+                // move cursor back to before the first quote
                 $this->moveStringCursor(-2, -2);
+
+                if ($code === 10) { // new line
+                    ++$this->line;
+                    $this->lineStart = $this->position;
+                }
+
                 $chunk .= $char;
             }
 

--- a/tests/Language/SchemaParserTest.php
+++ b/tests/Language/SchemaParserTest.php
@@ -199,6 +199,15 @@ type Hello {
             'loc' => $loc(0, 85),
         ];
         self::assertEquals($expected, $doc->toArray());
+
+        // ensure the lexer does not treat multi line comments as one line
+        $tokenAfterMultiLineComment = $doc->loc?->startToken?->next?->next;
+        self::assertEquals('Even with comments between them', trim($tokenAfterMultiLineComment?->value ?? ''));
+        self::assertEquals(5, $tokenAfterMultiLineComment?->line);
+
+        $typeToken = $tokenAfterMultiLineComment?->next;
+        self::assertEquals('type', $typeToken?->value);
+        self::assertEquals(6, $typeToken?->line);
     }
 
     /** @see it('Simple extension') */


### PR DESCRIPTION
See https://github.com/webonyx/graphql-php/issues/1177

Basically, the Lexer ignored any line breaks inside of multi line comments. This was pretty annoying when generating code coverage for graphql sdl files.
The test shows it pretty well. If you revert the change in the Lexer, you will get `2` as the line number for the single line comment instead of `5`.