### PR TITLE
:package: Drop `@throws Error` from protected method `ReferenceExecutor::executeOperation`

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -299,7 +299,6 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param mixed $rootValue
      *
      * @throws \Exception
-     * @throws Error
      *
      * @return array<mixed>|Promise|\stdClass|null
      */


### PR DESCRIPTION
This method catches `Error` and converts them to the `return null` and adds error to the context (https://github.com/webonyx/graphql-php/blob/f7b2ee082e32be5bbd14baf2c4fcf7aa2bd450c8/src/Executor/ReferenceExecutor.php#L328-L332)

