### PR TITLE
Fix scoping of context for mutations

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -538,7 +538,7 @@ class ReferenceExecutor implements ExecutorImplementation
 
                 $fieldPath = $path;
                 $fieldPath[] = $responseName;
-                $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath, $contextValue);
+                $result = $this->resolveField($parentType, $rootValue, $fieldNodes, $fieldPath, $this->maybeScopeContext($contextValue));
                 if ($result === static::$UNDEFINED) {
                     return $results;
                 }


### PR DESCRIPTION
In #1385 we introduced the `ScopedContext` interface. When implemented on the Context, it would clone the context down to it's children.

This works great for queries. But mutations are executed serially. I forgot to call `maybeScopeContext` there.

This fixes the problem, and adds a test to guard it.it would clone the context down to it's children.