### PR TITLE
perf(amp): avoid fibers in future adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Avoid creating an AMPHP Fiber for each `AmpFutureAdapter` continuation and aggregate https://github.com/webonyx/graphql-php/pull/1954
+
 ## v15.35.0
 
 ### Added

--- a/src/Executor/Promise/Adapter/AmpFutureAdapter.php
+++ b/src/Executor/Promise/Adapter/AmpFutureAdapter.php
@@ -8,9 +8,6 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Executor\Promise\PromiseAdapter;
 
-use function Amp\async;
-use function Amp\Future\await;
-
 /**
  * Allows integration with amphp/amp v3 (fiber-based futures).
  *
@@ -46,25 +43,38 @@ class AmpFutureAdapter implements PromiseAdapter
     {
         $future = $promise->adoptedPromise;
 
-        $next = async(static function () use ($future, $onFulfilled, $onRejected) {
-            try {
-                $value = $future->await();
-            } catch (\Throwable $reason) {
+        $deferred = new DeferredFuture();
+
+        static::observeFuture(
+            $future,
+            static function ($value) use ($deferred, $onFulfilled): void {
+                try {
+                    static::resolveDeferred(
+                        $deferred,
+                        $onFulfilled === null
+                            ? $value
+                            : $onFulfilled($value)
+                    );
+                } catch (\Throwable $fulfillmentException) {
+                    $deferred->error($fulfillmentException);
+                }
+            },
+            static function (\Throwable $exception) use ($deferred, $onRejected): void {
                 if ($onRejected === null) {
-                    throw $reason;
+                    $deferred->error($exception);
+
+                    return;
                 }
 
-                return static::unwrapResult($onRejected($reason));
+                try {
+                    static::resolveDeferred($deferred, $onRejected($exception));
+                } catch (\Throwable $rejectionException) {
+                    $deferred->error($rejectionException);
+                }
             }
+        );
 
-            if ($onFulfilled === null) {
-                return $value;
-            }
-
-            return static::unwrapResult($onFulfilled($value));
-        });
-
-        return new Promise($next, $this);
+        return new Promise($deferred->getFuture(), $this);
     }
 
     /** @throws InvariantViolation */
@@ -127,8 +137,9 @@ class AmpFutureAdapter implements PromiseAdapter
             ? $promisesOrValues
             : iterator_to_array($promisesOrValues);
 
-        /** @var array<Future<mixed>> $futures */
-        $futures = [];
+        $deferredFuture = new DeferredFuture();
+        $future = $deferredFuture->getFuture();
+        $remaining = 0;
 
         foreach ($items as $key => $item) {
             if ($item instanceof Promise) {
@@ -136,21 +147,38 @@ class AmpFutureAdapter implements PromiseAdapter
             }
 
             if ($item instanceof Future) {
-                $futures[$key] = $item;
+                ++$remaining;
+                static::observeFuture(
+                    $item,
+                    static function ($value) use (&$items, $key, $deferredFuture, $future, &$remaining): void {
+                        if ($future->isComplete()) {
+                            return;
+                        }
+
+                        $items[$key] = $value;
+                        --$remaining;
+                        if ($remaining !== 0) {
+                            return;
+                        }
+
+                        $deferredFuture->complete($items);
+                    },
+                    static function (\Throwable $exception) use ($deferredFuture, $future): void {
+                        if ($future->isComplete()) {
+                            return;
+                        }
+
+                        $deferredFuture->error($exception);
+                    }
+                );
             }
         }
 
-        $combined = async(static function () use ($items, $futures): array {
-            if ($futures === []) {
-                return $items;
-            }
+        if ($remaining === 0 && ! $future->isComplete()) {
+            $deferredFuture->complete($items);
+        }
 
-            $resolved = await($futures);
-
-            return array_replace($items, $resolved);
-        });
-
-        return new Promise($combined, $this);
+        return new Promise($future, $this);
     }
 
     /**
@@ -164,13 +192,15 @@ class AmpFutureAdapter implements PromiseAdapter
         }
 
         if ($value instanceof Future) {
-            async(static function () use ($deferred, $value): void {
-                try {
-                    $deferred->complete($value->await());
-                } catch (\Throwable $exception) {
+            static::observeFuture(
+                $value,
+                static function ($value) use ($deferred): void {
+                    $deferred->complete($value);
+                },
+                static function (\Throwable $exception) use ($deferred): void {
                     $deferred->error($exception);
                 }
-            });
+            );
 
             return;
         }
@@ -179,20 +209,21 @@ class AmpFutureAdapter implements PromiseAdapter
     }
 
     /**
-     * @param mixed $value
+     * @template T
      *
-     * @return mixed
+     * @param Future<T> $future
+     * @param \Closure(T): void $onFulfilled
+     * @param \Closure(\Throwable): void $onRejected
      */
-    protected static function unwrapResult($value)
+    protected static function observeFuture(Future $future, \Closure $onFulfilled, \Closure $onRejected): void
     {
-        if ($value instanceof Promise) {
-            $value = $value->adoptedPromise;
-        }
-
-        if ($value instanceof Future) {
-            return $value->await();
-        }
-
-        return $value;
+        $future
+            ->map(static function ($value) use ($onFulfilled): void {
+                $onFulfilled($value);
+            })
+            ->catch(static function (\Throwable $exception) use ($onRejected): void {
+                $onRejected($exception);
+            })
+            ->ignore();
     }
 }

--- a/tests/Executor/Promise/AmpFutureAdapterTest.php
+++ b/tests/Executor/Promise/AmpFutureAdapterTest.php
@@ -72,6 +72,78 @@ final class AmpFutureAdapterTest extends TestCase
         self::assertSame(1, $result);
     }
 
+    public function testThenUnwrapsFutureReturnedByFulfillmentCallback(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $deferred = new DeferredFuture();
+        $promise = $ampAdapter->convertThenable(Future::complete(1));
+
+        $resultPromise = $ampAdapter->then($promise, static function ($value) use ($deferred): Future {
+            self::assertSame(1, $value);
+
+            return $deferred->getFuture();
+        });
+
+        $deferred->complete(2);
+
+        self::assertSame(2, $resultPromise->adoptedPromise->await());
+    }
+
+    public function testThenDoesNotInvokeRejectionCallbackForFulfillmentCallbackException(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $promise = $ampAdapter->convertThenable(Future::complete());
+
+        $resultPromise = $ampAdapter->then(
+            $promise,
+            static function ($value): void {
+                self::assertNull($value);
+
+                throw new \RuntimeException('fulfillment failed');
+            },
+            static function (\Throwable $reason): void {
+                self::fail('The rejection callback must not run for a fulfillment callback exception.');
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('fulfillment failed');
+
+        $resultPromise->adoptedPromise->await();
+    }
+
+    public function testThenRejectsWhenNoRejectionCallbackIsProvided(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $promise = $ampAdapter->convertThenable(Future::error(new \RuntimeException('failed')));
+        $resultPromise = $ampAdapter->then($promise);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        $resultPromise->adoptedPromise->await();
+    }
+
+    public function testThenRejectsWhenRejectionCallbackThrows(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $promise = $ampAdapter->convertThenable(Future::error(new \RuntimeException('failed')));
+        $resultPromise = $ampAdapter->then(
+            $promise,
+            null,
+            static function (\Throwable $reason): void {
+                self::assertSame('failed', $reason->getMessage());
+
+                throw new \RuntimeException('rejection failed');
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('rejection failed');
+
+        $resultPromise->adoptedPromise->await();
+    }
+
     public function testCreate(): void
     {
         $ampAdapter = new AmpFutureAdapter();
@@ -88,6 +160,31 @@ final class AmpFutureAdapterTest extends TestCase
         $resultPromise->adoptedPromise->await();
 
         self::assertSame(1, $result);
+    }
+
+    public function testCreateUnwrapsPromise(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $nestedPromise = $ampAdapter->createFulfilled(1);
+        $promise = $ampAdapter->create(static function ($resolve) use ($nestedPromise): void {
+            $resolve($nestedPromise);
+        });
+
+        self::assertSame(1, $promise->adoptedPromise->await());
+    }
+
+    public function testCreateRejectsWhenNestedFutureFails(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $future = Future::error(new \RuntimeException('failed'));
+        $promise = $ampAdapter->create(static function ($resolve) use ($future): void {
+            $resolve($future);
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        $promise->adoptedPromise->await();
     }
 
     public function testCreateFulfilled(): void
@@ -126,6 +223,27 @@ final class AmpFutureAdapterTest extends TestCase
         self::assertSame('I am a bad promise', $exception->getMessage());
     }
 
+    public function testThenUnwrapsFutureReturnedByRejectionCallback(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $deferred = new DeferredFuture();
+        $promise = $ampAdapter->convertThenable(Future::error(new \RuntimeException('failed')));
+
+        $resultPromise = $ampAdapter->then(
+            $promise,
+            null,
+            static function (\Throwable $reason) use ($deferred): Future {
+                self::assertSame('failed', $reason->getMessage());
+
+                return $deferred->getFuture();
+            }
+        );
+
+        $deferred->complete('recovered');
+
+        self::assertSame('recovered', $resultPromise->adoptedPromise->await());
+    }
+
     public function testAll(): void
     {
         $ampAdapter = new AmpFutureAdapter();
@@ -138,11 +256,23 @@ final class AmpFutureAdapterTest extends TestCase
         self::assertSame([1, 2, 3], $result);
     }
 
-    public function testAllShouldPreserveTheOrderOfTheArrayWhenResolvingAsyncPromises(): void
+    public function testAllResolvesEmptyIterable(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+
+        self::assertSame([], $ampAdapter->all([])->adoptedPromise->await());
+    }
+
+    public function testAllShouldPreserveKeysWhenResolvingAsyncPromises(): void
     {
         $ampAdapter = new AmpFutureAdapter();
         $deferred = new DeferredFuture();
-        $promises = [Future::complete(1), 2, $deferred->getFuture(), Future::complete(4)];
+        $promises = [
+            'first' => Future::complete(1),
+            'second' => 2,
+            'third' => $deferred->getFuture(),
+            'fourth' => Future::complete(4),
+        ];
 
         $allPromise = $ampAdapter->all($promises);
 
@@ -150,6 +280,85 @@ final class AmpFutureAdapterTest extends TestCase
 
         $result = $allPromise->adoptedPromise->await();
 
-        self::assertSame([1, 2, 3, 4], $result);
+        self::assertSame([
+            'first' => 1,
+            'second' => 2,
+            'third' => 3,
+            'fourth' => 4,
+        ], $result);
+    }
+
+    public function testAllAcceptsPromisesInIterables(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $promise = $ampAdapter->createFulfilled(1);
+        $promises = (static function () use ($promise): \Generator {
+            yield 'promise' => $promise;
+            yield 'future' => Future::complete(2);
+        })();
+
+        $allPromise = $ampAdapter->all($promises);
+
+        self::assertSame(['promise' => 1, 'future' => 2], $allPromise->adoptedPromise->await());
+    }
+
+    public function testAllRejectsWhenOneFutureFails(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $deferred = new DeferredFuture();
+        $allPromise = $ampAdapter->all([
+            'resolved' => Future::complete(1),
+            'rejected' => $deferred->getFuture(),
+        ]);
+
+        $deferred->error(new \RuntimeException('failed'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        $allPromise->adoptedPromise->await();
+    }
+
+    public function testAllRemainsRejectedWhenAnotherFutureResolves(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $rejected = new DeferredFuture();
+        $resolved = new DeferredFuture();
+        $allPromise = $ampAdapter->all([$rejected->getFuture(), $resolved->getFuture()]);
+
+        $rejected->error(new \RuntimeException('failed'));
+        $resolved->complete('resolved');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        $allPromise->adoptedPromise->await();
+    }
+
+    public function testAllIgnoresOtherFuturesAfterRejection(): void
+    {
+        $ampAdapter = new AmpFutureAdapter();
+        $rejected = new DeferredFuture();
+        $resolved = new DeferredFuture();
+        $alsoRejected = new DeferredFuture();
+        $allPromise = $ampAdapter->all([
+            $rejected->getFuture(),
+            $resolved->getFuture(),
+            $alsoRejected->getFuture(),
+        ]);
+
+        $rejected->error(new \RuntimeException('failed'));
+
+        try {
+            $allPromise->adoptedPromise->await();
+            self::fail('Expected aggregate rejection.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('failed', $exception->getMessage());
+        }
+
+        $resolved->complete('resolved');
+        $alsoRejected->error(new \RuntimeException('also failed'));
+
+        async(static function (): void {})->await();
     }
 }


### PR DESCRIPTION
## Context
`AmpFutureAdapter` created an AMPHP Fiber for every promise continuation and aggregate. Wide GraphQL result graphs therefore retained many Fiber states and event-loop callbacks even when the underlying Futures only represented batched work.

## Decision
Compose and aggregate Futures through `map()` and `catch()` callbacks, settling one `DeferredFuture` while retaining Promise fulfillment, rejection, and nested-Future flattening semantics.

## Consequences
- Reduces per-field allocation and event-loop scheduling for wide asynchronous result graphs.
- Preserves deferred completion for genuinely asynchronous resolvers.
- Adds coverage for nested Future fulfillment/recovery, fulfillment errors, aggregate key preservation, aggregate rejection, and resolution after rejection.

## Benchmark

On the same wide GraphQL result graph with 838 parent objects and three Future-backed fields:

| Adapter | CPU time | Peak memory |
|---|---:|---:|
| Synchronous adapter | 1.48s | 122MB |
| Existing AMPHP adapter | 2.11s | 274MB |
| This change | 1.67-1.70s | 149MB |

Relative to the existing AMPHP adapter, this reduces CPU time by about 19% and peak memory by about 46%. The remaining overhead compared with the synchronous adapter is about 13-15% CPU and 22% memory.

## Disclosure

This change was identified while migrating a production GraphQL application that is not yet fully migrated to asynchronous resolving. It is a step toward that migration, rather than a claim of end-to-end asynchronous production use.