### PR TITLE
Update phpstan to 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "nyholm/psr7": "^1.5",
     "phpbench/phpbench": "^1.2",
     "phpstan/extension-installer": "^1.1",
-    "phpstan/phpstan": "2.2.1",
+    "phpstan/phpstan": "2.2.2",
     "phpstan/phpstan-phpunit": "2.0.16",
     "phpstan/phpstan-strict-rules": "2.0.11",
     "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,7 +55,7 @@ parameters:
 			path: src/Utils/AST.php
 
 		-
-			message: '#^Variable property access on array\|object\.$#'
+			message: '#^Variable property access on (array\|)?object\.$#'
 			identifier: property.dynamicName
 			count: 1
 			path: src/Utils/AST.php


### PR DESCRIPTION
Updates phpstan/phpstan from 2.2.1 to 2.2.2 and adjusts the PHPStan baseline pattern for the changed diagnostic message.