### PR TITLE
Detect REQUIRED_ARG_ADDED when the old field had no prior arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ## Unreleased
 
+### Fixed
+
+- Detect `REQUIRED_ARG_ADDED` in `BreakingChangesFinder::findArgChanges()` when the old field had no prior arguments https://github.com/webonyx/graphql-php/pull/TODO
+
 ## v15.37.2
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
 
 ### Fixed
 
-- Detect `REQUIRED_ARG_ADDED` in `BreakingChangesFinder::findArgChanges()` when the old field had no prior arguments https://github.com/webonyx/graphql-php/pull/TODO
+- Detect `REQUIRED_ARG_ADDED` in `BreakingChangesFinder::findArgChanges()` when the old field had no prior arguments https://github.com/webonyx/graphql-php/pull/1976
 
 ## v15.37.2
 

--- a/src/Utils/BreakingChangesFinder.php
+++ b/src/Utils/BreakingChangesFinder.php
@@ -535,33 +535,34 @@ class BreakingChangesFinder
                             'description' => "{$typeName}.{$fieldName} arg {$oldArgDef->name} was removed",
                         ];
                     }
+                }
 
-                    // Check if arg was added to the field
-                    foreach ($newTypeFields[$fieldName]->args as $newTypeFieldArgDef) {
-                        $oldArgDef = null;
-                        foreach ($oldTypeFields[$fieldName]->args as $oldArg) {
-                            if ($oldArg->name === $newTypeFieldArgDef->name) {
-                                $oldArgDef = $oldArg;
-                            }
+                // Check if arg was added to the field. This must run even when the old
+                // field had zero args, so it lives outside the loop over $oldField->args.
+                foreach ($newTypeFields[$fieldName]->args as $newTypeFieldArgDef) {
+                    $oldArgDef = null;
+                    foreach ($oldTypeFields[$fieldName]->args as $oldArg) {
+                        if ($oldArg->name === $newTypeFieldArgDef->name) {
+                            $oldArgDef = $oldArg;
                         }
+                    }
 
-                        if ($oldArgDef !== null) {
-                            continue;
-                        }
+                    if ($oldArgDef !== null) {
+                        continue;
+                    }
 
-                        $newTypeName = $newType->name;
-                        $newArgName = $newTypeFieldArgDef->name;
-                        if ($newTypeFieldArgDef->isRequired()) {
-                            $breakingChanges[] = [
-                                'type' => self::BREAKING_CHANGE_REQUIRED_ARG_ADDED,
-                                'description' => "A required arg {$newArgName} on {$newTypeName}.{$fieldName} was added",
-                            ];
-                        } else {
-                            $dangerousChanges[] = [
-                                'type' => self::DANGEROUS_CHANGE_OPTIONAL_ARG_ADDED,
-                                'description' => "An optional arg {$newArgName} on {$newTypeName}.{$fieldName} was added",
-                            ];
-                        }
+                    $newTypeName = $newType->name;
+                    $newArgName = $newTypeFieldArgDef->name;
+                    if ($newTypeFieldArgDef->isRequired()) {
+                        $breakingChanges[] = [
+                            'type' => self::BREAKING_CHANGE_REQUIRED_ARG_ADDED,
+                            'description' => "A required arg {$newArgName} on {$newTypeName}.{$fieldName} was added",
+                        ];
+                    } else {
+                        $dangerousChanges[] = [
+                            'type' => self::DANGEROUS_CHANGE_OPTIONAL_ARG_ADDED,
+                            'description' => "An optional arg {$newArgName} on {$newTypeName}.{$fieldName} was added",
+                        ];
                     }
                 }
             }

--- a/tests/Utils/BreakingChangesFinderTest.php
+++ b/tests/Utils/BreakingChangesFinderTest.php
@@ -855,6 +855,48 @@ final class BreakingChangesFinderTest extends TestCase
         );
     }
 
+    public function testShouldDetectIfANonNullFieldArgumentWasAddedToAFieldWithNoPriorArgs(): void
+    {
+        $oldType = new ObjectType([
+            'name' => 'Type1',
+            'fields' => [
+                'field1' => [
+                    'type' => Type::string(),
+                    'args' => [],
+                ],
+            ],
+        ]);
+        $newType = new ObjectType([
+            'name' => 'Type1',
+            'fields' => [
+                'field1' => [
+                    'type' => Type::string(),
+                    'args' => [
+                        'newRequiredArg' => Type::nonNull(Type::string()),
+                    ],
+                ],
+            ],
+        ]);
+        $oldSchema = new Schema([
+            'query' => $this->queryType,
+            'types' => [$oldType],
+        ]);
+        $newSchema = new Schema([
+            'query' => $this->queryType,
+            'types' => [$newType],
+        ]);
+
+        self::assertSame(
+            [
+                [
+                    'type' => BreakingChangesFinder::BREAKING_CHANGE_REQUIRED_ARG_ADDED,
+                    'description' => 'A required arg newRequiredArg on Type1.field1 was added',
+                ],
+            ],
+            BreakingChangesFinder::findArgChanges($oldSchema, $newSchema)['breakingChanges']
+        );
+    }
+
     /** @see it('should not flag args with the same type signature as breaking') */
     public function testShouldNotFlagArgsWithTheSameTypeSignatureAsBreaking(): void
     {


### PR DESCRIPTION
## Problem

`BreakingChangesFinder::findArgChanges()` fails to report `REQUIRED_ARG_ADDED` when a
new required argument is added to a field that had **zero** arguments in the old
schema. The same kind of change is detected correctly the moment the field already
had at least one argument.

## Root cause

The "check if arg was added to the field" loop was nested inside the loop over the
*old* field's existing args:

```php
foreach ($oldField->args as $oldArgDef) {
    // ... existing-arg comparisons (ARG_REMOVED / ARG_CHANGED_KIND) ...

    // Check if arg was added to the field
    foreach ($newTypeFields[$fieldName]->args as $newTypeFieldArgDef) {
        // ...
    }
}
```

Since the "was an arg added" check only ran as a side effect of iterating
`$oldField->args`, an empty `$oldField->args` skipped it entirely — regardless of
how many args (required or not) the new field had.

```php
// Reproduces on master:
$oldType = new ObjectType([
    'name' => 'Type1',
    'fields' => ['field1' => ['type' => Type::string(), 'args' => []]],
]);
$newType = new ObjectType([
    'name' => 'Type1',
    'fields' => ['field1' => [
        'type' => Type::string(),
        'args' => ['newRequiredArg' => Type::nonNull(Type::string())],
    ]],
]);
// findArgChanges($oldSchema, $newSchema)['breakingChanges'] === [] (should not be empty)
```

## Fix

Moved the "was an arg added" loop out from under `foreach ($oldField->args as
$oldArgDef)` so it runs once per field regardless of whether the old field had any
args — pure reordering, no behavior change for the already-working (non-empty
old-args) case. Mirrors how `findFieldsThatChangedTypeOnInputObjectTypes()` already
treats its own "was a field added" check as an independent loop.

## Tests

Added `testShouldDetectIfANonNullFieldArgumentWasAddedToAFieldWithNoPriorArgs()`
alongside the existing `testShouldDetectIfANonNullFieldArgumentWasAdded()`, covering
the old-field-has-zero-args case.

## Verification

`composer test` (2015 tests) and `phpstan` (full analysis) both pass; `php-cs-fixer`
reports 0 issues on the changed files. (`composer check`'s `rector` step currently
errors on a clean, unmodified `master` too — an unrelated pre-existing tooling issue,
not run by CI.)

No public API changes; this only makes an existing detection function more complete.