### PR TITLE
Remove default values from public properties always assigned in the constructor

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -42,7 +42,7 @@ The following elements are part of the stable public API:
 
 After merging a PR and releasing:
 
-1. Merge the PR via `gh pr merge` (use `--merge` for a merge commit)
+1. Merge the PR via `gh pr merge --squash`, or `--rebase` when the commit history is already clean (merge commits are disabled)
 2. Pull latest master: `git pull`
 3. Update CHANGELOG.md: move the entry from `## Unreleased` into a new versioned section (e.g. `## v15.32.0`), add the PR URL as a reference, leave an empty `## Unreleased` at the top
 4. Commit and push the CHANGELOG update to master
@@ -52,3 +52,4 @@ After merging a PR and releasing:
 Version bump rules (semver):
 - New feature → minor bump (v15.31.x → v15.32.0)
 - Bug fix / change → patch bump (v15.31.x → v15.31.x+1)
+- Breaking change → major bump: label the PR `breaking change` and leave it open for the next major release instead of merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Changed
+
+- Remove default values from public properties that are always assigned in the constructor https://github.com/webonyx/graphql-php/pull/1959
+
 ## v15.37.1
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ If your contribution requires significant or breaking changes, or if you plan to
 we recommend you to [create an issue](https://github.com/webonyx/graphql-php/issues/new)
 with a brief proposal and discuss it with us first.
 
+Breaking changes are collected for the next major release.
+Maintainers mark such pull requests with the [`breaking change`](https://github.com/webonyx/graphql-php/labels/breaking%20change) label, which may keep them open for a while.
+
 For smaller contributions use this workflow:
 
 1. Fork the project.

--- a/examples/04-async-php/reactphp/hello-world-http-server/graphql.php
+++ b/examples/04-async-php/reactphp/hello-world-http-server/graphql.php
@@ -33,7 +33,7 @@ $queryType = new ObjectType([
             'resolve' => function ($rootValue, array $args) {
                 $deferred = new \React\Promise\Deferred();
                 $promise = $deferred->promise();
-                $promise = $promise = $promise->then(static fn (): string => $rootValue['prefix'] . $args['message']);
+                $promise = $promise->then(static fn (): string => $rootValue['prefix'] . $args['message']);
                 $deferred->resolve(null);
 
                 return $promise;

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,6 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
         Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector::class => [
             __DIR__ . '/src/Type/Definition/CustomScalarType.php', // Refines PHPDoc types
         ],
-        Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector::class, // TODO reintroduce in v16 https://github.com/webonyx/graphql-php/pull/1959 - dropping defaults from public properties breaks reading them when the constructor is bypassed
         Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector::class, // TODO reintroduce when https://github.com/rectorphp/rector-src/pull/4491 is released
         Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector::class, // Sometimes necessary to prove runtime behavior matches defined types
         Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class, // Sometimes nicer for symmetry

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,9 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
         Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector::class => [
             __DIR__ . '/src/Type/Definition/CustomScalarType.php', // Refines PHPDoc types
         ],
+        Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector::class, // TODO reintroduce in v16 https://github.com/webonyx/graphql-php/pull/1959 - dropping defaults from public properties breaks reading them when the constructor is bypassed
         Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector::class, // TODO reintroduce when https://github.com/rectorphp/rector-src/pull/4491 is released
+        Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector::class, // Sometimes necessary to prove runtime behavior matches defined types
         Rector\PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class, // Sometimes nicer for symmetry
         Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class, // Prefer self::
         Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector::class => [

--- a/src/Executor/ExecutionResult.php
+++ b/src/Executor/ExecutionResult.php
@@ -40,7 +40,7 @@ class ExecutionResult implements \JsonSerializable
      *
      * @var array<string, mixed>|null
      */
-    public ?array $data = null;
+    public ?array $data;
 
     /**
      * Errors registered during query execution.
@@ -52,7 +52,7 @@ class ExecutionResult implements \JsonSerializable
      *
      * @var list<Error>
      */
-    public array $errors = [];
+    public array $errors;
 
     /**
      * User-defined serializable array of extensions included in serialized result.
@@ -61,7 +61,7 @@ class ExecutionResult implements \JsonSerializable
      *
      * @var array<string, mixed>|null
      */
-    public ?array $extensions = null;
+    public ?array $extensions;
 
     /**
      * @var callable|null

--- a/src/Language/AST/Location.php
+++ b/src/Language/AST/Location.php
@@ -20,13 +20,13 @@ class Location
     public int $end;
 
     /** The Token at which this Node begins. */
-    public ?Token $startToken = null;
+    public ?Token $startToken;
 
     /** The Token at which this Node ends. */
-    public ?Token $endToken = null;
+    public ?Token $endToken;
 
     /** The Source document the AST represents. */
-    public ?Source $source = null;
+    public ?Source $source;
 
     public static function create(int $start, int $end): self
     {

--- a/src/Type/Definition/ResolveInfo.php
+++ b/src/Type/Definition/ResolveInfo.php
@@ -98,7 +98,7 @@ class ResolveInfo
      *
      * @var array<string, FragmentDefinitionNode>
      */
-    public array $fragments = [];
+    public array $fragments;
 
     /**
      * Root value passed to query execution.
@@ -123,7 +123,7 @@ class ResolveInfo
      *
      * @var array<string, mixed>
      */
-    public array $variableValues = [];
+    public array $variableValues;
 
     /**
      * @param \ArrayObject<int, FieldNode> $fieldNodes

--- a/src/Type/Schema.php
+++ b/src/Type/Schema.php
@@ -78,7 +78,7 @@ class Schema
     public ?SchemaDefinitionNode $astNode;
 
     /** @var array<SchemaExtensionNode> */
-    public array $extensionASTNodes = [];
+    public array $extensionASTNodes;
 
     /**
      * @param SchemaConfig|array<string, mixed> $config


### PR DESCRIPTION
Rector's `RemoveDefaultValueFromAssignedPropertyRector` flags nine public property declarations as carrying redundant defaults, because every constructor provably assigns them:

| File | Properties |
| --- | --- |
| `src/Executor/ExecutionResult.php` | `$data`, `$errors`, `$extensions` |
| `src/Language/AST/Location.php` | `$startToken`, `$endToken`, `$source` |
| `src/Type/Definition/ResolveInfo.php` | `$fragments`, `$variableValues` |
| `src/Type/Schema.php` | `$extensionASTNodes` |

The defaults remain observable through paths that bypass the constructor: `unserialize()`, `ReflectionClass::newInstanceWithoutConstructor()`, and subclasses that skip `parent::__construct()`.
Those go from reading `null` or `[]` to `Error: Typed property must not be accessed before initialization`.

All nine are `public` on non-final classes, and `ExecutionResult` in particular is handed to user code on every execution, so this is deferred to the next major release.

Until then `rector.php` skips the rule so `make fix` does not keep reintroducing the change. This branch removes that skip entry again.