### PR TITLE
Fix the native Enum serialization

### DIFF
--- a/src/Type/Definition/EnumType.php
+++ b/src/Type/Definition/EnumType.php
@@ -137,11 +137,11 @@ class EnumType extends Type implements InputType, OutputType, LeafType, Nullable
         }
 
         if (is_a($value, \BackedEnum::class)) {
-            return $value->name;
+            return mb_strtoupper($value->name);
         }
 
         if (is_a($value, \UnitEnum::class)) {
-            return $value->name;
+            return mb_strtoupper($value->name);
         }
 
         $safeValue = Utils::printSafe($value);

--- a/src/Type/Definition/PhpEnumType.php
+++ b/src/Type/Definition/PhpEnumType.php
@@ -60,7 +60,7 @@ class PhpEnumType extends EnumType
     public function serialize($value): string
     {
         if ($value instanceof $this->enumClass) {
-            return $value->name;
+            return mb_strtoupper($value->name);
         }
 
         if (is_a($this->enumClass, \BackedEnum::class, true)) {
@@ -71,7 +71,7 @@ class PhpEnumType extends EnumType
                 throw new SerializationError("Cannot serialize value as enum: {$notEnumInstanceOrValue}, expected instance or valid value of {$this->enumClass}.");
             }
 
-            return $instance->name;
+            return mb_strtoupper($instance->name);
         }
 
         $notEnum = Utils::printSafe($value);


### PR DESCRIPTION
During the serialization of a native Enum, we do not normalize its name to the GraphQL standard, which requires all uppercase letters.

The full discussion on this topic can be found here: https://github.com/nuwave/lighthouse/issues/2629