### PR TITLE
Call `resolveValue` before calling `resolveType`

### DIFF
--- a/src/Executor/ReferenceExecutor.php
+++ b/src/Executor/ReferenceExecutor.php
@@ -1082,8 +1082,8 @@ class ReferenceExecutor implements ExecutorImplementation
         &$result,
         $contextValue
     ) {
-        $typeCandidate = $returnType->resolveType($result, $contextValue, $info);
         $result = $returnType->resolveValue($result, $contextValue, $info);
+        $typeCandidate = $returnType->resolveType($result, $contextValue, $info);
 
         if ($typeCandidate === null) {
             $runtimeType = static::defaultTypeResolver($result, $contextValue, $info, $returnType);

--- a/src/Type/Definition/AbstractType.php
+++ b/src/Type/Definition/AbstractType.php
@@ -25,6 +25,7 @@ interface AbstractType
 
     /**
      * Receives the original resolved value and transforms it if necessary.
+     * This will be called before calling `resolveType`.
      *
      * @param mixed $objectValue The resolved value for the object type
      * @param mixed $context The context that was passed to GraphQL::execute()

--- a/tests/Executor/AbstractTest.php
+++ b/tests/Executor/AbstractTest.php
@@ -792,19 +792,19 @@ final class AbstractTest extends TestCase
     {
         $PetType = new InterfaceType([
             'name' => 'Pet',
-            'resolveType' => static function (PetEntity $objectValue): string {
-                if ($objectValue->type === 'dog') {
-                    return 'Dog';
-                }
-
-                return 'Cat';
-            },
             'resolveValue' => static function (PetEntity $objectValue): object {
                 if ($objectValue->type === 'dog') {
                     return new Dog($objectValue->name, $objectValue->vocalizes);
                 }
 
                 return new Cat($objectValue->name, $objectValue->vocalizes);
+            },
+            'resolveType' => static function ($objectValue): string {
+                if ($objectValue instanceof Dog) {
+                    return 'Dog';
+                }
+
+                return 'Cat';
             },
             'fields' => [
                 'name' => Type::string(),
@@ -916,19 +916,19 @@ final class AbstractTest extends TestCase
         $PetType = new UnionType([
             'name' => 'Pet',
             'types' => [$DogType, $CatType],
-            'resolveType' => static function (PetEntity $objectValue): string {
-                if ($objectValue->type === 'dog') {
-                    return 'Dog';
-                }
-
-                return 'Cat';
-            },
             'resolveValue' => static function (PetEntity $objectValue): object {
                 if ($objectValue->type === 'dog') {
                     return new Dog($objectValue->name, $objectValue->vocalizes);
                 }
 
                 return new Cat($objectValue->name, $objectValue->vocalizes);
+            },
+            'resolveType' => static function ($objectValue): string {
+                if ($objectValue instanceof Dog) {
+                    return 'Dog';
+                }
+
+                return 'Cat';
             },
         ]);
 


### PR DESCRIPTION
In hindsight it makes more sense to first resolve the value to the desired type before calling `resolveType`.

I figured this out while implementing this new feature in our project. 

Related to #1776