### PR TITLE
Fix "Cannot traverse an already closed generator" in Schema::getTypeMap()

### DIFF
--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -122,17 +122,12 @@ class Schema
     public function getTypeMap(): array
     {
         if (! $this->fullyLoaded) {
-            $types = $this->config->types;
-            if (is_callable($types)) {
-                $types = $types();
-            }
-
             // Reset order of user provided types, since calls to getType() may have loaded them
             $this->resolvedTypes = [];
 
             $scalarOverrides = $this->getScalarOverrides();
 
-            foreach ($types as $typeOrLazyType) {
+            foreach ($this->materializeTypes() as $typeOrLazyType) {
                 /** @var Type|callable(): Type $typeOrLazyType */
                 $type = self::resolveType($typeOrLazyType);
                 assert($type instanceof NamedType);
@@ -380,20 +375,8 @@ class Schema
         if ($this->scalarOverrides === null) {
             $this->scalarOverrides = [];
 
-            $types = $this->config->types;
-            if (is_callable($types)) {
-                $types = $types();
-            }
-
-            // Materialize the iterable in case it is a generator, so that
-            // getTypeMap() can still iterate config->types later.
-            if (! is_array($types)) {
-                $types = iterator_to_array($types);
-                $this->config->types = $types;
-            }
-
             $builtInScalars = Type::builtInScalars();
-            foreach ($types as $typeOrLazyType) {
+            foreach ($this->materializeTypes() as $typeOrLazyType) {
                 /** @var Type|callable(): Type $typeOrLazyType */
                 $type = self::resolveType($typeOrLazyType);
                 if ($type instanceof ScalarType
@@ -406,6 +389,26 @@ class Schema
         }
 
         return $this->scalarOverrides;
+    }
+
+    /**
+     * Resolve config->types to an array, materializing callables and generators.
+     *
+     * @return array<Type|callable(): Type>
+     */
+    private function materializeTypes(): array
+    {
+        $types = $this->config->types;
+        if (is_callable($types)) {
+            $types = $types();
+        }
+
+        if (! is_array($types)) {
+            $types = iterator_to_array($types);
+            $this->config->types = $types;
+        }
+
+        return $types;
     }
 
     /**

--- a/tests/Type/ScalarOverridesTest.php
+++ b/tests/Type/ScalarOverridesTest.php
@@ -487,7 +487,7 @@ final class ScalarOverridesTest extends TestCase
         self::assertSame(['data' => ['greeting' => 'HELLO WORLD']], $result->toArray());
     }
 
-    public function testTypesOverrideWorksWithGeneratorTypesConfig(): void
+    public function testTypesOverrideWorksWithCallableGeneratorTypesConfig(): void
     {
         $uppercaseString = self::createUppercaseString();
         $queryType = self::createQueryType();
@@ -498,6 +498,26 @@ final class ScalarOverridesTest extends TestCase
             'types' => static function () use ($uppercaseString): \Generator {
                 yield $uppercaseString;
             },
+        ]);
+
+        $result = GraphQL::executeQuery($schema, '{ greeting }');
+
+        self::assertSame(['data' => ['greeting' => 'HELLO WORLD']], $result->toArray());
+
+        $schema->assertValid();
+    }
+
+    public function testTypesOverrideWorksWithGeneratorTypesConfig(): void
+    {
+        $uppercaseString = self::createUppercaseString();
+        $queryType = self::createQueryType();
+
+        /** @var \Generator<int, CustomScalarType> $types */
+        $types = self::generateTypes($uppercaseString);
+
+        $schema = new Schema([
+            'query' => $queryType,
+            'types' => $types,
         ]);
 
         $result = GraphQL::executeQuery($schema, '{ greeting }');
@@ -608,6 +628,12 @@ final class ScalarOverridesTest extends TestCase
                 return $node->value;
             },
         ]);
+    }
+
+    /** @return \Generator<int|string, ScalarType> */
+    private static function generateTypes(ScalarType ...$types): \Generator
+    {
+        yield from $types;
     }
 
     /** @throws InvariantViolation */


### PR DESCRIPTION
# Description
Fixing bug introduced at https://github.com/webonyx/graphql-php/pull/1886, merged in version 15.31.5.

https://github.com/jerowork/graphql-attribute-schema/blob/main/src/SchemaBuilder.php#L56 is failing now since the SchemaBuilder uses a bare Generator as types input (which is allowed according to the [private property type](https://github.com/webonyx/graphql-php/blob/master/src/Type/SchemaConfig.php#L59)).

### The problem
When `SchemaConfig::$types` is configured with a 'bare' `Generator` (an iterable that can only be traversed once), both `getScalarOverrides()` and `getTypeMap()` need to iterate over it. 
Previously, each method independently resolved `config->types`; calling the callable if needed and then iterating the result. This caused a problem: if the generator was consumed by `getScalarOverrides()` (either called from `getType()` beforehand, or from within `getTypeMap()` itself), the subsequent `foreach` in `getTypeMap()` would fail with: `"Cannot traverse an already closed generator".`

### The fix
This fix extracts a `materializeTypes()` method that both `getScalarOverrides()` and `getTypeMap()` now call. This method resolves `config->types` by invoking the callable (if applicable) and converting any non-array iterable (such as a `Generator`) into an array via `iterator_to_array()`, storing the result back in `config->types`. This ensures the generator is consumed exactly once and all subsequent access operates on the materialized array.

## Changes
- [x] Added `Schema::materializeTypes()` that resolves callables, materializes generators to arrays, and caches the result in `config->types`
- [x] `getScalarOverrides()` and `getTypeMap()` both call `materializeTypes()` instead of duplicating the resolution logic