### PR TITLE
chore: migrate Renovate base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-      "config:base"
+      "config:recommended"
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "replace",


### PR DESCRIPTION
Renovate's Dependency Dashboard is currently showing "Config Migration Needed" for this repository.

This PR makes the smallest config-only migration for the deprecated preset:

- `config:base` -> `config:recommended`

I left the existing labels, range strategy, assignee, and package rules unchanged. Validation run locally:

```bash
python3 -m json.tool renovate.json >/dev/null
```

This should let Renovate clear the dashboard migration warning without touching application code or dependency versions.
