### PR TITLE
Remove redundant lines in ReferenceExecutor

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -1350,9 +1350,6 @@ class ReferenceExecutor implements ExecutorImplementation
         $containsPromise = false;
         $results = [];
         foreach ($fields as $responseName => $fieldNodes) {
-            $fieldNodes = $fields[$responseName];
-            assert($fieldNodes instanceof \ArrayObject, 'The keys of $fields populate $responseName');
-
             $fieldPath = $path;
             $fieldPath[] = $responseName;
 


### PR DESCRIPTION
Somehow this was added in #1548 but I fail to see why.

Let's remove it.

This might be the cause for the performance degradation reported in #1548.