### PR TITLE
Apply PHP CS Fixer updates

### DIFF
--- a/tests/Executor/AbstractTest.php
+++ b/tests/Executor/AbstractTest.php
@@ -460,14 +460,14 @@ final class AbstractTest extends TestCase
             ],
         ];
         yield [
-            new class() {
+            new class {
                 public string $__typename = 'Dog';
 
                 public string $name = 'Odie';
 
                 public bool $woofs = true;
             },
-            new class() {
+            new class {
                 public string $__typename = 'Cat';
 
                 public string $name = 'Garfield';

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1223,7 +1223,7 @@ final class ExecutorTest extends TestCase
                     ],
                     'arrayAccess' => [
                         'type' => $ArrayAccess,
-                        'resolve' => static fn (): \ArrayAccess => new class() implements \ArrayAccess {
+                        'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
                             /** @param mixed $offset */
                             #[\ReturnTypeWillChange]
                             public function offsetExists($offset): bool
@@ -1271,7 +1271,7 @@ final class ExecutorTest extends TestCase
                     ],
                     'objectField' => [
                         'type' => $ObjectField,
-                        'resolve' => static fn (): \stdClass => new class() extends \stdClass {
+                        'resolve' => static fn (): \stdClass => new class extends \stdClass {
                             public ?int $set = 1;
 
                             public ?int $unset;
@@ -1279,7 +1279,7 @@ final class ExecutorTest extends TestCase
                     ],
                     'objectVirtual' => [
                         'type' => $ObjectVirtual,
-                        'resolve' => static fn (): object => new class() {
+                        'resolve' => static fn (): object => new class {
                             public function __isset(string $name): bool
                             {
                                 switch ($name) {

--- a/tests/Type/LazyDefinitionTest.php
+++ b/tests/Type/LazyDefinitionTest.php
@@ -53,7 +53,7 @@ final class LazyDefinitionTest extends TestCaseBase
         $objType = new ObjectType([
             'name' => 'SomeObject',
             'fields' => [
-                'f' => new class() {
+                'f' => new class {
                     /**
                      * @throws InvariantViolation
                      *

--- a/tests/Type/ScalarSerializationTest.php
+++ b/tests/Type/ScalarSerializationTest.php
@@ -111,7 +111,7 @@ final class ScalarSerializationTest extends TestCase
         self::assertSame('1', $stringType->serialize(true));
         self::assertSame('', $stringType->serialize(false));
         self::assertSame('', $stringType->serialize(null));
-        self::assertSame('foo', $stringType->serialize(new class() implements \Stringable {
+        self::assertSame('foo', $stringType->serialize(new class implements \Stringable {
             public function __toString(): string
             {
                 return 'foo';

--- a/tests/Validator/CustomRuleTest.php
+++ b/tests/Validator/CustomRuleTest.php
@@ -16,7 +16,7 @@ final class CustomRuleTest extends ValidatorTestCase
 
     public function testAddRuleCanReplaceDefaultRules(): void
     {
-        DocumentValidator::addRule(new class() extends ExecutableDefinitions {
+        DocumentValidator::addRule(new class extends ExecutableDefinitions {
             public function getName(): string
             {
                 return ExecutableDefinitions::class;


### PR DESCRIPTION
## Summary
- Apply PHP CS Fixer formatting after the dependency update
- Remove empty parentheses from anonymous class instantiations in tests