### PR TITLE
Serialize valid `\BackedEnum` values in `GraphQL\Type\Definition\PhpEnumType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+## v15.13.0
+
+### Added
+
+- Serialize valid `\BackedEnum` values in `GraphQL\Type\Definition\PhpEnumType` https://github.com/webonyx/graphql-php/pull/1604
+
 ## v15.12.5
 
 ### Fixed

--- a/src/Type/Definition/PhpEnumType.php
+++ b/src/Type/Definition/PhpEnumType.php
@@ -6,9 +6,7 @@ use GraphQL\Error\SerializationError;
 use GraphQL\Utils\PhpDoc;
 use GraphQL\Utils\Utils;
 
-/**
- * @phpstan-import-type PartialEnumValueConfig from EnumType
- */
+/** @phpstan-import-type PartialEnumValueConfig from EnumType */
 class PhpEnumType extends EnumType
 {
     public const MULTIPLE_DESCRIPTIONS_DISALLOWED = 'Using more than 1 Description attribute is not supported.';
@@ -47,12 +45,23 @@ class PhpEnumType extends EnumType
 
     public function serialize($value): string
     {
-        if (! ($value instanceof $this->enumClass)) {
-            $notEnum = Utils::printSafe($value);
-            throw new SerializationError("Cannot serialize value as enum: {$notEnum}, expected instance of {$this->enumClass}.");
+        if ($value instanceof $this->enumClass) {
+            return $value->name;
         }
 
-        return $value->name;
+        if (is_a($this->enumClass, \BackedEnum::class, true)) {
+            try {
+                $instance = $this->enumClass::from($value);
+            } catch (\ValueError|\TypeError $_) {
+                $notEnumInstanceOrValue = Utils::printSafe($value);
+                throw new SerializationError("Cannot serialize value as enum: {$notEnumInstanceOrValue}, expected instance or valid value of {$this->enumClass}.");
+            }
+
+            return $instance->name;
+        }
+
+        $notEnum = Utils::printSafe($value);
+        throw new SerializationError("Cannot serialize value as enum: {$notEnum}, expected instance of {$this->enumClass}.");
     }
 
     public function parseValue($value)

--- a/tests/Type/PhpEnumTypeTest.php
+++ b/tests/Type/PhpEnumTypeTest.php
@@ -136,6 +136,28 @@ GRAPHQL, SchemaPrinter::printType($enumType));
         ], GraphQL::executeQuery($schema, '{ foo(bar: A) }')->toArray());
     }
 
+    public function testSerializesBackedEnumsByValue(): void
+    {
+        $enumType = new PhpEnumType(IntPhpEnum::class);
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'foo' => [
+                        'type' => Type::nonNull($enumType),
+                        'resolve' => static fn (): int => IntPhpEnum::A->value,
+                    ],
+                ],
+            ]),
+        ]);
+
+        self::assertSame([
+            'data' => [
+                'foo' => 'A',
+            ],
+        ], GraphQL::executeQuery($schema, '{ foo }')->toArray());
+    }
+
     public function testAcceptsEnumFromVariableValues(): void
     {
         $enumType = new PhpEnumType(PhpEnum::class);
@@ -210,6 +232,27 @@ GRAPHQL, SchemaPrinter::printType($enumType));
         $result = GraphQL::executeQuery($schema, '{ foo }');
 
         self::expectExceptionObject(new SerializationError('Cannot serialize value as enum: "A", expected instance of GraphQL\\Tests\\Type\\PhpEnumType\\PhpEnum.'));
+        $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
+    }
+
+    public function testFailsToSerializeNonEnumValue(): void
+    {
+        $enumType = new PhpEnumType(IntPhpEnum::class);
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'foo' => [
+                        'type' => Type::nonNull($enumType),
+                        'resolve' => static fn (): string => 'A',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $result = GraphQL::executeQuery($schema, '{ foo }');
+
+        self::expectExceptionObject(new SerializationError('Cannot serialize value as enum: "A", expected instance or valid value of GraphQL\\Tests\\Type\\PhpEnumType\\IntPhpEnum.'));
         $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
     }
 }

--- a/tests/Type/PhpEnumTypeTest.php
+++ b/tests/Type/PhpEnumTypeTest.php
@@ -145,7 +145,7 @@ GRAPHQL, SchemaPrinter::printType($enumType));
                 'fields' => [
                     'foo' => [
                         'type' => Type::nonNull($enumType),
-                        'resolve' => static fn (): int => IntPhpEnum::A->value,
+                        'resolve' => static fn (): int => 1,
                     ],
                 ],
             ]),


### PR DESCRIPTION
This allows the resolvers to return the raw enum values and automatically takes care of converting them.