### PR TITLE
Early return when passing NonNull to Type::nonNull

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -246,7 +246,7 @@ static function listOf($type): GraphQL\Type\Definition\ListOfType
 /**
  * Wraps the given type in a non-null type.
  *
- * @param (NullableType&Type)|callable():(NullableType&Type) $type
+ * @param NonNull|(NullableType&Type)|callable():(NullableType&Type) $type
  *
  * @api
  */

--- a/src/Type/Definition/Type.php
+++ b/src/Type/Definition/Type.php
@@ -105,12 +105,16 @@ abstract class Type implements \JsonSerializable
     /**
      * Wraps the given type in a non-null type.
      *
-     * @param (NullableType&Type)|callable():(NullableType&Type) $type
+     * @param NonNull|(NullableType&Type)|callable():(NullableType&Type) $type
      *
      * @api
      */
     public static function nonNull($type): NonNull
     {
+        if ($type instanceof NonNull) {
+            return $type;
+        }
+
         return new NonNull($type);
     }
 

--- a/tests/Type/Definition/TypeTest.php
+++ b/tests/Type/Definition/TypeTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\TestCase;
+
+final class TypeTest extends TestCase
+{
+    public function testWrappingNonNullableTypeWithNonNull(): void
+    {
+        $nonNullableString = Type::nonNull(Type::string());
+
+        self::assertSame($nonNullableString, Type::nonNull($nonNullableString));
+    }
+}


### PR DESCRIPTION
This improves developer experience. If the intent was non null, and it already is non null, just return it.