### PR TITLE
ResolveInfo->getFieldSelectionWithAliases(): Fix edge case query with ListOf Type

### DIFF
--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -397,6 +397,10 @@ class ResolveInfo
         /** @var array<string, bool> $fields */
         $fields = [];
 
+        if ($parentType instanceof WrappingType) {
+            $parentType = $parentType->getInnermostType();
+        }
+
         foreach ($selectionSet->selections as $selection) {
             if ($selection instanceof FieldNode) {
                 $fieldName = $selection->name->value;
@@ -410,9 +414,6 @@ class ResolveInfo
 
                 $fieldDef = $parentType->getField($fieldName);
                 $fieldType = $fieldDef->getType();
-                if ($fieldType instanceof WrappingType) {
-                    $fieldType = $fieldType->getInnermostType();
-                }
                 $fields[$fieldName][$aliasName]['args'] = Values::getArgumentValues($fieldDef, $selection, $this->variableValues);
 
                 if ($descend <= 0) {

--- a/tests/Type/ResolveInfoTest.php
+++ b/tests/Type/ResolveInfoTest.php
@@ -703,6 +703,21 @@ final class ResolveInfoTest extends TestCase
             ],
         ]);
 
+        $queryList = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'level1' => [
+                    'type' => Type::listOf($level1),
+                    'resolve' => $returnResolveInfo,
+                    'args' => [
+                        'testName' => [
+                            'type' => Type::string(),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
         $result1 = GraphQL::executeQuery(
             new Schema(['query' => $query]),
             <<<GRAPHQL
@@ -828,6 +843,18 @@ final class ResolveInfoTest extends TestCase
             GRAPHQL
         );
 
+        $result9 = GraphQL::executeQuery(
+            new Schema(['query' => $queryList]),
+            <<<GRAPHQL
+            query {
+              level1(testName: "NoAliasFirst") {
+                level2(width: 1, height: 1)
+                level1000: level2(width: 2, height: 20)
+              }
+            }
+            GRAPHQL
+        );
+
         self::assertEmpty($result1->errors, 'Query NoAlias should have no errors');
         self::assertEmpty($result2->errors, 'Query NoAliasFirst should have no errors');
         self::assertEmpty($result3->errors, 'Query NoAliasLast should have no errors');
@@ -836,6 +863,7 @@ final class ResolveInfoTest extends TestCase
         self::assertEmpty($result6->errors, 'Query WithFragments should have no errors');
         self::assertSame('Failed asserting that two arrays are identical.', $result7->errors[0]->getMessage(), 'Query DeepestTooLowDepth should have failed');
         self::assertEmpty($result8->errors, 'Query Deepest should have no errors');
+        self::assertEmpty($result9->errors, 'Query With ListOf type should have no errors');
     }
 
     public function testPathAndUnaliasedPath(): void


### PR DESCRIPTION
I have found a problem with the function getFieldSelectionWithAliases() and Type::listOf() during some new tests.
I fix that here.