### PR TITLE
Allow disabling query short form in Printer

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1250,6 +1250,10 @@ $ast = GraphQL\Language\Parser::parse($query);
 $printed = GraphQL\Language\Printer::doPrint($ast);
 ```
 
+@phpstan-type Options array{
+queryShortForm?: bool,
+}
+
 @see \GraphQL\Tests\Language\PrinterTest
 
 ### GraphQL\Language\Printer Methods
@@ -1260,11 +1264,15 @@ $printed = GraphQL\Language\Printer::doPrint($ast);
  *
  * Handles both executable definitions and schema definitions.
  *
+ * @param array<string, bool> $options
+ *
+ * @phpstan-param Options $options
+ *
  * @throws \JsonException
  *
  * @api
  */
-static function doPrint(GraphQL\Language\AST\Node $ast): string
+static function doPrint(GraphQL\Language\AST\Node $ast, array $options = []): string
 ```
 
 ## GraphQL\Language\Visitor

--- a/src/Language/Printer.php
+++ b/src/Language/Printer.php
@@ -515,7 +515,7 @@ class Printer
      * @param array<string, bool> $options
      *
      * @phpstan-param Options $options
-     * 
+     *
      * @throws \JsonException
      */
     protected static function addDescription(?StringValueNode $description, string $body, $options): string

--- a/tests/Language/PrinterTest.php
+++ b/tests/Language/PrinterTest.php
@@ -316,4 +316,22 @@ GRAPHQL,
             Printer::doPrint($ast),
         );
     }
+
+    public function testDisableQueyrShortForm(): void
+    {
+        $ast = Parser::parse('query { id, name }');
+
+        self::assertSame(
+            <<<'GRAPHQL'
+      query {
+        id
+        name
+      }
+
+      GRAPHQL,
+            Printer::doPrint($ast, [
+                'queryShortForm' => false,
+            ])
+        );
+    }
 }


### PR DESCRIPTION
In our project, I'd like to print operations explicitly, disabling the short form.

```graphql
query {
    id
    name
}
```

instead of

```graphql
{
    id
    name
}
```

I guess this is the downside of having this class static. I now have to pass this options along. Ideally, this would have been a property on the Printer object.