### PR TITLE
Reapply reading properties of objects that implement \ArrayAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- If an object implements `\ArrayAccess`, check both array value and property https://github.com/webonyx/graphql-php/pull/1960
+
 ## v15.37.1
 
 ### Fixed

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -268,8 +268,14 @@ class Utils
      */
     public static function extractKey($objectLikeValue, string $key)
     {
-        if (is_array($objectLikeValue) || $objectLikeValue instanceof \ArrayAccess) {
+        if (is_array($objectLikeValue)) {
             return $objectLikeValue[$key] ?? null;
+        }
+
+        if ($objectLikeValue instanceof \ArrayAccess) {
+            return $objectLikeValue[$key]
+                ?? $objectLikeValue->{$key} // @phpstan-ignore-line Variable property access on ArrayAccess is fine here, we do the same for arbitrary objects
+                ?? null;
         }
 
         if (is_object($objectLikeValue)) {

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1190,6 +1190,7 @@ final class ExecutorTest extends TestCase
             'name' => 'ArrayAccess',
             'fields' => [
                 'set' => Type::int(),
+                'setProperty' => Type::int(),
                 'unsetNull' => Type::int(),
                 'unsetThrow' => Type::int(),
             ],
@@ -1224,6 +1225,8 @@ final class ExecutorTest extends TestCase
                     'arrayAccess' => [
                         'type' => $ArrayAccess,
                         'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
+                            public ?int $setProperty = 1;
+
                             /** @param mixed $offset */
                             #[\ReturnTypeWillChange]
                             public function offsetExists($offset): bool
@@ -1317,6 +1320,7 @@ final class ExecutorTest extends TestCase
                 }
                 arrayAccess {
                     set
+                    setProperty
                     unsetNull
                     unsetThrow
                 }
@@ -1344,6 +1348,7 @@ final class ExecutorTest extends TestCase
                     ],
                     'arrayAccess' => [
                         'set' => 1,
+                        'setProperty' => 1,
                         'unsetNull' => null,
                         'unsetThrow' => null,
                     ],
@@ -1356,77 +1361,6 @@ final class ExecutorTest extends TestCase
                         'set' => 1,
                         'unsetNull' => null,
                         'unsetThrow' => null,
-                    ],
-                ],
-            ],
-            $result->toArray()
-        );
-    }
-
-    public function testDefaultResolverDoesNotAccessPropertiesOfArrayAccess(): void
-    {
-        $schema = new Schema([
-            'query' => new ObjectType([
-                'name' => 'Query',
-                'fields' => [
-                    'arrayAccess' => [
-                        'type' => new ObjectType([
-                            'name' => 'ArrayAccess',
-                            'fields' => [
-                                'property' => Type::int(),
-                            ],
-                        ]),
-                        // Eloquent models implement \ArrayAccess to expose their attributes.
-                        // Their properties hold internal state that must stay hidden.
-                        // https://github.com/webonyx/graphql-php/pull/1531
-                        'resolve' => static fn (): \ArrayAccess => new class implements \ArrayAccess {
-                            public ?int $property = 1;
-
-                            /** @param mixed $offset */
-                            #[\ReturnTypeWillChange]
-                            public function offsetExists($offset): bool
-                            {
-                                return false;
-                            }
-
-                            /** @param mixed $offset */
-                            #[\ReturnTypeWillChange]
-                            public function offsetGet($offset): ?int
-                            {
-                                return null;
-                            }
-
-                            /**
-                             * @param mixed $offset
-                             * @param mixed $value
-                             */
-                            #[\ReturnTypeWillChange]
-                            public function offsetSet($offset, $value): void {}
-
-                            /** @param mixed $offset */
-                            #[\ReturnTypeWillChange]
-                            public function offsetUnset($offset): void {}
-                        },
-                    ],
-                ],
-            ]),
-        ]);
-
-        $query = Parser::parse('
-            {
-                arrayAccess {
-                    property
-                }
-            }
-        ');
-
-        $result = Executor::execute($schema, $query);
-
-        self::assertSame(
-            [
-                'data' => [
-                    'arrayAccess' => [
-                        'property' => null,
                     ],
                 ],
             ],


### PR DESCRIPTION
Reapplies https://github.com/webonyx/graphql-php/pull/1531, which shipped in v15.37.0 and was reverted in https://github.com/webonyx/graphql-php/pull/1958 for v15.37.1.

`Utils::extractKey()` gains a dedicated `\ArrayAccess` branch that falls back to property access when the offset does not exist:

```php
if ($objectLikeValue instanceof \ArrayAccess) {
    return $objectLikeValue[$key]
        ?? $objectLikeValue->{$key}
        ?? null;
}
```

## Why it was reverted

Objects implement `\ArrayAccess` to expose a curated set of values, most prominently Eloquent models mapping array access to attributes.
Falling back to property access leaks internal object state as field values and shadows fields that are meant to resolve to `null`.

Lighthouse broke on all 23 PHPUnit jobs: https://github.com/nuwave/lighthouse/actions/runs/30370354427.
Its `PropertyAccessTest::testPhpProperty` expects `php_property: null` and got `"value of the PHP property"` instead.

This branch also removes the regression test that https://github.com/webonyx/graphql-php/pull/1958 added to pin that behavior, since the two cannot both hold.

## Open question

There is no opt-in mechanism here, so this is the same unconditional behavior change that broke downstream consumers.

Lighthouse is not itself a blocker - it shares a maintainer with this library and can be adapted.
The question is whether the unconditional change is acceptable for everyone else whose `\ArrayAccess` implementations carry PHP properties unrelated to the exposed offsets.

Directions, none of them decided:

- Adapt Lighthouse and ship this unconditionally, treating the property fallback as the intended default resolver behavior
- A flag on `Executor` or the field config, so schemas opt in explicitly
- A marker interface that classes implement to invite property access
- Leave `Utils::extractKey()` alone and document that consumers who want this write their own `defaultFieldResolver`

Until that is settled this stays labelled `breaking change` and unmerged.