### PR TITLE
fix(error): avoid phpunit crash by triggering side-effect via count on testcase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "phpstan/phpstan": "1.11.4",
     "phpstan/phpstan-phpunit": "1.4.0",
     "phpstan/phpstan-strict-rules": "1.6.0",
-    "phpunit/phpunit": "^9.5 || 10.5.20",
+    "phpunit/phpunit": "^9.5 || ^10.5.21",
     "psr/http-message": "^1 || ^2",
     "react/http": "^1.6",
     "react/promise": "^2.0 || ^3.0",

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -7,6 +7,7 @@ use GraphQL\Language\Source;
 use GraphQL\Language\SourceLocation;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Utils\Utils;
+use PHPUnit\Framework\Test;
 
 /**
  * This class is used for [default error formatting](error-handling.md).
@@ -299,7 +300,11 @@ class FormattedError
         }
 
         if (\is_object($var)) {
-            return 'instance of ' . \get_class($var) . ($var instanceof \Countable ? '(' . \count($var) . ')' : '');
+            $count = ! $var instanceof Test && $var instanceof \Countable
+                ? '(' . \count($var) . ')'
+                : '';
+
+            return 'instance of ' . \get_class($var) . $count;
         }
 
         if (\is_array($var)) {

--- a/src/Error/FormattedError.php
+++ b/src/Error/FormattedError.php
@@ -300,6 +300,7 @@ class FormattedError
         }
 
         if (\is_object($var)) {
+            // Calling `count` on instances of `PHPUnit\Framework\Test` triggers an unintended side effect - see https://github.com/sebastianbergmann/phpunit/issues/5866#issuecomment-2172429263
             $count = ! $var instanceof Test && $var instanceof \Countable
                 ? '(' . \count($var) . ')'
                 : '';


### PR DESCRIPTION
@mfn this is a followup of https://github.com/sebastianbergmann/phpunit/issues/5866#issuecomment-2172429263

What do you think about the fix? I don't see any other option since we analyze the whole stacktrace.