### PR TITLE
[RFC] Pass `$objectValue` by reference when calling `resolveType`

### DIFF
--- a/src/Type/Definition/AbstractType.php
+++ b/src/Type/Definition/AbstractType.php
@@ -20,5 +20,5 @@ interface AbstractType
      *
      * @phpstan-return ResolveTypeReturn
      */
-    public function resolveType($objectValue, $context, ResolveInfo $info);
+    public function resolveType(&$objectValue, $context, ResolveInfo $info);
 }

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -67,7 +67,7 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
         return $type;
     }
 
-    public function resolveType($objectValue, $context, ResolveInfo $info)
+    public function resolveType(&$objectValue, $context, ResolveInfo $info)
     {
         if (isset($this->config['resolveType'])) {
             return ($this->config['resolveType'])($objectValue, $context, $info);

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -106,7 +106,7 @@ class UnionType extends Type implements AbstractType, OutputType, CompositeType,
         return $this->types;
     }
 
-    public function resolveType($objectValue, $context, ResolveInfo $info)
+    public function resolveType(&$objectValue, $context, ResolveInfo $info)
     {
         if (isset($this->config['resolveType'])) {
             return ($this->config['resolveType'])($objectValue, $context, $info);

--- a/tests/Executor/AbstractTest.php
+++ b/tests/Executor/AbstractTest.php
@@ -13,6 +13,7 @@ use GraphQL\Language\Parser;
 use GraphQL\Tests\Executor\TestClasses\Cat;
 use GraphQL\Tests\Executor\TestClasses\Dog;
 use GraphQL\Tests\Executor\TestClasses\Human;
+use GraphQL\Tests\Executor\TestClasses\PetEntity;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -771,6 +772,99 @@ final class AbstractTest extends TestCase
         self::assertStringContainsString(
             'Schema must contain unique named types but contains multiple types named "Test". Make sure that `resolveType` function of abstract type "Node" returns the same type instance as referenced anywhere else within the schema (see https://webonyx.github.io/graphql-php/type-definitions/#type-registry).',
             $error->getMessage()
+        );
+    }
+
+    public function testResolveTypeAllowsModifyingObjectValue(): void
+    {
+        $PetType = new InterfaceType([
+            'name' => 'Pet',
+            'resolveType' => static function (PetEntity &$objectValue): string {
+                if ($objectValue->type === 'dog') {
+                    $objectValue = new Dog($objectValue->name, $objectValue->woofs);
+
+                    return 'Dog';
+                }
+
+                $objectValue = new Cat($objectValue->name, $objectValue->woofs);
+
+                return 'Cat';
+            },
+            'fields' => [
+                'name' => ['type' => Type::string()],
+            ],
+        ]);
+
+        $DogType = new ObjectType([
+            'name' => 'Dog',
+            'interfaces' => [$PetType],
+            'fields' => [
+                'name' => [
+                    'type' => Type::string(),
+                    'resolve' => fn (Dog $dog) => $dog->name,
+                ],
+                'woofs' => [
+                    'type' => Type::boolean(),
+                    'resolve' => fn (Dog $dog) => $dog->woofs,
+                ],
+            ],
+        ]);
+
+        $CatType = new ObjectType([
+            'name' => 'Cat',
+            'interfaces' => [$PetType],
+            'fields' => [
+                'name' => [
+                    'type' => Type::string(),
+                    'resolve' => fn (Cat $cat) => $cat->name,
+                ],
+                'meows' => [
+                    'type' => Type::boolean(),
+                    'resolve' => fn (Cat $cat) => $cat->meows,
+                ],
+            ],
+        ]);
+
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'pets' => [
+                        'type' => Type::listOf($PetType),
+                        'resolve' => static fn (): array => [
+                            new PetEntity('dog', 'Odie', true),
+                            new PetEntity('cat', 'Garfield', false),
+                        ],
+                    ],
+                ],
+            ]),
+            'types' => [$CatType, $DogType],
+        ]);
+
+        $query = '{
+          pets {
+            name
+            ... on Dog {
+              woofs
+            }
+            ... on Cat {
+              meows
+            }
+          }
+        }';
+
+        $result = GraphQL::executeQuery($schema, $query)->toArray();
+
+        self::assertEquals(
+            [
+                'data' => [
+                    'pets' => [
+                        ['name' => 'Odie', 'woofs' => true],
+                        ['name' => 'Garfield', 'meows' => false],
+                    ],
+                ],
+            ],
+            $result
         );
     }
 }

--- a/tests/Executor/TestClasses/PetEntity.php
+++ b/tests/Executor/TestClasses/PetEntity.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Executor\TestClasses;
+
+final class PetEntity
+{
+    /** @var 'dog'|'cat' */
+    public string $type;
+
+    public string $name;
+
+    public bool $woofs;
+
+    /** @param 'dog'|'cat' $type */
+    public function __construct(string $type, string $name, bool $woofs)
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->woofs = $woofs;
+    }
+}

--- a/tests/Utils/SchemaExtenderTest/SomeInterfaceClassType.php
+++ b/tests/Utils/SchemaExtenderTest/SomeInterfaceClassType.php
@@ -11,7 +11,7 @@ final class SomeInterfaceClassType extends InterfaceType
 {
     public ObjectType $concrete;
 
-    public function resolveType($objectValue, $context, ResolveInfo $info): ObjectType
+    public function resolveType(&$objectValue, $context, ResolveInfo $info): ObjectType
     {
         return $this->concrete;
     }

--- a/tests/Utils/SchemaExtenderTest/SomeUnionClassType.php
+++ b/tests/Utils/SchemaExtenderTest/SomeUnionClassType.php
@@ -11,7 +11,7 @@ final class SomeUnionClassType extends UnionType
 {
     public ObjectType $concrete;
 
-    public function resolveType($objectValue, $context, ResolveInfo $info): ObjectType
+    public function resolveType(&$objectValue, $context, ResolveInfo $info): ObjectType
     {
         return $this->concrete;
     }


### PR DESCRIPTION
This allows the Interface or Union type resolver to modify the object value.

This is useful when you have a single entity that needs different representations. For example, when your data layer returns a generic `PetEntity` with a type discriminator, but your GraphQL schema has separate `Dog` and `Cat` types.

Example:

```php
$PetType = new InterfaceType([
    'name' => 'Pet',
    'resolveType' => static function (PetEntity &$objectValue): string {
        if ($objectValue->type === 'dog') {
            $objectValue = new Dog($objectValue->name, $objectValue->woofs);
            return 'Dog';
        }

        $objectValue = new Cat($objectValue->name, $objectValue->meows);
        return 'Cat';
    },
    'fields' => ['name' => ['type' => Type::string()]],
]);
```

Now field resolvers receive the properly typed Dog or Cat object instead of the generic PetEntity,
allowing for type-safe resolution without needing to transform objects before they reach the type
resolver.

Common use cases:
- Database polymorphism (single table with type column)
- External APIs returning generic objects with type discriminators

> [!IMPORTANT]
> Unfortunately, this breaks the InterfaceType and UnionType contract. So this can only be done in a new major
> But this serves as a RFC. Maybe there is a better non-breaking way to do this.

/cc @spawnia @simPod 