### PR TITLE
Revert "If an object implements \ArrayAccess, check both array value and property"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Revert reading properties of objects that implement `\ArrayAccess`, it exposed internal object state as field values https://github.com/webonyx/graphql-php/pull/1958
+- Revert reading properties of objects that implement `\ArrayAccess` because it exposed internal object state as field values https://github.com/webonyx/graphql-php/pull/1958
 
 ## v15.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Revert reading properties of objects that implement `\ArrayAccess`, it exposed internal object state as field values https://github.com/webonyx/graphql-php/pull/1958
+
 ## v15.37.0
 
 ### Added

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -268,14 +268,8 @@ class Utils
      */
     public static function extractKey($objectLikeValue, string $key)
     {
-        if (is_array($objectLikeValue)) {
+        if (is_array($objectLikeValue) || $objectLikeValue instanceof \ArrayAccess) {
             return $objectLikeValue[$key] ?? null;
-        }
-
-        if ($objectLikeValue instanceof \ArrayAccess) {
-            return $objectLikeValue[$key]
-                ?? $objectLikeValue->{$key} // @phpstan-ignore-line Variable property access on ArrayAccess is fine here, we do the same for arbitrary objects
-                ?? null;
         }
 
         if (is_object($objectLikeValue)) {

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1376,8 +1376,8 @@ final class ExecutorTest extends TestCase
                                 'property' => Type::int(),
                             ],
                         ]),
-                        // Eloquent models implement \ArrayAccess to expose their attributes,
-                        // their properties hold internal state that must stay hidden
+                        // Eloquent models implement \ArrayAccess to expose their attributes.
+                        // Their properties hold internal state that must stay hidden.
                         // https://github.com/webonyx/graphql-php/pull/1531
                         'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
                             public ?int $property = 1;

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1190,7 +1190,6 @@ final class ExecutorTest extends TestCase
             'name' => 'ArrayAccess',
             'fields' => [
                 'set' => Type::int(),
-                'setProperty' => Type::int(),
                 'unsetNull' => Type::int(),
                 'unsetThrow' => Type::int(),
             ],
@@ -1225,8 +1224,6 @@ final class ExecutorTest extends TestCase
                     'arrayAccess' => [
                         'type' => $ArrayAccess,
                         'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
-                            public ?int $setProperty = 1;
-
                             /** @param mixed $offset */
                             #[\ReturnTypeWillChange]
                             public function offsetExists($offset): bool
@@ -1320,7 +1317,6 @@ final class ExecutorTest extends TestCase
                 }
                 arrayAccess {
                     set
-                    setProperty
                     unsetNull
                     unsetThrow
                 }
@@ -1348,7 +1344,6 @@ final class ExecutorTest extends TestCase
                     ],
                     'arrayAccess' => [
                         'set' => 1,
-                        'setProperty' => 1,
                         'unsetNull' => null,
                         'unsetThrow' => null,
                     ],
@@ -1361,6 +1356,77 @@ final class ExecutorTest extends TestCase
                         'set' => 1,
                         'unsetNull' => null,
                         'unsetThrow' => null,
+                    ],
+                ],
+            ],
+            $result->toArray()
+        );
+    }
+
+    public function testDefaultResolverDoesNotAccessPropertiesOfArrayAccess(): void
+    {
+        $schema = new Schema([
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => [
+                    'arrayAccess' => [
+                        'type' => new ObjectType([
+                            'name' => 'ArrayAccess',
+                            'fields' => [
+                                'property' => Type::int(),
+                            ],
+                        ]),
+                        // Eloquent models implement \ArrayAccess to expose their attributes,
+                        // their properties hold internal state that must stay hidden
+                        // https://github.com/webonyx/graphql-php/pull/1531
+                        'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
+                            public ?int $property = 1;
+
+                            /** @param mixed $offset */
+                            #[\ReturnTypeWillChange]
+                            public function offsetExists($offset): bool
+                            {
+                                return false;
+                            }
+
+                            /** @param mixed $offset */
+                            #[\ReturnTypeWillChange]
+                            public function offsetGet($offset): ?int
+                            {
+                                return null;
+                            }
+
+                            /**
+                             * @param mixed $offset
+                             * @param mixed $value
+                             */
+                            #[\ReturnTypeWillChange]
+                            public function offsetSet($offset, $value): void {}
+
+                            /** @param mixed $offset */
+                            #[\ReturnTypeWillChange]
+                            public function offsetUnset($offset): void {}
+                        },
+                    ],
+                ],
+            ]),
+        ]);
+
+        $query = Parser::parse('
+            {
+                arrayAccess {
+                    property
+                }
+            }
+        ');
+
+        $result = Executor::execute($schema, $query);
+
+        self::assertSame(
+            [
+                'data' => [
+                    'arrayAccess' => [
+                        'property' => null,
                     ],
                 ],
             ],


### PR DESCRIPTION
Reverts #1531, released in [v15.37.0](https://github.com/webonyx/graphql-php/releases/tag/v15.37.0).

Objects implement `\ArrayAccess` to expose a curated set of values. The most prominent case is Eloquent models, where array access maps to attributes — a model may well hold unrelated internal state in ordinary PHP properties. Falling back to property access leaks that state as field values, and worse, shadows fields that are meant to resolve to `null`.

This shows up as widespread failures in Lighthouse: https://github.com/nuwave/lighthouse/actions/runs/30370354427 — `PropertyAccessTest::testPhpProperty` asserts that a plain PHP property on a model does not resolve, which v15.37.0 turns into the property value.

The added test pins the reverted behaviour so it cannot regress again.

@shish sorry for the churn. The original problem is real, but it needs an opt-in mechanism rather than a change to the default resolver — every object implementing `\ArrayAccess` is affected otherwise. A custom `fieldResolver` (or `resolve` on the affected fields) solves it today.