### PR TITLE
feat: do not override ClientSafe exception with CoercionError

### DIFF
--- a/src/Utils/Value.php
+++ b/src/Utils/Value.php
@@ -2,6 +2,7 @@
 
 namespace GraphQL\Utils;
 
+use GraphQL\Error\ClientAware;
 use GraphQL\Error\CoercionError;
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
@@ -61,7 +62,10 @@ class Value
             try {
                 return self::ofValue($type->parseValue($value));
             } catch (\Throwable $error) {
-                if ($error instanceof Error) {
+                if (
+                    $error instanceof Error
+                    || ($error instanceof ClientAware && $error->isClientSafe())
+                ) {
                     return self::ofErrors([
                         CoercionError::make($error->getMessage(), $path, $value, $error),
                     ]);


### PR DESCRIPTION
When `ClientSafe` exception is thrown during `parseValue`, it is overriden by CoercionError. Therefore, the actual error message is not propagated to the caller. This allows propagating not only `GraphQL\Error\Error` but also ClientSafe exceptions. 