### PR TITLE
Skip benchmark history action in forks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
         run: php benchmarks/convert-results.php benchmark.xml > benchmark-results.json
 
       - uses: benchmark-action/github-action-benchmark@v1
+        if: github.repository == 'webonyx/graphql-php'
         with:
           tool: customSmallerIsBetter
           output-file-path: benchmark-results.json
@@ -76,6 +77,7 @@ jobs:
         run: php benchmarks/convert-results.php benchmark.xml > benchmark-results.json
 
       - uses: benchmark-action/github-action-benchmark@v1
+        if: github.repository == 'webonyx/graphql-php'
         with:
           tool: customSmallerIsBetter
           output-file-path: benchmark-results.json


### PR DESCRIPTION
Skips the benchmark history/comment action when workflows run outside webonyx/graphql-php, where the benchmark-results branch may not exist. The PHPBench run itself still executes.

Failure example https://github.com/simPod/graphql-php/actions/runs/27083416968/job/79933283961