### PR TITLE
Avoid infinite recursion in `QueryDepth` validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix infinite recursion in QueryDepth validator https://github.com/webonyx/graphql-php/pull/1581
+- Fix infinite recursion in `QueryDepth` validator https://github.com/webonyx/graphql-php/pull/1581
 
 ## v15.12.4
 
 ### Fixed
 
-- Ensure unaliasedPath does not grow for each list item https://github.com/webonyx/graphql-php/pull/1579
+- Ensure `unaliasedPath` does not grow for each list item https://github.com/webonyx/graphql-php/pull/1579
 
 ## v15.12.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Fix infinite recursion in `QueryDepth` validator https://github.com/webonyx/graphql-php/pull/1581
+- Avoid infinite recursion in `QueryDepth` validator https://github.com/webonyx/graphql-php/pull/1581
 
 ## v15.12.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Fix infinite recursion in QueryDepth validator https://github.com/webonyx/graphql-php/pull/1581
+
 ## v15.12.4
 
 ### Fixed

--- a/src/Validator/Rules/QueryDepth.php
+++ b/src/Validator/Rules/QueryDepth.php
@@ -15,7 +15,7 @@ use GraphQL\Validator\QueryValidationContext;
 
 class QueryDepth extends QuerySecurityRule
 {
-    /** @var array<string, bool> hash of fragment names which are already calculated in recursion */
+    /** @var array<string, bool> Fragment names which are already calculated in recursion */
     protected array $calculatedFragments = [];
 
     protected int $maxQueryDepth;

--- a/tests/Validator/QueryDepthTest.php
+++ b/tests/Validator/QueryDepthTest.php
@@ -93,6 +93,12 @@ final class QueryDepthTest extends QuerySecurityTestCase
         $this->assertTypeNameMetaFieldQuery(1);
     }
 
+    public function testInfiniteRecursion(): void
+    {
+        $query = 'query MyQuery { human { ...F1 } } fragment F1 on Human { ...F1 }';
+        $this->assertDocumentValidator($query, 7, [self::createFormattedError(7, 8)]);
+    }
+
     /** @return iterable<array{0: int, 1?: int, 2?: array<int, array<string, mixed>>}> */
     public static function queryDataProvider(): iterable
     {


### PR DESCRIPTION
The `QueryDepth` validator goes into infinite recursion on the following query:
```GraphQL
query MyQuery { 
  human { ...F1 }
}

fragment F1 {
  ...F1
}
```

I added a simple protection against recursive fragments. However, we might just break depth calculation when it reaches the max query depth.