### PR TITLE
Allow replacing a Node with a NodeList in Visitor

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1350,7 +1350,7 @@ visitor API:
    ]
    ]);
 
-@phpstan-type NodeVisitor callable(Node): (VisitorOperation|Node|null|false|void)
+@phpstan-type NodeVisitor callable(Node): (VisitorOperation|Node|NodeList<Node>|null|false|void)
 @phpstan-type VisitorArray array<string, NodeVisitor>|array<string, array<string, NodeVisitor>>
 
 @see \GraphQL\Tests\Language\VisitorTest

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -83,9 +83,3 @@ parameters:
 			identifier: property.dynamicName
 			count: 1
 			path: src/Utils/AST.php
-
-		-
-			message: '#^Method GraphQL\\Validator\\Rules\\KnownDirectives\:\:getDirectiveLocationForASTPath\(\) has parameter \$ancestors with generic class GraphQL\\Language\\AST\\NodeList but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Validator/Rules/KnownDirectives.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,7 +35,7 @@ parameters:
           path: tests
 
         # Cannot satisfy input covariance
-        - '~(expects|should return) array\<string, array\<string, callable\(GraphQL\\Language\\AST\\Node\)\: \(GraphQL\\Language\\AST\\Node\|GraphQL\\Language\\VisitorOperation\|void\|false\|null\)\>\|\(callable\(GraphQL\\Language\\AST\\Node\)\: \(GraphQL\\Language\\AST\\Node\|GraphQL\\Language\\VisitorOperation\|void\|false\|null\)\)\>(,| but returns)?~'
+        - '~(expects|should return) array\<string, array\<string, callable\(GraphQL\\Language\\AST\\Node\)\: \(GraphQL\\Language\\AST\\Node\|GraphQL\\Language\\AST\\NodeList<GraphQL\\Language\\AST\\Node>\|GraphQL\\Language\\VisitorOperation\|void\|false\|null\)\>\|\(callable\(GraphQL\\Language\\AST\\Node\)\: \(GraphQL\\Language\\AST\\Node\|GraphQL\\Language\\AST\\NodeList<GraphQL\\Language\\AST\\Node>\|GraphQL\\Language\\VisitorOperation\|void\|false\|null\)\)\>(,| but returns)?~'
 
         # No need to have @throws in methods that are never called
         ## PHPUnit

--- a/src/Language/AST/NodeList.php
+++ b/src/Language/AST/NodeList.php
@@ -104,12 +104,16 @@ class NodeList implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Remove a portion of the NodeList and replace it with something else.
      *
-     * @param T|array<T>|null $replacement
+     * @param T|iterable<T>|null $replacement
      *
      * @phpstan-return NodeList<T> the NodeList with the extracted elements
      */
     public function splice(int $offset, int $length, $replacement = null): NodeList
     {
+        if (is_iterable($replacement) && ! is_array($replacement)) {
+            $replacement = iterator_to_array($replacement);
+        }
+
         return new NodeList(
             array_splice($this->nodes, $offset, $length, $replacement)
         );

--- a/src/Language/Visitor.php
+++ b/src/Language/Visitor.php
@@ -218,21 +218,13 @@ class Visitor
                             ++$editOffset;
                         } elseif ($node instanceof NodeList) {
                             if ($editValue instanceof NodeList) {
-                                // Replace a single node with multiple nodes from a NodeList
-                                // We need to splice the NodeList's contents into the parent
-                                $replacementNodes = [];
-                                foreach ($editValue as $replacementNode) {
-                                    $replacementNodes[] = $replacementNode;
-                                }
-                                // Remove the original node and insert all replacement nodes
-                                $node->splice($editKey, 1, $replacementNodes);
-                                // Adjust the offset for subsequent edits
-                                $editOffset -= count($replacementNodes) - 1;
+                                $node->splice($editKey, 1, $editValue);
+                                $editOffset -= count($editValue) - 1;
                             } elseif ($editValue instanceof Node) {
                                 $node[$editKey] = $editValue;
                             } else {
-                                $notNode = Utils::printSafe($editValue);
-                                throw new \Exception("Can only add Node or NodeList to NodeList, got: {$notNode}.");
+                                $notNodeOrNodeList = Utils::printSafe($editValue);
+                                throw new \Exception("Can only add Node or NodeList to NodeList, got: {$notNodeOrNodeList}.");
                             }
                         } else {
                             $node->{$editKey} = $editValue;

--- a/src/Validator/Rules/KnownDirectives.php
+++ b/src/Validator/Rules/KnownDirectives.php
@@ -131,7 +131,7 @@ class KnownDirectives extends ValidationRule
     }
 
     /**
-     * @param array<Node|NodeList> $ancestors
+     * @param array<Node|NodeList<Node>> $ancestors
      *
      * @throws \Exception
      */

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -1799,4 +1799,76 @@ final class VisitorTest extends ValidatorTestCase
 
         self::assertEquals($expected, $editedAst);
     }
+
+    public function testThrowsExceptionWhenAddingNonNodeToNodeList(): void
+    {
+        $ast = Parser::parse('
+            {
+                field1
+                ... on Type {
+                    field2
+                }
+            }
+        ', ['noLocation' => true]);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('Can only add Node or NodeList to NodeList, got: "invalid string value"');
+
+        Visitor::visit(
+            $ast,
+            [
+                NodeKind::INLINE_FRAGMENT => [
+                    'leave' => fn (InlineFragmentNode $node) => 'invalid string value',
+                ],
+            ]
+        );
+    }
+
+    public function testThrowsExceptionWhenAddingArrayToNodeList(): void
+    {
+        $ast = Parser::parse('
+            {
+                field1
+                ... on Type {
+                    field2
+                }
+            }
+        ', ['noLocation' => true]);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('Can only add Node or NodeList to NodeList, got:');
+
+        Visitor::visit(
+            $ast,
+            [
+                NodeKind::INLINE_FRAGMENT => [
+                    'leave' => fn (InlineFragmentNode $node) => ['invalid', 'array'],
+                ],
+            ]
+        );
+    }
+
+    public function testThrowsExceptionWhenAddingIntegerToNodeList(): void
+    {
+        $ast = Parser::parse('
+            {
+                field1
+                ... on Type {
+                    field2
+                }
+            }
+        ', ['noLocation' => true]);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('Can only add Node or NodeList to NodeList, got: 42');
+
+        Visitor::visit(
+            $ast,
+            [
+                NodeKind::INLINE_FRAGMENT => [
+                    'leave' => fn (InlineFragmentNode $node) => 42,
+                ],
+            ]
+        );
+    }
 }

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -5,6 +5,7 @@ namespace GraphQL\Tests\Language;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\FieldDefinitionNode;
 use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
 use GraphQL\Language\AST\InputValueDefinitionNode;
 use GraphQL\Language\AST\NameNode;
@@ -1750,7 +1751,7 @@ final class VisitorTest extends ValidatorTestCase
             $ast,
             [
                 NodeKind::INLINE_FRAGMENT => [
-                    'leave' => fn ($node) => $node->selectionSet->selections,
+                    'leave' => fn (InlineFragmentNode $node) => $node->selectionSet->selections,
                 ],
             ]
         );

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -1732,4 +1732,70 @@ final class VisitorTest extends ValidatorTestCase
             ],
         ]);
     }
+
+    public function testAllowsReplacingNodeWithNodeList(): void
+    {
+        $ast = Parser::parse('
+            {
+                field1
+                ... on Type {
+                    field2
+                    field3
+                }
+                field4
+            }
+        ', ['noLocation' => true]);
+
+        $editedAst = Visitor::visit(
+            $ast,
+            [
+                NodeKind::INLINE_FRAGMENT => [
+                    'leave' => fn ($node) => $node->selectionSet->selections,
+                ],
+            ]
+        );
+
+        $expected = Parser::parse('
+            {
+                field1
+                field2
+                field3
+                field4
+            }
+        ', ['noLocation' => true]);
+
+        self::assertEquals($expected, $editedAst);
+    }
+
+    public function testAllowsReplacingNodeWithNodeListOnEnter(): void
+    {
+        $ast = Parser::parse('
+            {
+                field1
+                ... on Type {
+                    field2
+                    field3
+                }
+                field4
+            }
+        ', ['noLocation' => true]);
+
+        $editedAst = Visitor::visit(
+            $ast,
+            [
+                NodeKind::INLINE_FRAGMENT => fn ($node) => $node->selectionSet->selections,
+            ]
+        );
+
+        $expected = Parser::parse('
+            {
+                field1
+                field2
+                field3
+                field4
+            }
+        ', ['noLocation' => true]);
+
+        self::assertEquals($expected, $editedAst);
+    }
 }

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -1784,7 +1784,7 @@ final class VisitorTest extends ValidatorTestCase
         $editedAst = Visitor::visit(
             $ast,
             [
-                NodeKind::INLINE_FRAGMENT => fn ($node) => $node->selectionSet->selections,
+                NodeKind::INLINE_FRAGMENT => fn (InlineFragmentNode $node): NodeList => $node->selectionSet->selections,
             ]
         );
 

--- a/tests/Language/VisitorTest.php
+++ b/tests/Language/VisitorTest.php
@@ -1751,7 +1751,7 @@ final class VisitorTest extends ValidatorTestCase
             $ast,
             [
                 NodeKind::INLINE_FRAGMENT => [
-                    'leave' => fn (InlineFragmentNode $node) => $node->selectionSet->selections,
+                    'leave' => fn (InlineFragmentNode $node): NodeList => $node->selectionSet->selections,
                 ],
             ]
         );


### PR DESCRIPTION
The first 2 commits are actually from this branch: https://github.com/webonyx/graphql-php/pull/1752

With this change, it's now possible to do something like this:

```php
$editedAst = Visitor::visit(
    $ast,
    [
        NodeKind::INLINE_FRAGMENT => function ($node) {
            return $node->selectionSet->selections;
        },
    ]
);
```

It replaces an inline fragment (Node) with the selections (NodeList).

This makes it possible to create specific optimizer Visitors that cleanup operations.

For example, remove useless inline fragments on the same type:
```php
$wrapped = Visitor::visitWithTypeInfo($this->typeInfo, [
    NodeKind::INLINE_FRAGMENT => [
        'leave' => function (Node $node) : ?NodeList {
            Assert::isInstanceOf($node, InlineFragmentNode::class);

            $type = Type::getNamedType($this->typeInfo->getParentType());

            if ( ! $type instanceof \GraphQL\Type\Definition\ObjectType) {
                return null;
            }

            if ($type->name() !== $node->typeCondition?->name->value) {
                return null;
            }

            return $node->selectionSet->selections;
        },
    ],
]);

return Visitor::visit($node, $wrapped);
```

Or inline fragments that don't have a type selection and also don't use directives.