### PR TITLE
Make NodeVisitor Node argument covariant

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1298,7 +1298,7 @@ visitor API:
    ]
    ]);
 
-@phpstan-type NodeVisitor callable(Node): (VisitorOperation|null|false|void)
+@phpstan-type NodeVisitor callable(covariant Node): (VisitorOperation|null|false|void)
 @phpstan-type VisitorArray array<string, NodeVisitor>|array<string, array<string, NodeVisitor>>
 
 @see \GraphQL\Tests\Language\VisitorTest

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -89,7 +89,7 @@ use GraphQL\Utils\Utils;
  *       ]
  *     ]);
  *
- * @phpstan-type NodeVisitor callable(Node): (VisitorOperation|null|false|void)
+ * @phpstan-type NodeVisitor callable(covariant Node): (VisitorOperation|null|false|void)
  * @phpstan-type VisitorArray array<string, NodeVisitor>|array<string, array<string, NodeVisitor>>
  *
  * @see \GraphQL\Tests\Language\VisitorTest


### PR DESCRIPTION
When creating a node visitor that uses more specific types, we get this error:

```
Parameter #2 $visitor of static method GraphQL\Language\Visitor::visit() expects array<string, array<string, callable(GraphQL\Language\AST\Node): (GraphQL\Language\VisitorOperation|void|false|null)>|(callable(GraphQL\Language\AST\Node): (GraphQL\Language\VisitorOperation|void|false|null))>, array{OperationDefinition: array{enter: Closure(GraphQL\Language\AST\OperationDefinitionNode): void, leave: Closure(): void}, Field: array{enter: Closure(GraphQL\Language\AST\FieldNode): void, leave: Closure(GraphQL\Language\AST\FieldNode): void}, InlineFragment: array{enter: Closure(GraphQL\Language\AST\InlineFragmentNode): void, leave: Closure(GraphQL\Language\AST\InlineFragmentNode): void}, FragmentDefinition: array{enter: Closure(GraphQL\Language\AST\FragmentDefinitionNode): void, leave: Closure(GraphQL\Language\AST\FragmentDefinitionNode): void}, SelectionSet: Closure(GraphQL\Language\AST\SelectionSetNode): void} given.
```

For the following code:
```php
$ast = Visitor::visit($ast, [
                NodeKind::OPERATION_DEFINITION => [
                    'enter' => function (OperationDefinitionNode $node) : void {
                        $this->parents[] = $node->operation;

                        // Remove the operation name as we don't need this
                        $node->name = null;
                    },
                    'leave' => function () : void {
                        array_pop($this->parents);
                    },
                ],
                NodeKind::FIELD => [
                    'enter' => function (FieldNode $node) : void {
                        $this->parents[] = $node->name->value;
                    },
                    'leave' => function (FieldNode $node) : void {
                        array_pop($this->parents);
                    },
                ],
 // ...
```

By changing the signature to `covariant` the problem goes away.