### PR TITLE
Use better error formatter for PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "rector/rector": "^2.0",
     "symfony/polyfill-php81": "^1.23",
     "symfony/var-exporter": "^5 || ^6 || ^7",
-    "thecodingmachine/safe": "^1.3 || ^2 || ^3"
+    "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+    "ticketswap/phpstan-error-formatter": "^1.2"
   },
   "suggest": {
     "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,9 @@ parameters:
     # TODO increase to max
     level: 8
 
+    errorFormat: ticketswap
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
+
     paths:
         - benchmarks
         - examples


### PR DESCRIPTION
I would like to propose using a new (and better) error formatter for PHPStan.

<img src="https://raw.githubusercontent.com/TicketSwap/phpstan-error-formatter/main/screenshot.png" alt="Screenshot" height="300">

## Features

* Every error has it's own clickable file + line link (default formatter shows the file once, and then displays the line + errors)
* Errors don't wrap, so they take your while terminal (default formatter wraps in a table)
* Highlighting of variables, fully qualified class names and other common types. This is done naively and there are cases where it does not work.
* Long file paths are truncated visually (src/App/../Entity/User.php) while keeping the clickable link intact
* The filename + line is clickable depending on your terminal and their support for clickable links. For example, in PHPStorm's built-in editor, it doesn't work and there we print `file:///Volumes/CS/www/src/App/User.php`.

See https://github.com/TicketSwap/phpstan-error-formatter

Curious what you think @spawnia @simPod 