### PR TITLE
Remove private constructor for Printer

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1261,6 +1261,8 @@ $printed = GraphQL\Language\Printer::doPrint($ast);
  * Handles both executable definitions and schema definitions.
  *
  * @api
+ *
+ * @throws \JsonException
  */
 static function doPrint(GraphQL\Language\AST\Node $ast): string
 ```

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -70,16 +70,13 @@ class Printer
      * Handles both executable definitions and schema definitions.
      *
      * @api
+     *
+     * @throws \JsonException
      */
     public static function doPrint(Node $ast): string
     {
-        static $instance;
-        $instance ??= new static();
-
-        return $instance->printAST($ast);
+        return (new static())->printAST($ast);
     }
-
-    protected function __construct() {}
 
     /**
      * Recursively traverse an AST depth-first and produce a pretty string.


### PR DESCRIPTION
The Printer is not stateful. So enforcing a singleton serves no purpose (anymore?). 

We can easily use `new Printer()->printAST($node)`.