### PR TITLE
Fix php-cs-fixer Docker build for older PHP versions

### DIFF
--- a/.php-cs-fixer.dockerfile
+++ b/.php-cs-fixer.dockerfile
@@ -9,8 +9,13 @@ RUN apt-get update \
 
 COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 
-COPY composer.json /deps/
-RUN composer update --working-dir=/deps --no-interaction --quiet
+COPY composer.json /tmp/
+RUN VERSION=$(grep -oP '"friendsofphp/php-cs-fixer":\s*"\K[^"]+' /tmp/composer.json) \
+  && MLL_VERSION=$(grep -oP '"mll-lab/php-cs-fixer-config":\s*"\K[^"]+' /tmp/composer.json) \
+  && mkdir /deps \
+  && composer require --working-dir=/deps --no-interaction --quiet \
+    "friendsofphp/php-cs-fixer:$VERSION" \
+    "mll-lab/php-cs-fixer-config:$MLL_VERSION"
 ENTRYPOINT ["/deps/vendor/bin/php-cs-fixer", "fix", "--config=/app/.php-cs-fixer.php"]
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Extract php-cs-fixer versions from composer.json using grep
- Install only php-cs-fixer and mll-lab/php-cs-fixer-config instead of all dev dependencies
- This avoids dependency resolution failures when transitive dependencies drop support for older PHP versions like 8.0

## Problem

The autofix CI step was failing with `exit code: 100` (Composer dependency resolution failure) when building the Docker image for PHP 8.0. The root cause was that the Dockerfile copied the full `composer.json` and ran `composer update`, which tried to resolve ALL dev dependencies for the target PHP version. Some transitive dependencies have dropped PHP 8.0 support (PHP 8.0 EOL was November 2023).

## Test plan

- [x] Verified locally that `make php-cs-fixer` passes for all three PHP versions (7.4, 8.0, 8.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)