### PR TITLE
Allow computing query complexity without variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Added
+
+- Add `QueryComplexity::$assumeWorstCaseForUnprovidedVariables` to compute query complexity without variable values https://github.com/webonyx/graphql-php/pull/1970
+
 ## v15.37.2
 
 ### Changed

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,6 +82,32 @@ $type = new ObjectType([
 ]);
 ```
 
+### Complexity Without Variable Values
+
+Evaluating `@include`/`@skip` and the arguments passed to **complexity** functions requires
+the variable values of the operation. When those are not available, such as when validating
+a manifest of persisted operations ahead of time, the rule can compute the worst-case
+complexity instead of failing:
+
+```php
+use GraphQL\Validator\Rules\QueryComplexity;
+
+$rule = new QueryComplexity(100);
+$rule->assumeWorstCaseForUnprovidedVariables = true;
+```
+
+Variables that were not provided a value are then considered unknown:
+
+- Fields with `@include(if: $var)` or `@skip(if: $var)` count as included,
+  only literal `@include(if: false)` and `@skip(if: true)` exclude a field.
+- Field arguments that depend on such a variable are omitted from the arguments passed to
+  **complexity** functions, even when their definition has a default value, because the
+  value used at runtime is unknown. Those functions should thus account for missing
+  arguments, for example by using the worst case as a fallback: `$args['limit'] ?? 100`.
+
+Variables that were provided a value are always used as given, and providing an invalid
+value still results in an error.
+
 ## Limiting Query Depth
 
 This is a port of [Limiting Query Depth in Sangria](https://sangria-graphql.github.io/learn#limiting-query-depth).

--- a/src/Validator/Rules/QueryComplexity.php
+++ b/src/Validator/Rules/QueryComplexity.php
@@ -5,18 +5,24 @@ namespace GraphQL\Validator\Rules;
 use GraphQL\Error\Error;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Executor\Values;
+use GraphQL\Language\AST\DirectiveNode;
 use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
+use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\AST\SelectionNode;
 use GraphQL\Language\AST\SelectionSetNode;
+use GraphQL\Language\AST\ValueNode;
 use GraphQL\Language\AST\VariableDefinitionNode;
+use GraphQL\Language\AST\VariableNode;
 use GraphQL\Language\Visitor;
 use GraphQL\Language\VisitorOperation;
+use GraphQL\Type\Definition\Argument;
 use GraphQL\Type\Definition\Directive;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Introspection;
@@ -33,6 +39,23 @@ class QueryComplexity extends QuerySecurityRule
 
     /** @var array<string, mixed> */
     protected array $rawVariableValues = [];
+
+    /**
+     * Compute the worst-case complexity of variables that were not provided a value?
+     *
+     * Enable this to compute the complexity of operations without variable values,
+     * such as when validating a persisted operation manifest. Variables that were
+     * not provided a value are then considered unknown:
+     * - fields with `@include(if: $var)` or `@skip(if: $var)` count as included,
+     *   only literal `@include(if: false)` and `@skip(if: true)` exclude a field
+     * - field arguments that depend on such a variable are omitted from the arguments
+     *   passed to `complexity` functions, even when their definition has a default value,
+     *   because the value used at runtime is unknown
+     *
+     * Variables that were provided a value are always used as given, and providing
+     * an invalid value still results in an error.
+     */
+    public bool $assumeWorstCaseForUnprovidedVariables = false;
 
     /** @var NodeList<VariableDefinitionNode> */
     protected NodeList $variableDefs;
@@ -186,7 +209,18 @@ class QueryComplexity extends QuerySecurityRule
     protected function directiveExcludesField(FieldNode $node): bool
     {
         foreach ($node->directives as $directiveNode) {
-            if ($directiveNode->name->value === Directive::INCLUDE_NAME) {
+            $directiveName = $directiveNode->name->value;
+            if ($directiveName !== Directive::INCLUDE_NAME && $directiveName !== Directive::SKIP_NAME) {
+                continue;
+            }
+
+            if ($this->conditionDependsOnUnprovidedVariable($directiveNode)) {
+                // Without a variable value, the condition can not be evaluated.
+                // The worst case is that the field is included.
+                continue;
+            }
+
+            if ($directiveName === Directive::INCLUDE_NAME) {
                 $includeArguments = Values::getArgumentValues(
                     Directive::includeDirective(),
                     $directiveNode,
@@ -197,9 +231,7 @@ class QueryComplexity extends QuerySecurityRule
                 if (! $includeArguments['if']) {
                     return true;
                 }
-            }
-
-            if ($directiveNode->name->value === Directive::SKIP_NAME) {
+            } else {
                 $skipArguments = Values::getArgumentValues(
                     Directive::skipDirective(),
                     $directiveNode,
@@ -208,6 +240,58 @@ class QueryComplexity extends QuerySecurityRule
                 assert(is_bool($skipArguments['if']), 'ensured by query validation');
 
                 if ($skipArguments['if']) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is the condition of the given `@include`/`@skip` directive a variable without a value?
+     *
+     * @throws \Exception
+     * @throws InvariantViolation
+     */
+    private function conditionDependsOnUnprovidedVariable(DirectiveNode $directiveNode): bool
+    {
+        if (! $this->assumeWorstCaseForUnprovidedVariables) {
+            return false;
+        }
+
+        foreach ($directiveNode->arguments as $argumentNode) {
+            if ($argumentNode->name->value === 'if') {
+                return $this->dependsOnUnprovidedVariable($argumentNode->value);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Does the given value reference a variable that was not provided a value?
+     *
+     * @throws \Exception
+     * @throws InvariantViolation
+     */
+    private function dependsOnUnprovidedVariable(ValueNode $value): bool
+    {
+        if ($value instanceof VariableNode) {
+            return ! array_key_exists($value->name->value, $this->getCoercedVariableValues());
+        }
+
+        if ($value instanceof ListValueNode) {
+            foreach ($value->values as $itemValue) {
+                if ($this->dependsOnUnprovidedVariable($itemValue)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($value instanceof ObjectValueNode) {
+            foreach ($value->fields as $fieldValue) {
+                if ($this->dependsOnUnprovidedVariable($fieldValue->value)) {
                     return true;
                 }
             }
@@ -232,7 +316,7 @@ class QueryComplexity extends QuerySecurityRule
 
         [$errors, $variableValues] = Values::getVariableValues(
             $this->context->getSchema(),
-            $this->variableDefs,
+            $this->coercibleVariableDefs(),
             $this->getRawVariableValues()
         );
         if ($errors !== null && $errors !== []) {
@@ -240,6 +324,35 @@ class QueryComplexity extends QuerySecurityRule
         }
 
         return $this->coercedVariableValues = $variableValues ?? [];
+    }
+
+    /**
+     * The variable definitions that can be coerced with the raw variable values at hand.
+     *
+     * Unless the worst case is assumed, this is simply all of them - coercion reports an
+     * error for variables that require a value but were not provided one. When assuming
+     * the worst case, those variables are left out, so their values remain unknown.
+     *
+     * @return NodeList<VariableDefinitionNode>
+     */
+    private function coercibleVariableDefs(): NodeList
+    {
+        if (! $this->assumeWorstCaseForUnprovidedVariables) {
+            return $this->variableDefs;
+        }
+
+        $rawVariableValues = $this->getRawVariableValues();
+
+        $coercible = [];
+        foreach ($this->variableDefs as $variableDef) {
+            if (array_key_exists($variableDef->variable->name->value, $rawVariableValues)
+                || $variableDef->defaultValue !== null
+            ) {
+                $coercible[] = $variableDef;
+            }
+        }
+
+        return new NodeList($coercible);
     }
 
     /** @return array<string, mixed> */
@@ -257,32 +370,51 @@ class QueryComplexity extends QuerySecurityRule
     /**
      * @throws \Exception
      * @throws Error
+     * @throws InvariantViolation
      *
      * @return array<string, mixed>
      */
     protected function buildFieldArguments(FieldNode $node): array
     {
-        $rawVariableValues = $this->getRawVariableValues();
         $fieldDef = $this->fieldDefinition($node);
-
-        /** @var array<string, mixed> $args */
-        $args = [];
-
-        if ($fieldDef instanceof FieldDefinition) {
-            [$errors, $variableValues] = Values::getVariableValues(
-                $this->context->getSchema(),
-                $this->variableDefs,
-                $rawVariableValues
-            );
-
-            if (is_array($errors) && $errors !== []) {
-                throw new Error(implode("\n\n", array_map(static fn ($error) => $error->getMessage(), $errors)));
-            }
-
-            $args = Values::getArgumentValues($fieldDef, $node, $variableValues);
+        if (! $fieldDef instanceof FieldDefinition) {
+            return [];
         }
 
-        return $args;
+        $variableValues = $this->getCoercedVariableValues();
+
+        if (! $this->assumeWorstCaseForUnprovidedVariables) {
+            return Values::getArgumentValues($fieldDef, $node, $variableValues);
+        }
+
+        // Arguments that depend on a variable without a value can not be coerced,
+        // so they are left out and complexity functions get to decide what to make
+        // of their absence.
+        $unknownArgumentNames = [];
+        $argumentValueMap = [];
+        foreach ($node->arguments as $argumentNode) {
+            $argumentName = $argumentNode->name->value;
+
+            if ($this->dependsOnUnprovidedVariable($argumentNode->value)) {
+                $unknownArgumentNames[$argumentName] = true;
+                continue;
+            }
+
+            $argumentValueMap[$argumentName] = $argumentNode->value;
+        }
+
+        if ($unknownArgumentNames !== []) {
+            // Coercion is done as if the field did not define the unknown arguments at all.
+            // Were they left in, coercion would substitute the default value of their
+            // definition - hiding that the value is unknown - or fail when they are required.
+            $fieldDef = clone $fieldDef;
+            $fieldDef->args = array_values(array_filter(
+                $fieldDef->args,
+                static fn (Argument $argument): bool => ! isset($unknownArgumentNames[$argument->name])
+            ));
+        }
+
+        return Values::getArgumentValuesForMap($fieldDef, $argumentValueMap, $variableValues, $node);
     }
 
     public function getMaxQueryComplexity(): int

--- a/tests/Validator/QueryComplexityTest.php
+++ b/tests/Validator/QueryComplexityTest.php
@@ -317,6 +317,145 @@ final class QueryComplexityTest extends QuerySecurityTestCase
     }
 
     /**
+     * Persisted operation manifests contain only the operation text, so there are no
+     * variable values to validate them with.
+     */
+    public function testUnprovidedVariableValuesForConditionsFailByDefault(): void
+    {
+        $query = 'query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Variable "$withDogs" of required type "Boolean!" was not provided.');
+
+        DocumentValidator::validate(
+            QuerySecuritySchema::buildSchema(),
+            Parser::parse($query),
+            [new QueryComplexity(100)]
+        );
+    }
+
+    /** @dataProvider unprovidedVariableConditionProvider */
+    public function testUnprovidedVariableConditionsCountAsIncluded(string $query): void
+    {
+        // dogs is counted as if it were included: human(1) + dogs(1, given the literal name) + name(1)
+        self::assertSame(3, $this->complexityWithoutVariableValues($query));
+    }
+
+    /** @return iterable<array{string}> */
+    public static function unprovidedVariableConditionProvider(): iterable
+    {
+        yield ['query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }'];
+        yield ['query MyQuery($withoutDogs: Boolean!) { human { dogs(name: "Root") @skip(if:$withoutDogs) { name } } }'];
+        yield ['query MyQuery($withDogs: Boolean!, $withoutDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) @skip(if:$withoutDogs) { name } } }'];
+    }
+
+    /** @dataProvider literalConditionProvider */
+    public function testLiteralConditionsStillExcludeFields(string $query): void
+    {
+        // dogs is excluded, so only human(1) is counted
+        self::assertSame(1, $this->complexityWithoutVariableValues($query));
+    }
+
+    /** @return iterable<array{string}> */
+    public static function literalConditionProvider(): iterable
+    {
+        yield ['query MyQuery { human { dogs(name: "Root") @include(if:false) { name } } }'];
+        yield ['query MyQuery { human { dogs(name: "Root") @skip(if:true) { name } } }'];
+        yield ['query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) @skip(if:true) { name } } }'];
+    }
+
+    public function testVariableConditionsFallBackToTheirDefaultValue(): void
+    {
+        $query = 'query MyQuery($withDogs: Boolean = false) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        self::assertSame(1, $this->complexityWithoutVariableValues($query));
+    }
+
+    public function testProvidedVariableValuesAreStillUsedForConditions(): void
+    {
+        $query = 'query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        self::assertSame(1, $this->complexityWithoutVariableValues($query, ['withDogs' => false]));
+        self::assertSame(3, $this->complexityWithoutVariableValues($query, ['withDogs' => true]));
+    }
+
+    public function testInvalidProvidedVariableValuesStillFail(): void
+    {
+        $query = 'query MyQuery($withDogs: Boolean!) { human { dogs(name: "Root") @include(if:$withDogs) { name } } }';
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Variable "$withDogs" got invalid value "not a boolean"; Boolean cannot represent a non boolean value: "not a boolean"');
+
+        $this->complexityWithoutVariableValues($query, ['withDogs' => 'not a boolean']);
+    }
+
+    /** @dataProvider unprovidedVariableArgumentProvider */
+    public function testArgumentsDependingOnUnprovidedVariablesAreOmitted(string $query): void
+    {
+        // The complexity function of dogs falls back to 10 when it is not passed a name:
+        // human(1) + dogs(10) + name(1)
+        self::assertSame(12, $this->complexityWithoutVariableValues($query));
+    }
+
+    /** @return iterable<array{string}> */
+    public static function unprovidedVariableArgumentProvider(): iterable
+    {
+        yield ['query MyQuery($name: String!) { human { dogs(name: $name) { name } } }'];
+        yield ['query MyQuery($name: String!) { human { dogs(names: [$name]) { name } } }'];
+        yield ['query MyQuery($name: String!) { human { dogs(filter: {name: $name}) { name } } }'];
+    }
+
+    public function testRequiredArgumentsDependingOnUnprovidedVariablesAreOmitted(): void
+    {
+        $query = 'query MyQuery($first: Int!) { human { pets(first: $first) { name } } }';
+
+        // first is unknown, so the complexity function of pets falls back to 100, while
+        // last still gets the default value of its definition:
+        // human(1) + name(1) + first(100) + last(5)
+        self::assertSame(107, $this->complexityWithoutVariableValues($query));
+    }
+
+    public function testArgumentDefaultValuesDoNotHideUnprovidedVariables(): void
+    {
+        $query = 'query MyQuery($last: Int) { human { pets(first: 2, last: $last) { name } } }';
+
+        // last is unknown, so the default value of its definition must not be used,
+        // which makes the complexity function of pets fall back to 1000:
+        // human(1) + name(1) + first(2) + last(1000)
+        self::assertSame(1004, $this->complexityWithoutVariableValues($query));
+    }
+
+    public function testProvidedVariableValuesAreStillUsedForArguments(): void
+    {
+        $query = 'query MyQuery($name: String!) { human { dogs(name: $name) { name } } }';
+
+        // Passing a name makes the complexity function of dogs return 1: human(1) + dogs(1) + name(1)
+        self::assertSame(3, $this->complexityWithoutVariableValues($query, ['name' => 'Root']));
+    }
+
+    /**
+     * @param array<string, mixed> $rawVariableValues
+     *
+     * @throws \Exception
+     * @throws \GraphQL\Error\SyntaxError
+     */
+    private function complexityWithoutVariableValues(string $query, array $rawVariableValues = []): int
+    {
+        $rule = new QueryComplexity(PHP_INT_MAX);
+        $rule->assumeWorstCaseForUnprovidedVariables = true;
+        $rule->setRawVariableValues($rawVariableValues);
+
+        $errors = DocumentValidator::validate(
+            QuerySecuritySchema::buildSchema(),
+            Parser::parse($query),
+            [$rule]
+        );
+        self::assertSame([], $errors);
+
+        return $rule->getQueryComplexity();
+    }
+
+    /**
      * Verifies that variable coercion is cached: when multiple fields each have @skip,
      * coercion is only performed once, not once per field.
      */

--- a/tests/Validator/QuerySecuritySchema.php
+++ b/tests/Validator/QuerySecuritySchema.php
@@ -6,6 +6,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\GraphQL;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\Directive;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
@@ -21,6 +22,8 @@ final class QuerySecuritySchema
     private static ObjectType $humanType;
 
     private static ObjectType $queryRootType;
+
+    private static InputObjectType $dogFilterType;
 
     /** @throws InvariantViolation */
     public static function buildSchema(): Schema
@@ -65,8 +68,32 @@ final class QuerySecuritySchema
 
                         return $childrenComplexity + $ownComplexity;
                     },
-                    'args' => ['name' => ['type' => Type::string()]],
+                    'args' => [
+                        'name' => ['type' => Type::string()],
+                        'names' => ['type' => Type::listOf(Type::nonNull(Type::string()))],
+                        'filter' => ['type' => self::buildDogFilterType()],
+                    ],
                 ],
+                'pets' => [
+                    'type' => Type::listOf(Type::nonNull(self::buildDogType())),
+                    // Falls back to a distinct worst case per limit it is not passed
+                    'complexity' => static fn (int $childrenComplexity, array $args): int => $childrenComplexity + ($args['first'] ?? 100) + ($args['last'] ?? 1000),
+                    'args' => [
+                        'first' => ['type' => Type::nonNull(Type::int())],
+                        'last' => ['type' => Type::int(), 'defaultValue' => 5],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /** @throws InvariantViolation */
+    public static function buildDogFilterType(): InputObjectType
+    {
+        return self::$dogFilterType ??= new InputObjectType([
+            'name' => 'DogFilter',
+            'fields' => [
+                'name' => ['type' => Type::nonNull(Type::string())],
             ],
         ]);
     }


### PR DESCRIPTION
Fixes #1968.

`QueryComplexity` coerces the operation's variable definitions to evaluate `@include`/`@skip` and to build the arguments of fields with a `complexity` function, which fails for every operation that declares a required variable — so validating operation text alone, such as a manifest of Apollo persisted operations checked in CI, was only possible by subclassing the rule and overriding the protected `directiveExcludesField()`.

Setting the new `QueryComplexity::$assumeWorstCaseForUnprovidedVariables` treats variables without a value as unknown instead of coercing them: conditional fields count as included, so only literal `@include(if: false)`/`@skip(if: true)` are dropped, and arguments that depend on such a variable (including ones nested in list or input object literals) are left out of what is passed to `complexity` functions, which can then pick their own fallback.

Variables that were provided a value are still used as given, invalid values still error out, and the default behaviour is unchanged. Along the way `buildFieldArguments()` now reuses the cached coerced variable values instead of re-coercing every variable definition per field.