### PR TITLE
Fix known type names validation for fragments with experimental variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- KnownTypeNames validation for fragments with variables (experimentalFragmentVariables option)
+
 ## v15.20.0
 
 ### Added

--- a/src/Language/AST/FragmentDefinitionNode.php
+++ b/src/Language/AST/FragmentDefinitionNode.php
@@ -2,7 +2,7 @@
 
 namespace GraphQL\Language\AST;
 
-class FragmentDefinitionNode extends Node implements ExecutableDefinitionNode, HasSelectionSet
+class FragmentDefinitionNode extends Node implements ExecutableDefinitionNode, HasSelectionSet, TypeSystemDefinitionNode
 {
     public string $kind = NodeKind::FRAGMENT_DEFINITION;
 

--- a/tests/Validator/KnownTypeNamesTest.php
+++ b/tests/Validator/KnownTypeNamesTest.php
@@ -32,6 +32,30 @@ final class KnownTypeNamesTest extends ValidatorTestCase
         );
     }
 
+    /** @see it('known type names are valid') */
+    public function testKnownTypeWithExperimentalFragmentVariablesAreValid(): void
+    {
+        $this->expectPassesRule(
+            new KnownTypeNames(),
+            '
+      query Foo(
+        $var: String
+        $required: [Int!]!
+        $introspectionType: __EnumValue
+      ) {
+        user(id: 4) {
+          pets { ... on Dog { isAtLocationField(x: 0, y: 0) } }
+        }
+      }
+
+      fragment isAtLocationField($x: Int = 0, $y: Int = 0) on Dog {
+        isAtLocation(x: $x, y: $y)
+      }
+            ',
+            ['experimentalFragmentVariables' => true]
+        );
+    }
+
     /** @see it('unknown type names are invalid') */
     public function testUnknownTypeNamesAreInvalid(): void
     {


### PR DESCRIPTION
This fixes building a schema with `experimentalFragmentVariables`.

Currenty, the `DocumentValidator` returns `Unknown type "String"`.

Example:
```
$typeDefs = '
            type Hello {
                world(phrase: String): String
            }
            fragment hello($phrase: String = "world") on Hello {
                world(phrase: $phrase)
            }
            type RootQuery {
                hello: Hello
            }
            schema {
                query: RootQuery
            }
        ';

$astDocument = Parser::parse($typeDefs, ['experimentalFragmentVariables' => true]);

return BuildSchema::buildAST($astDocument);
```

Fragments should also implement `TypeSystemDefinitionNode` to have the type names validated against the `Type::BUILT_IN_TYPE_NAMES` by the `GraphQL\Validator\Rules\KnownTypeNames` rule:

```
$isSDL = $definitionNode instanceof TypeSystemDefinitionNode || $definitionNode instanceof TypeSystemExtensionNode;
if ($isSDL && in_array($typeName, Type::BUILT_IN_TYPE_NAMES, true)) {
    return;
}
```

Sorry, i struggled to add a test for this case with the current mock data in the `KnownTypeNamesTest`. Please advise if it is required.