### PR TITLE
Return value of validateOperationParams is a list

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -2225,7 +2225,7 @@ function parseRequestParams(string $method, array $bodyParams, array $queryParam
  * Checks validity of OperationParams extracted from HTTP request and returns an array of errors
  * if params are invalid (or empty array when params are valid).
  *
- * @return array<int, RequestError>
+ * @return list<RequestError>
  *
  * @api
  */

--- a/src/Server/Helper.php
+++ b/src/Server/Helper.php
@@ -140,7 +140,7 @@ class Helper
      * Checks validity of OperationParams extracted from HTTP request and returns an array of errors
      * if params are invalid (or empty array when params are valid).
      *
-     * @return array<int, RequestError>
+     * @return list<RequestError>
      *
      * @api
      */


### PR DESCRIPTION
## Summary
The list built with `$errors[] = …` exclusively, which means it cannot have gaps.

The helps libraries using this method, as they can type the result passing through as `list<…>` as well.

---
Currently I need this workaround https://github.com/rebing/graphql-laravel/pull/1147/files#diff-a9a648e9e869340c2272eeeb6e14c37a0ef8f9ce32b23f63503391e8384c975cR26

when I want to map this to an `\GraphQL\Error\Error` which I want to pass to https://github.com/webonyx/graphql-php/blob/9e675b577b766dc83fa860f0878a1e1b2996f919/src/Executor/ExecutionResult.php#L82

With this change, I wouldn't need the `phpstan-var` in my code.