### PR TITLE
Add missing `__Directive.args(includeDeprecated:)`

### DIFF
--- a/src/Type/Introspection.php
+++ b/src/Type/Introspection.php
@@ -354,7 +354,7 @@ GRAPHQL;
                     'type' => Type::listOf(Type::nonNull(self::_field())),
                     'args' => [
                         'includeDeprecated' => [
-                            'type' => Type::boolean(),
+                            'type' => Type::nonNull(Type::boolean()),
                             'defaultValue' => false,
                         ],
                     ],
@@ -391,7 +391,7 @@ GRAPHQL;
                     'type' => Type::listOf(Type::nonNull(self::_enumValue())),
                     'args' => [
                         'includeDeprecated' => [
-                            'type' => Type::boolean(),
+                            'type' => Type::nonNull(Type::boolean()),
                             'defaultValue' => false,
                         ],
                     ],
@@ -416,7 +416,7 @@ GRAPHQL;
                     'type' => Type::listOf(Type::nonNull(self::_inputValue())),
                     'args' => [
                         'includeDeprecated' => [
-                            'type' => Type::boolean(),
+                            'type' => Type::nonNull(Type::boolean()),
                             'defaultValue' => false,
                         ],
                     ],
@@ -516,7 +516,7 @@ GRAPHQL;
                     'type' => Type::nonNull(Type::listOf(Type::nonNull(self::_inputValue()))),
                     'args' => [
                         'includeDeprecated' => [
-                            'type' => Type::boolean(),
+                            'type' => Type::nonNull(Type::boolean()),
                             'defaultValue' => false,
                         ],
                     ],
@@ -669,7 +669,7 @@ GRAPHQL;
                     'type' => Type::nonNull(Type::listOf(Type::nonNull(self::_inputValue()))),
                     'args' => [
                         'includeDeprecated' => [
-                            'type' => Type::boolean(),
+                            'type' => Type::nonNull(Type::boolean()),
                             'defaultValue' => false,
                         ],
                     ],

--- a/tests/Type/IntrospectionTest.php
+++ b/tests/Type/IntrospectionTest.php
@@ -4,8 +4,10 @@ namespace GraphQL\Tests\Type;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use GraphQL\GraphQL;
+use GraphQL\Language\DirectiveLocation;
 use GraphQL\Language\SourceLocation;
 use GraphQL\Tests\ErrorHelper;
+use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputObjectType;
@@ -775,7 +777,19 @@ final class IntrospectionTest extends TestCase
                                 ],
                                 [
                                     'name' => 'args',
-                                    'args' => [],
+                                    'args' => [
+                                        0 => [
+                                            'name' => 'includeDeprecated',
+                                            'type' => [
+                                                'kind' => 'SCALAR',
+                                                'name' => 'Boolean',
+                                                'ofType' => null,
+                                            ],
+                                            'defaultValue' => 'false',
+                                            'isDeprecated' => false,
+                                            'deprecationReason' => null,
+                                        ],
+                                    ],
                                     'type' => [
                                         'kind' => 'NON_NULL',
                                         'name' => null,
@@ -1871,5 +1885,87 @@ final class IntrospectionTest extends TestCase
 
         $introspection = Introspection::fromSchema($schema);
         self::assertTrue($introspection['__schema']['types'][1]['isOneOf']);
+    }
+
+    public function testRespectsTheIncludeDeprecatedParameterForDirectiveArgs(): void
+    {
+        $query = new ObjectType([
+            'name' => 'QueryRoot',
+            'fields' => [
+                [
+                    'name' => 'test',
+                    'type' => Type::int(),
+                ],
+            ],
+        ]);
+
+        $directive = new Directive([
+            'name' => 'TestDirective',
+            'args' => [
+                'nonDeprecated' => [
+                    'type' => Type::string(),
+                ],
+                'deprecated' => [
+                    'type' => Type::string(),
+                    'deprecationReason' => 'Removed in 1.0',
+                ],
+            ],
+            'locations' => [DirectiveLocation::FIELD],
+        ]);
+
+        $schema = new Schema([
+            'query' => $query,
+            'directives' => [$directive],
+        ]);
+
+        $request = '
+            {
+                __schema {
+                    directives {
+                        trueArgs: args(includeDeprecated: true) {
+                            name
+                            isDeprecated
+                            deprecationReason
+                        }
+                        falseArgs: args(includeDeprecated: false) {
+                            name
+                        }
+                        omittedArgs: args {
+                            name
+                        }
+                    }
+                }
+            }
+        ';
+
+        $expected = [
+            [
+                'trueArgs' => [
+                    [
+                        'name' => 'nonDeprecated',
+                        'isDeprecated' => false,
+                        'deprecationReason' => null,
+                    ],
+                    [
+                        'name' => 'deprecated',
+                        'isDeprecated' => true,
+                        'deprecationReason' => 'Removed in 1.0',
+                    ],
+                ],
+                'falseArgs' => [
+                    [
+                        'name' => 'nonDeprecated',
+                    ],
+                ],
+                'omittedArgs' => [
+                    [
+                        'name' => 'nonDeprecated',
+                    ],
+                ],
+            ],
+        ];
+
+        $result = GraphQL::executeQuery($schema, $request)->toArray();
+        self::assertSame($expected, $result['data']['__schema']['directives'] ?? null);
     }
 }

--- a/tests/Type/IntrospectionTest.php
+++ b/tests/Type/IntrospectionTest.php
@@ -237,9 +237,13 @@ final class IntrospectionTest extends TestCase
                                         0 => [
                                             'name' => 'includeDeprecated',
                                             'type' => [
-                                                'kind' => 'SCALAR',
-                                                'name' => 'Boolean',
-                                                'ofType' => null,
+                                                'kind' => 'NON_NULL',
+                                                'name' => null,
+                                                'ofType' => [
+                                                    'kind' => 'SCALAR',
+                                                    'name' => 'Boolean',
+                                                    'ofType' => null,
+                                                ],
                                             ],
                                             'defaultValue' => 'false',
                                             'isDeprecated' => false,
@@ -306,9 +310,13 @@ final class IntrospectionTest extends TestCase
                                         0 => [
                                             'name' => 'includeDeprecated',
                                             'type' => [
-                                                'kind' => 'SCALAR',
-                                                'name' => 'Boolean',
-                                                'ofType' => null,
+                                                'kind' => 'NON_NULL',
+                                                'name' => null,
+                                                'ofType' => [
+                                                    'kind' => 'SCALAR',
+                                                    'name' => 'Boolean',
+                                                    'ofType' => null,
+                                                ],
                                             ],
                                             'defaultValue' => 'false',
                                             'isDeprecated' => false,
@@ -337,9 +345,13 @@ final class IntrospectionTest extends TestCase
                                         0 => [
                                             'name' => 'includeDeprecated',
                                             'type' => [
-                                                'kind' => 'SCALAR',
-                                                'name' => 'Boolean',
-                                                'ofType' => null,
+                                                'kind' => 'NON_NULL',
+                                                'name' => null,
+                                                'ofType' => [
+                                                    'kind' => 'SCALAR',
+                                                    'name' => 'Boolean',
+                                                    'ofType' => null,
+                                                ],
                                             ],
                                             'defaultValue' => 'false',
                                             'isDeprecated' => false,
@@ -478,9 +490,13 @@ final class IntrospectionTest extends TestCase
                                         0 => [
                                             'name' => 'includeDeprecated',
                                             'type' => [
-                                                'kind' => 'SCALAR',
-                                                'name' => 'Boolean',
-                                                'ofType' => null,
+                                                'kind' => 'NON_NULL',
+                                                'name' => null,
+                                                'ofType' => [
+                                                    'kind' => 'SCALAR',
+                                                    'name' => 'Boolean',
+                                                    'ofType' => null,
+                                                ],
                                             ],
                                             'defaultValue' => 'false',
                                             'isDeprecated' => false,
@@ -781,9 +797,13 @@ final class IntrospectionTest extends TestCase
                                         0 => [
                                             'name' => 'includeDeprecated',
                                             'type' => [
-                                                'kind' => 'SCALAR',
-                                                'name' => 'Boolean',
-                                                'ofType' => null,
+                                                'kind' => 'NON_NULL',
+                                                'name' => null,
+                                                'ofType' => [
+                                                    'kind' => 'SCALAR',
+                                                    'name' => 'Boolean',
+                                                    'ofType' => null,
+                                                ],
                                             ],
                                             'defaultValue' => 'false',
                                             'isDeprecated' => false,

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1160,7 +1160,7 @@ final class SchemaPrinterTest extends TestCase
         description: String
         isRepeatable: Boolean!
         locations: [__DirectiveLocation!]!
-        args: [__InputValue!]!
+        args(includeDeprecated: Boolean = false): [__InputValue!]!
       }
 
       "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."

--- a/tests/Utils/SchemaPrinterTest.php
+++ b/tests/Utils/SchemaPrinterTest.php
@@ -1083,11 +1083,11 @@ final class SchemaPrinterTest extends TestCase
         kind: __TypeKind!
         name: String
         description: String
-        fields(includeDeprecated: Boolean = false): [__Field!]
+        fields(includeDeprecated: Boolean! = false): [__Field!]
         interfaces: [__Type!]
         possibleTypes: [__Type!]
-        enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-        inputFields(includeDeprecated: Boolean = false): [__InputValue!]
+        enumValues(includeDeprecated: Boolean! = false): [__EnumValue!]
+        inputFields(includeDeprecated: Boolean! = false): [__InputValue!]
         ofType: __Type
         isOneOf: Boolean
       }
@@ -1123,7 +1123,7 @@ final class SchemaPrinterTest extends TestCase
       type __Field {
         name: String!
         description: String
-        args(includeDeprecated: Boolean = false): [__InputValue!]!
+        args(includeDeprecated: Boolean! = false): [__InputValue!]!
         type: __Type!
         isDeprecated: Boolean!
         deprecationReason: String
@@ -1160,7 +1160,7 @@ final class SchemaPrinterTest extends TestCase
         description: String
         isRepeatable: Boolean!
         locations: [__DirectiveLocation!]!
-        args(includeDeprecated: Boolean = false): [__InputValue!]!
+        args(includeDeprecated: Boolean! = false): [__InputValue!]!
       }
 
       "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."


### PR DESCRIPTION
Hey! First time contributing here 👋

Adds the missing includeDeprecated argument to `__Directive.args` field to match GraphQL.js implementation (graphql/graphql-js#3273) and GraphQL Spec (graphql/graphql-spec#805).

The argument allows filtering deprecated directive arguments from introspection results when set to false (default behavior).

This notably fixes schema generation with `graphql-codegen` when using the "inputValueDeprecation" option (see dotansimha/graphql-code-generator#9659).

Includes tests for deprecated argument filtering that I didn't find in GraphQL.js.

Thanks for your review time.