### PR TITLE
Introduce `resolveValue` method to Interface and Union types

### DIFF
--- a/src/Executor/PromiseExecutor.php
+++ b/src/Executor/PromiseExecutor.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Executor;
+
+use GraphQL\Executor\Promise\Promise;
+
+class PromiseExecutor implements ExecutorImplementation
+{
+    private Promise $result;
+
+    public function __construct(Promise $result)
+    {
+        $this->result = $result;
+    }
+
+    public function doExecute(): Promise
+    {
+        return $this->result;
+    }
+}

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -120,19 +120,10 @@ class ReferenceExecutor implements ExecutorImplementation
         );
 
         if (is_array($exeContext)) {
-            return new class($promiseAdapter->createFulfilled(new ExecutionResult(null, $exeContext))) implements ExecutorImplementation {
-                private Promise $result;
+            $executionResult = new ExecutionResult(null, $exeContext);
+            $fulfilledPromise = $promiseAdapter->createFulfilled($executionResult);
 
-                public function __construct(Promise $result)
-                {
-                    $this->result = $result;
-                }
-
-                public function doExecute(): Promise
-                {
-                    return $this->result;
-                }
-            };
+            return new PromiseExecutor($fulfilledPromise);
         }
 
         return new static($exeContext);

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -1092,6 +1092,7 @@ class ReferenceExecutor implements ExecutorImplementation
         $contextValue
     ) {
         $typeCandidate = $returnType->resolveType($result, $contextValue, $info);
+        $result = $returnType->resolveValue($result, $contextValue, $info);
 
         if ($typeCandidate === null) {
             $runtimeType = static::defaultTypeResolver($result, $contextValue, $info, $returnType);

--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -1064,7 +1064,7 @@ class ReferenceExecutor implements ExecutorImplementation
      * @param \ArrayObject<int, FieldNode> $fieldNodes
      * @param list<string|int> $path
      * @param list<string|int> $unaliasedPath
-     * @param array<mixed> $result
+     * @param mixed $result
      * @param mixed $contextValue
      *
      * @throws \Exception
@@ -1264,7 +1264,7 @@ class ReferenceExecutor implements ExecutorImplementation
 
     /**
      * @param \ArrayObject<int, FieldNode> $fieldNodes
-     * @param array<mixed> $result
+     * @param mixed $result
      */
     protected function invalidReturnTypeError(
         ObjectType $returnType,
@@ -1400,7 +1400,7 @@ class ReferenceExecutor implements ExecutorImplementation
      *
      * @param array<mixed>|mixed $results
      *
-     * @return array<mixed>|\stdClass|mixed
+     * @return non-empty-array<mixed>|\stdClass|mixed
      */
     protected static function fixResultsIfEmptyArray($results)
     {

--- a/src/Type/Definition/AbstractType.php
+++ b/src/Type/Definition/AbstractType.php
@@ -24,12 +24,12 @@ interface AbstractType
     public function resolveType($objectValue, $context, ResolveInfo $info);
 
     /**
-     * Resolves/transforms the value after type resolution.
+     * Receives the original resolved value and transforms it if necessary.
      *
      * @param mixed $objectValue The resolved value for the object type
      * @param mixed $context The context that was passed to GraphQL::execute()
      *
-     * @return mixed The transformed value (or original if no transformation needed)
+     * @return mixed The possibly transformed value
      */
     public function resolveValue($objectValue, $context, ResolveInfo $info);
 }

--- a/src/Type/Definition/AbstractType.php
+++ b/src/Type/Definition/AbstractType.php
@@ -7,6 +7,7 @@ use GraphQL\Deferred;
 /**
  * @phpstan-type ResolveTypeReturn ObjectType|string|callable(): (ObjectType|string|null)|Deferred|null
  * @phpstan-type ResolveType callable(mixed $objectValue, mixed $context, ResolveInfo $resolveInfo): ResolveTypeReturn
+ * @phpstan-type ResolveValue callable(mixed $objectValue, mixed $context, ResolveInfo $resolveInfo): mixed
  */
 interface AbstractType
 {
@@ -21,4 +22,14 @@ interface AbstractType
      * @phpstan-return ResolveTypeReturn
      */
     public function resolveType($objectValue, $context, ResolveInfo $info);
+
+    /**
+     * Resolves/transforms the value after type resolution.
+     *
+     * @param mixed $objectValue The resolved value for the object type
+     * @param mixed $context The context that was passed to GraphQL::execute()
+     *
+     * @return mixed The transformed value (or original if no transformation needed)
+     */
+    public function resolveValue($objectValue, $context, ResolveInfo $info);
 }

--- a/src/Type/Definition/InterfaceType.php
+++ b/src/Type/Definition/InterfaceType.php
@@ -10,6 +10,7 @@ use GraphQL\Utils\Utils;
 
 /**
  * @phpstan-import-type ResolveType from AbstractType
+ * @phpstan-import-type ResolveValue from AbstractType
  * @phpstan-import-type FieldsConfig from FieldDefinition
  *
  * @phpstan-type InterfaceTypeReference InterfaceType|callable(): InterfaceType
@@ -19,6 +20,7 @@ use GraphQL\Utils\Utils;
  *   fields: FieldsConfig,
  *   interfaces?: iterable<InterfaceTypeReference>|callable(): iterable<InterfaceTypeReference>,
  *   resolveType?: ResolveType|null,
+ *   resolveValue?: ResolveValue|null,
  *   astNode?: InterfaceTypeDefinitionNode|null,
  *   extensionASTNodes?: array<InterfaceTypeExtensionNode>|null
  * }
@@ -74,6 +76,15 @@ class InterfaceType extends Type implements AbstractType, OutputType, CompositeT
         }
 
         return null;
+    }
+
+    public function resolveValue($objectValue, $context, ResolveInfo $info)
+    {
+        if (isset($this->config['resolveValue'])) {
+            return ($this->config['resolveValue'])($objectValue, $context, $info);
+        }
+
+        return $objectValue;
     }
 
     /**

--- a/src/Type/Definition/UnionType.php
+++ b/src/Type/Definition/UnionType.php
@@ -10,6 +10,7 @@ use GraphQL\Utils\Utils;
 
 /**
  * @phpstan-import-type ResolveType from AbstractType
+ * @phpstan-import-type ResolveValue from AbstractType
  *
  * @phpstan-type ObjectTypeReference ObjectType|callable(): ObjectType
  * @phpstan-type UnionConfig array{
@@ -17,6 +18,7 @@ use GraphQL\Utils\Utils;
  *   description?: string|null,
  *   types: iterable<ObjectTypeReference>|callable(): iterable<ObjectTypeReference>,
  *   resolveType?: ResolveType|null,
+ *   resolveValue?: ResolveValue|null,
  *   astNode?: UnionTypeDefinitionNode|null,
  *   extensionASTNodes?: array<UnionTypeExtensionNode>|null
  * }
@@ -113,6 +115,15 @@ class UnionType extends Type implements AbstractType, OutputType, CompositeType,
         }
 
         return null;
+    }
+
+    public function resolveValue($objectValue, $context, ResolveInfo $info)
+    {
+        if (isset($this->config['resolveValue'])) {
+            return ($this->config['resolveValue'])($objectValue, $context, $info);
+        }
+
+        return $objectValue;
     }
 
     public function assertValid(): void

--- a/tests/Executor/TestClasses/PetEntity.php
+++ b/tests/Executor/TestClasses/PetEntity.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace GraphQL\Tests\Executor\TestClasses;
+
+final class PetEntity
+{
+    /** @var 'dog'|'cat' */
+    public string $type;
+
+    public string $name;
+
+    public bool $vocalizes;
+
+    /** @param 'dog'|'cat' $type */
+    public function __construct(string $type, string $name, bool $vocalizes)
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->vocalizes = $vocalizes;
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This is an alternative (and I think better) approach to:
> - https://github.com/webonyx/graphql-php/pull/1774

This allows transforming the object value after type resolution.

This is useful when you have a single entity that needs different representations. For example, when your data layer returns a generic `PetEntity` with a type discriminator, but your GraphQL schema has separate `Dog` and `Cat` types.

Example:

```php
$PetType = new InterfaceType([
    'name' => 'Pet',
    'resolveType' => static function (PetEntity $objectValue): string {
        if ($objectValue->type === 'dog') {
            return 'Dog';
        }
        return 'Cat';
    },
    'resolveValue' => static function (PetEntity $objectValue) {
        if ($objectValue->type === 'dog') {
            return new Dog($objectValue->name, $objectValue->woofs);
        }
        return new Cat($objectValue->name, $objectValue->meows);
    },
    'fields' => ['name' => ['type' => Type::string()]],
]);
```

Now field resolvers receive the properly typed Dog or Cat object instead of the generic PetEntity,
allowing for type-safe resolution without needing to transform objects before they reach the type
resolver.

Common use cases:
- Database polymorphism (single table with type column)
- External APIs returning generic objects with type discriminators
