### PR TITLE
feat: make Promise and PromiseAdapter generic over the adopted promise type

### DIFF
--- a/docs/class-reference.md
+++ b/docs/class-reference.md
@@ -1805,6 +1805,8 @@ function toArray(int $debug = 'GraphQL\\Error\\DebugFlag::NONE'): array
 
 Provides a means for integration of async PHP platforms ([related docs](data-fetching.md#async-php)).
 
+@template TAdopted = mixed
+
 ### GraphQL\Executor\Promise\PromiseAdapter Methods
 
 ```php
@@ -1824,6 +1826,8 @@ function isThenable($value): bool
  *
  * @param mixed $thenable
  *
+ * @phpstan-return Promise<TAdopted>
+ *
  * @api
  */
 function convertThenable($thenable): GraphQL\Executor\Promise\Promise
@@ -1833,6 +1837,10 @@ function convertThenable($thenable): GraphQL\Executor\Promise\Promise
 /**
  * Accepts our Promise wrapper, extracts adopted promise out of it and executes actual `then` logic described
  * in Promises/A+ specs. Then returns new wrapped instance of GraphQL\Executor\Promise\Promise.
+ *
+ * @phpstan-param Promise<covariant TAdopted> $promise
+ *
+ * @phpstan-return Promise<TAdopted>
  *
  * @api
  */
@@ -1849,6 +1857,8 @@ function then(
  *
  * @param callable(callable $resolve, callable $reject): void $resolver
  *
+ * @phpstan-return Promise<TAdopted>
+ *
  * @api
  */
 function create(callable $resolver): GraphQL\Executor\Promise\Promise
@@ -1860,6 +1870,8 @@ function create(callable $resolver): GraphQL\Executor\Promise\Promise
  *
  * @param mixed $value
  *
+ * @phpstan-return Promise<TAdopted>
+ *
  * @api
  */
 function createFulfilled($value = null): GraphQL\Executor\Promise\Promise
@@ -1867,9 +1879,9 @@ function createFulfilled($value = null): GraphQL\Executor\Promise\Promise
 
 ```php
 /**
- * Creates a rejected promise for a reason if the reason is not a promise.
+ * Return a promise rejected with the given reason.
  *
- * If the provided reason is a promise, then it is returned as-is.
+ * @phpstan-return Promise<TAdopted>
  *
  * @api
  */
@@ -1882,6 +1894,8 @@ function createRejected(Throwable $reason): GraphQL\Executor\Promise\Promise
  * items in the iterable are fulfilled.
  *
  * @param iterable<Promise|mixed> $promisesOrValues
+ *
+ * @phpstan-return Promise<TAdopted>
  *
  * @api
  */

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,6 +61,22 @@ parameters:
             - src/Executor/Promise
             - examples/04-async-php
 
+        # The v2 AmpPromiseAdapter wraps concrete Amp\Success/Amp\Failure; against the
+        # invariant Amp\Promise<mixed> binding PHPStan reports a return mismatch (as
+        # Amp\Success<mixed> on a v2 install, or bare Amp\Success when v2 is absent on a
+        # v3 install). Tolerate either form / either state.
+        - message: "~Method GraphQL\\\\Executor\\\\Promise\\\\Adapter\\\\AmpPromiseAdapter::create(Fulfilled|Rejected)\\(\\) should return GraphQL\\\\Executor\\\\Promise\\\\Promise<Amp\\\\Promise<mixed>> but returns GraphQL\\\\Executor\\\\Promise\\\\Promise<(Amp\\\\Promise<mixed>\\|)?Amp\\\\(Success|Failure)(<mixed>)?(\\|Amp\\\\Promise<mixed>)?>~"
+          reportUnmatched: false
+          path: src/Executor/Promise/Adapter/AmpPromiseAdapter.php
+
+        # AmpFutureAdapter::createFulfilled()/createRejected() build a concrete Amp\Future
+        # whose generic arg PHPStan infers narrower than the invariant Amp\Future<mixed>
+        # binding. Only reported when amphp/amp v3 is installed (absent under v2), so
+        # tolerate either state.
+        - message: "~Method GraphQL\\\\Executor\\\\Promise\\\\Adapter\\\\AmpFutureAdapter::create(Fulfilled|Rejected)\\(\\) should return GraphQL\\\\Executor\\\\Promise\\\\Promise<Amp\\\\Future<mixed>> but returns GraphQL\\\\Executor\\\\Promise\\\\Promise<Amp\\\\Future(<[a-z]+>)?>~"
+          reportUnmatched: false
+          path: src/Executor/Promise/Adapter/AmpFutureAdapter.php
+
 includes:
     - phpstan-baseline.neon
     - phpstan/include-by-php-version.php

--- a/src/Executor/Promise/Adapter/AmpFutureAdapter.php
+++ b/src/Executor/Promise/Adapter/AmpFutureAdapter.php
@@ -15,6 +15,8 @@ use function Amp\Future\await;
  * Allows integration with amphp/amp v3 (fiber-based futures).
  *
  * @see https://amphp.org/amp
+ *
+ * @implements PromiseAdapter<Future<mixed>>
  */
 class AmpFutureAdapter implements PromiseAdapter
 {
@@ -23,17 +25,26 @@ class AmpFutureAdapter implements PromiseAdapter
         return $value instanceof Future;
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<Future<mixed>>
+     */
     public function convertThenable($thenable): Promise
     {
         return new Promise($thenable, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @phpstan-param Promise<covariant Future<mixed>> $promise
+     *
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<Future<mixed>>
+     */
     public function then(Promise $promise, ?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         $future = $promise->adoptedPromise;
-        assert($future instanceof Future);
 
         $next = async(static function () use ($future, $onFulfilled, $onRejected) {
             try {
@@ -80,6 +91,8 @@ class AmpFutureAdapter implements PromiseAdapter
     /**
      * @throws \Error
      * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<Future<mixed>>
      */
     public function createFulfilled($value = null): Promise
     {
@@ -94,7 +107,11 @@ class AmpFutureAdapter implements PromiseAdapter
         return new Promise(Future::complete($value), $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<Future<mixed>>
+     */
     public function createRejected(\Throwable $reason): Promise
     {
         return new Promise(Future::error($reason), $this);

--- a/src/Executor/Promise/Adapter/AmpPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/AmpPromiseAdapter.php
@@ -12,6 +12,9 @@ use GraphQL\Executor\Promise\PromiseAdapter;
 
 use function Amp\Promise\all;
 
+/**
+ * @implements PromiseAdapter<AmpPromise<mixed>>
+ */
 class AmpPromiseAdapter implements PromiseAdapter
 {
     public function isThenable($value): bool
@@ -25,7 +28,13 @@ class AmpPromiseAdapter implements PromiseAdapter
         return new Promise($thenable, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @phpstan-param Promise<covariant AmpPromise<mixed>> $promise
+     *
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<AmpPromise<mixed>>
+     */
     public function then(Promise $promise, ?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         $deferred = new Deferred();
@@ -42,7 +51,6 @@ class AmpPromiseAdapter implements PromiseAdapter
         };
 
         $ampPromise = $promise->adoptedPromise;
-        assert($ampPromise instanceof AmpPromise);
         $ampPromise->onResolve($onResolve);
 
         return new Promise($deferred->promise(), $this);
@@ -68,6 +76,8 @@ class AmpPromiseAdapter implements PromiseAdapter
     /**
      * @throws \Error
      * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<AmpPromise<mixed>>
      */
     public function createFulfilled($value = null): Promise
     {
@@ -76,7 +86,11 @@ class AmpPromiseAdapter implements PromiseAdapter
         return new Promise($promise, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<AmpPromise<mixed>>
+     */
     public function createRejected(\Throwable $reason): Promise
     {
         $promise = new Failure($reason);

--- a/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/ReactPromiseAdapter.php
@@ -12,6 +12,9 @@ use function React\Promise\all;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
+/**
+ * @implements PromiseAdapter<ReactPromiseInterface<mixed>>
+ */
 class ReactPromiseAdapter implements PromiseAdapter
 {
     public function isThenable($value): bool
@@ -25,16 +28,25 @@ class ReactPromiseAdapter implements PromiseAdapter
         return new Promise($thenable, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @phpstan-param Promise<covariant ReactPromiseInterface<mixed>> $promise
+     *
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<ReactPromiseInterface<mixed>>
+     */
     public function then(Promise $promise, ?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         $reactPromise = $promise->adoptedPromise;
-        assert($reactPromise instanceof ReactPromiseInterface);
 
         return new Promise($reactPromise->then($onFulfilled, $onRejected), $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<ReactPromiseInterface<mixed>>
+     */
     public function create(callable $resolver): Promise
     {
         $reactPromise = new ReactPromise($resolver);
@@ -42,7 +54,11 @@ class ReactPromiseAdapter implements PromiseAdapter
         return new Promise($reactPromise, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<ReactPromiseInterface<mixed>>
+     */
     public function createFulfilled($value = null): Promise
     {
         $reactPromise = resolve($value);
@@ -50,15 +66,24 @@ class ReactPromiseAdapter implements PromiseAdapter
         return new Promise($reactPromise, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<ReactPromiseInterface<mixed>>
+     */
     public function createRejected(\Throwable $reason): Promise
     {
+        /** @var ReactPromiseInterface<mixed> $reactPromise */
         $reactPromise = reject($reason);
 
         return new Promise($reactPromise, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<ReactPromiseInterface<mixed>>
+     */
     public function all(iterable $promisesOrValues): Promise
     {
         foreach ($promisesOrValues as &$promiseOrValue) {
@@ -70,6 +95,7 @@ class ReactPromiseAdapter implements PromiseAdapter
         $promisesOrValuesArray = is_array($promisesOrValues)
             ? $promisesOrValues
             : iterator_to_array($promisesOrValues);
+        /** @var ReactPromiseInterface<mixed> $reactPromise */
         $reactPromise = all($promisesOrValuesArray)->then(static fn (array $values): array => array_map(
             static fn ($key) => $values[$key],
             array_keys($promisesOrValuesArray),

--- a/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
+++ b/src/Executor/Promise/Adapter/SyncPromiseAdapter.php
@@ -11,6 +11,8 @@ use GraphQL\Utils\Utils;
 /**
  * Allows changing order of field resolution even in sync environments
  * (by leveraging queue of deferreds and promises).
+ *
+ * @implements PromiseAdapter<SyncPromise>
  */
 class SyncPromiseAdapter implements PromiseAdapter
 {
@@ -32,11 +34,16 @@ class SyncPromiseAdapter implements PromiseAdapter
         return new Promise($thenable, $this);
     }
 
-    /** @throws InvariantViolation */
+    /**
+     * @phpstan-param Promise<covariant SyncPromise> $promise
+     *
+     * @throws InvariantViolation
+     *
+     * @phpstan-return Promise<SyncPromise>
+     */
     public function then(Promise $promise, ?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         $syncPromise = $promise->adoptedPromise;
-        assert($syncPromise instanceof SyncPromise);
 
         return new Promise($syncPromise->then($onFulfilled, $onRejected), $this);
     }

--- a/src/Executor/Promise/Promise.php
+++ b/src/Executor/Promise/Promise.php
@@ -2,24 +2,34 @@
 
 namespace GraphQL\Executor\Promise;
 
-use Amp\Future as AmpFuture;
-use Amp\Promise as AmpPromise;
 use GraphQL\Error\InvariantViolation;
-use GraphQL\Executor\Promise\Adapter\SyncPromise;
-use React\Promise\PromiseInterface as ReactPromise;
 
 /**
  * Convenience wrapper for promises represented by Promise Adapter.
+ *
+ * The adopted promise is whatever the configured adapter produces (e.g.
+ * {@see \GraphQL\Executor\Promise\Adapter\SyncPromise}, a ReactPHP promise or an
+ * amphp Future). It is kept as a generic so the concrete platform type never has
+ * to be named in this class, which would otherwise require importing a class
+ * that may not exist for the installed platform.
+ *
+ * @template TAdopted = mixed
  */
 class Promise
 {
-    /** @var SyncPromise|ReactPromise<mixed>|AmpFuture<mixed>|AmpPromise<mixed> */
+    /**
+     * @phpstan-var TAdopted
+     *
+     * @readonly
+     */
     public $adoptedPromise;
 
+    /** @phpstan-var PromiseAdapter<TAdopted> */
     private PromiseAdapter $adapter;
 
     /**
-     * @param mixed $adoptedPromise
+     * @phpstan-param TAdopted $adoptedPromise
+     * @phpstan-param PromiseAdapter<TAdopted> $adapter
      *
      * @throws InvariantViolation
      */
@@ -34,6 +44,7 @@ class Promise
         $this->adapter = $adapter;
     }
 
+    /** @phpstan-return Promise<TAdopted> */
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null): Promise
     {
         return $this->adapter->then($this, $onFulfilled, $onRejected);

--- a/src/Executor/Promise/PromiseAdapter.php
+++ b/src/Executor/Promise/PromiseAdapter.php
@@ -4,6 +4,8 @@ namespace GraphQL\Executor\Promise;
 
 /**
  * Provides a means for integration of async PHP platforms ([related docs](data-fetching.md#async-php)).
+ *
+ * @template TAdopted = mixed
  */
 interface PromiseAdapter
 {
@@ -21,6 +23,8 @@ interface PromiseAdapter
      *
      * @param mixed $thenable
      *
+     * @phpstan-return Promise<TAdopted>
+     *
      * @api
      */
     public function convertThenable($thenable): Promise;
@@ -28,6 +32,10 @@ interface PromiseAdapter
     /**
      * Accepts our Promise wrapper, extracts adopted promise out of it and executes actual `then` logic described
      * in Promises/A+ specs. Then returns new wrapped instance of GraphQL\Executor\Promise\Promise.
+     *
+     * @phpstan-param Promise<covariant TAdopted> $promise
+     *
+     * @phpstan-return Promise<TAdopted>
      *
      * @api
      */
@@ -38,6 +46,8 @@ interface PromiseAdapter
      *
      * @param callable(callable $resolve, callable $reject): void $resolver
      *
+     * @phpstan-return Promise<TAdopted>
+     *
      * @api
      */
     public function create(callable $resolver): Promise;
@@ -47,14 +57,16 @@ interface PromiseAdapter
      *
      * @param mixed $value
      *
+     * @phpstan-return Promise<TAdopted>
+     *
      * @api
      */
     public function createFulfilled($value = null): Promise;
 
     /**
-     * Creates a rejected promise for a reason if the reason is not a promise.
+     * Return a promise rejected with the given reason.
      *
-     * If the provided reason is a promise, then it is returned as-is.
+     * @phpstan-return Promise<TAdopted>
      *
      * @api
      */
@@ -65,6 +77,8 @@ interface PromiseAdapter
      * items in the iterable are fulfilled.
      *
      * @param iterable<Promise|mixed> $promisesOrValues
+     *
+     * @phpstan-return Promise<TAdopted>
      *
      * @api
      */

--- a/tests/Executor/Promise/AmpFutureAdapterTest.php
+++ b/tests/Executor/Promise/AmpFutureAdapterTest.php
@@ -49,7 +49,7 @@ final class AmpFutureAdapterTest extends TestCase
 
         $promise = $ampAdapter->convertThenable($future);
 
-        self::assertInstanceOf(Future::class, $promise->adoptedPromise);
+        self::assertSame($future, $promise->adoptedPromise);
     }
 
     public function testThen(): void
@@ -67,8 +67,6 @@ final class AmpFutureAdapterTest extends TestCase
             }
         );
 
-        self::assertInstanceOf(Future::class, $resultPromise->adoptedPromise);
-
         $resultPromise->adoptedPromise->await();
 
         self::assertSame(1, $result);
@@ -81,17 +79,13 @@ final class AmpFutureAdapterTest extends TestCase
             $resolve(1);
         });
 
-        self::assertInstanceOf(Future::class, $resolvedPromise->adoptedPromise);
-
         $result = null;
 
         $resultPromise = $resolvedPromise->then(static function ($value) use (&$result): void {
             $result = $value;
         });
 
-        $resultFuture = $resultPromise->adoptedPromise;
-        self::assertInstanceOf(Future::class, $resultFuture);
-        $resultFuture->await();
+        $resultPromise->adoptedPromise->await();
 
         self::assertSame(1, $result);
     }
@@ -101,17 +95,13 @@ final class AmpFutureAdapterTest extends TestCase
         $ampAdapter = new AmpFutureAdapter();
         $fulfilledPromise = $ampAdapter->createFulfilled(1);
 
-        self::assertInstanceOf(Future::class, $fulfilledPromise->adoptedPromise);
-
         $result = null;
 
         $resultPromise = $fulfilledPromise->then(static function ($value) use (&$result): void {
             $result = $value;
         });
 
-        $resultFuture = $resultPromise->adoptedPromise;
-        self::assertInstanceOf(Future::class, $resultFuture);
-        $resultFuture->await();
+        $resultPromise->adoptedPromise->await();
 
         self::assertSame(1, $result);
     }
@@ -120,8 +110,6 @@ final class AmpFutureAdapterTest extends TestCase
     {
         $ampAdapter = new AmpFutureAdapter();
         $rejectedPromise = $ampAdapter->createRejected(new \Exception('I am a bad promise'));
-
-        self::assertInstanceOf(Future::class, $rejectedPromise->adoptedPromise);
 
         $exception = null;
 
@@ -132,9 +120,7 @@ final class AmpFutureAdapterTest extends TestCase
             }
         );
 
-        $resultFuture = $resultPromise->adoptedPromise;
-        self::assertInstanceOf(Future::class, $resultFuture);
-        $resultFuture->await();
+        $resultPromise->adoptedPromise->await();
 
         self::assertInstanceOf(\Throwable::class, $exception);
         self::assertSame('I am a bad promise', $exception->getMessage());
@@ -146,8 +132,6 @@ final class AmpFutureAdapterTest extends TestCase
         $promises = [Future::complete(1), Future::complete(2), Future::complete(3)];
 
         $allPromise = $ampAdapter->all($promises);
-
-        self::assertInstanceOf(Future::class, $allPromise->adoptedPromise);
 
         $result = $allPromise->adoptedPromise->await();
 
@@ -164,9 +148,7 @@ final class AmpFutureAdapterTest extends TestCase
 
         $deferred->complete(3);
 
-        $allFuture = $allPromise->adoptedPromise;
-        self::assertInstanceOf(Future::class, $allFuture);
-        $result = $allFuture->await();
+        $result = $allPromise->adoptedPromise->await();
 
         self::assertSame([1, 2, 3, 4], $result);
     }

--- a/tests/Executor/Promise/AmpPromiseAdapterTest.php
+++ b/tests/Executor/Promise/AmpPromiseAdapterTest.php
@@ -76,7 +76,6 @@ final class AmpPromiseAdapterTest extends TestCase
         );
 
         self::assertSame(1, $result);
-        self::assertInstanceOf(Promise::class, $resultPromise->adoptedPromise);
     }
 
     public function testCreate(): void
@@ -85,8 +84,6 @@ final class AmpPromiseAdapterTest extends TestCase
         $resolvedPromise = $ampAdapter->create(static function ($resolve): void {
             $resolve(1);
         });
-
-        self::assertInstanceOf(Promise::class, $resolvedPromise->adoptedPromise);
 
         $result = null;
 
@@ -139,8 +136,6 @@ final class AmpPromiseAdapterTest extends TestCase
         $promises = [new Success(1), new Success(2), new Success(3)];
 
         $allPromise = $ampAdapter->all($promises);
-
-        self::assertInstanceOf(Promise::class, $allPromise->adoptedPromise);
 
         $result = null;
 

--- a/tests/Executor/Promise/SyncPromiseAdapterTest.php
+++ b/tests/Executor/Promise/SyncPromiseAdapterTest.php
@@ -37,7 +37,7 @@ final class SyncPromiseAdapterTest extends TestCase
         $dfd = new Deferred(static function (): void {});
         $result = $this->promises->convertThenable($dfd);
 
-        self::assertInstanceOf(SyncPromise::class, $result->adoptedPromise);
+        self::assertSame($dfd, $result->adoptedPromise);
 
         $this->expectException(InvariantViolation::class);
         $this->expectExceptionMessage('Expected instance of GraphQL\Deferred, got (empty string)');
@@ -51,14 +51,12 @@ final class SyncPromiseAdapterTest extends TestCase
 
         $result = $this->promises->then($promise);
 
-        self::assertInstanceOf(SyncPromise::class, $result->adoptedPromise);
+        self::assertNotSame($promise, $result);
     }
 
     public function testCreatePromise(): void
     {
-        $promise = $this->promises->create(static function ($resolve, $reject): void {});
-
-        self::assertInstanceOf(SyncPromise::class, $promise->adoptedPromise);
+        $this->promises->create(static function ($resolve, $reject): void {});
 
         $promise = $this->promises->create(static function ($resolve, $reject): void {
             $resolve('A');
@@ -200,13 +198,9 @@ final class SyncPromiseAdapterTest extends TestCase
         // until all pending promises are resolved
         self::assertSame(2, $result);
 
-        $p3AdoptedPromise = $p3->adoptedPromise;
-        self::assertInstanceOf(SyncPromise::class, $p3AdoptedPromise);
-        self::assertSame(SyncPromise::FULFILLED, $p3AdoptedPromise->state);
+        self::assertSame(SyncPromise::FULFILLED, $p3->adoptedPromise->state);
 
-        $allAdoptedPromise = $all->adoptedPromise;
-        self::assertInstanceOf(SyncPromise::class, $allAdoptedPromise);
-        self::assertSame(SyncPromise::FULFILLED, $allAdoptedPromise->state);
+        self::assertSame(SyncPromise::FULFILLED, $all->adoptedPromise->state);
 
         self::assertSame([1, 2, 3, 4], $called);
 


### PR DESCRIPTION
## Problem

`GraphQL\Executor\Promise\Promise` documents `$adoptedPromise` with a `@var` union naming every supported platform type, which requires importing both `Amp\Future` and `Amp\Promise`:

```php
/** @var SyncPromise|ReactPromise<mixed>|AmpFuture<mixed>|AmpPromise<mixed> */
public $adoptedPromise;
```

amphp/amp v2 ships `Amp\Promise` and v3 ships `Amp\Future`, so on any single installation one of those classes does not exist. Because the property is read by consumers, static analysis resolves the whole union and crashes on the missing class — e.g. PHPStan:

> Internal error: Class Amp\Promise was not found while trying to analyse it

## Change

Make `Promise` and `PromiseAdapter` generic over `TAdopted`, with each adapter binding the concrete platform type:

- `SyncPromiseAdapter` → `PromiseAdapter<SyncPromise>`
- `ReactPromiseAdapter` → `PromiseAdapter<React\Promise\PromiseInterface<mixed>>`
- `AmpFutureAdapter` → `PromiseAdapter<Amp\Future<mixed>>`
- `AmpPromiseAdapter` → `PromiseAdapter<Amp\Promise<mixed>>`

`Promise` no longer names any optional platform class, so it analyses cleanly regardless of which promise library is installed. The adapters gain `@phpstan-return Promise<T>` annotations and shed now-redundant `assert()`/`instanceof` guards; adapter tests drop `assertInstanceOf` assertions the generics make statically provable.

`TAdopted` defaults to `mixed`, so existing bare `Promise`/`PromiseAdapter` references are unchanged — **not a BC break**.